### PR TITLE
fix(Devtools): Removed SHOULD_INSTRUMENT token

### DIFF
--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -5,12 +5,10 @@ import { InjectionToken, Type } from '@angular/core';
 export interface StoreDevtoolsConfig {
   maxAge: number | false;
   monitor: ActionReducer<any, any>;
-  shouldInstrument: Type<boolean> | InjectionToken<boolean>;
 }
 
 export const STORE_DEVTOOLS_CONFIG = new InjectionToken<StoreDevtoolsConfig>('@ngrx/devtools Options');
 export const INITIAL_OPTIONS = new InjectionToken<StoreDevtoolsConfig>('@ngrx/devtools Initial Config');
-export const SHOULD_INSTRUMENT = new InjectionToken<boolean>('@ngrx/devtools Should Instrument');
 
 export type StoreDevtoolsOptions
   = Partial<StoreDevtoolsConfig>

--- a/modules/store-devtools/src/index.ts
+++ b/modules/store-devtools/src/index.ts
@@ -1,4 +1,4 @@
 export { StoreDevtoolsModule } from './instrument';
 export { LiftedState } from './reducer';
 export { StoreDevtools } from './devtools';
-export { StoreDevtoolsConfig, StoreDevtoolsOptions, SHOULD_INSTRUMENT } from './config';
+export { StoreDevtoolsConfig, StoreDevtoolsOptions } from './config';

--- a/modules/store-devtools/src/instrument.ts
+++ b/modules/store-devtools/src/instrument.ts
@@ -14,7 +14,7 @@ import {
   INITIAL_REDUCERS,
   REDUCER_FACTORY } from '@ngrx/store';
 import { StoreDevtools, DevtoolsDispatcher } from './devtools';
-import { StoreDevtoolsConfig, StoreDevtoolsOptions, STORE_DEVTOOLS_CONFIG, INITIAL_OPTIONS, SHOULD_INSTRUMENT } from './config';
+import { StoreDevtoolsConfig, StoreDevtoolsOptions, STORE_DEVTOOLS_CONFIG, INITIAL_OPTIONS } from './config';
 import { DevtoolsExtension, REDUX_DEVTOOLS_EXTENSION, ReduxDevtoolsExtension } from './extension';
 
 
@@ -40,12 +40,8 @@ export function createReduxDevtoolsExtension() {
   }
 }
 
-export function createStateObservable(shouldInstrument: boolean, injector: Injector) {
-  return shouldInstrument ? injector.get(StoreDevtools).state : injector.get(State);
-}
-
-export function createReducerManagerDispatcher(shouldInstrument: boolean, injector: Injector) {
-  return shouldInstrument ? injector.get(DevtoolsDispatcher) : injector.get(ActionsSubject);
+export function createStateObservable(devtools: StoreDevtools) {
+  return devtools.state;
 }
 
 export function noMonitor(): null {
@@ -55,8 +51,7 @@ export function noMonitor(): null {
 export function createConfig(_options: StoreDevtoolsOptions): StoreDevtoolsConfig {
   const DEFAULT_OPTIONS: StoreDevtoolsConfig = {
     maxAge: false,
-    monitor: noMonitor,
-    shouldInstrument: IS_EXTENSION_OR_MONITOR_PRESENT,
+    monitor: noMonitor
   };
 
   let options = typeof _options === 'function' ? _options() : _options;
@@ -67,10 +62,6 @@ export function createConfig(_options: StoreDevtoolsOptions): StoreDevtoolsConfi
   }
 
   return config;
-}
-
-export function createShouldInstrument(injector: Injector, config: StoreDevtoolsConfig) {
-  return injector.get(config.shouldInstrument);
 }
 
 @NgModule({
@@ -102,24 +93,18 @@ export class StoreDevtoolsModule {
           useFactory: createReduxDevtoolsExtension
         },
         {
-          provide: SHOULD_INSTRUMENT,
-          deps: [ Injector, STORE_DEVTOOLS_CONFIG ],
-          useFactory: createShouldInstrument
-        },
-        {
           provide: STORE_DEVTOOLS_CONFIG,
           deps: [ INITIAL_OPTIONS ],
           useFactory: createConfig
         },
         {
           provide: StateObservable,
-          deps: [ SHOULD_INSTRUMENT, Injector ],
+          deps: [ StoreDevtools ],
           useFactory: createStateObservable
         },
         {
           provide: ReducerManagerDispatcher,
-          deps: [ SHOULD_INSTRUMENT, Injector ],
-          useFactory: createReducerManagerDispatcher
+          useExisting: DevtoolsDispatcher
         },
       ]
     };

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -5,7 +5,7 @@ export { combineReducers, compose } from './utils';
 export { ActionsSubject, INIT } from './actions_subject';
 export { ReducerManager, ReducerObservable, ReducerManagerDispatcher, UPDATE } from './reducer_manager';
 export { ScannedActionsSubject } from './scanned_actions_subject';
-export { createSelector, createFeatureSelector } from './selector';
+export { createSelector, createFeatureSelector, MemoizedSelector } from './selector';
 export { State, StateObservable, reduceState } from './state';
 export { INITIAL_STATE, REDUCER_FACTORY, INITIAL_REDUCERS, STORE_FEATURES } from './tokens';
 export { StoreRootModule, StoreFeatureModule } from './store_module';


### PR DESCRIPTION
We were previously using the SHOULD_INSTRUMENT token to decide whether the instrumentation should occur due to AOT. Since this is no longer needed as NgModules can be conditionally included, this code that introduces eager providers can be removed.

Also exports the MemoizedSelector type

Fixed #30 , #49 