### PR TITLE
Fix typings for AOT

### DIFF
--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -8,8 +8,8 @@ export interface StoreDevtoolsConfig {
   shouldInstrument: Type<boolean> | InjectionToken<boolean>;
 }
 
-export const STORE_DEVTOOLS_CONFIG = new InjectionToken('@ngrx/devtools Options');
-export const INITIAL_OPTIONS = new InjectionToken('@ngrx/devtools Initial Config');
+export const STORE_DEVTOOLS_CONFIG = new InjectionToken<StoreDevtoolsConfig>('@ngrx/devtools Options');
+export const INITIAL_OPTIONS = new InjectionToken<StoreDevtoolsConfig>('@ngrx/devtools Initial Config');
 export const SHOULD_INSTRUMENT = new InjectionToken<boolean>('@ngrx/devtools Should Instrument');
 
 

--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -12,7 +12,6 @@ export const STORE_DEVTOOLS_CONFIG = new InjectionToken<StoreDevtoolsConfig>('@n
 export const INITIAL_OPTIONS = new InjectionToken<StoreDevtoolsConfig>('@ngrx/devtools Initial Config');
 export const SHOULD_INSTRUMENT = new InjectionToken<boolean>('@ngrx/devtools Should Instrument');
 
-
 export type StoreDevtoolsOptions
   = Partial<StoreDevtoolsConfig>
   | (() => Partial<StoreDevtoolsConfig>)


### PR DESCRIPTION
Using `StoreDevToolsModule.instrument()` fails to compile with AOT enabled on AngularCLI. This fixes the problem.