### PR TITLE
feat(all): added dispatch thunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ output
 *.ngsummary.json
 *.ngfactory.ts
 tmp
+package-lock.json

--- a/docs/store/actions.md
+++ b/docs/store/actions.md
@@ -6,11 +6,25 @@ Strongly type actions to take advantage of TypeScript's compile-time checking.
 
 ```ts
 // counter.actions.ts
-import { Action } from '@ngrx/store';
+import { Action, StateSelector } from '@ngrx/store';
 
 export const INCREMENT  = '[Counter] Increment';
 export const DECREMENT  = '[Counter] Decrement';
 export const RESET      = '[Counter] Reset';
+
+// thunked action
+export function resetIfNeeded() {
+  return (getState: StateSelector<number>): Action | undefined => {
+      const state = getState(x => x);
+      if (state) {
+          return {
+            type: CounterActions.RESET,
+            payload: 0
+          };
+      }
+      return undefined;
+  };
+}
 
 export class Increment implements Action {
   readonly type = INCREMENT;
@@ -100,5 +114,10 @@ export class MyAppComponent {
 	reset(){
 		this.store.dispatch(new Counter.Reset(3));
 	}
+
+  resetIfNeeded(){
+    this.store.dispatch(Counter.resetIfNeeded());
+  }
+
 }
 ```

--- a/docs/store/selectors.md
+++ b/docs/store/selectors.md
@@ -36,14 +36,17 @@ import * as fromRoot from './reducers';
 @Component({
 	selector: 'my-app',
 	template: `
-		<div>Current Count: {{ counter | async }}</div>
+		<div>Current Count: {{ counter$ | async }}</div>
 	`
 })
 class MyAppComponent {
-	counter: Observable<number>;
+	counter$: Observable<number>;
+	counter: number
 
 	constructor(private store: Store<fromRoot.AppState>){
-		this.counter = store.select(fromRoot.selectFeatureCount);
+		this.counter$ = store.select(fromRoot.selectFeatureCount);
+		// selector is run synchronously and current value is returned
+		this.counter = store.getSync(fromRoot.selectFeatureCount);
 	}
 }
 ```

--- a/modules/store/src/actions_subject.ts
+++ b/modules/store/src/actions_subject.ts
@@ -2,7 +2,8 @@ import { Injectable, OnDestroy, Provider } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
-import { Action } from './models';
+import { Action, ActionThunk } from './models';
+import { isAction } from './utils';
 
 
 export const INIT = '@ngrx/store/init';
@@ -17,7 +18,7 @@ export class ActionsSubject extends BehaviorSubject<Action> implements OnDestroy
     if (typeof action === 'undefined') {
       throw new Error(`Actions must be objects`);
     }
-    else if (typeof action.type === 'undefined') {
+    else if (!isAction(action)) {
       throw new Error(`Actions must have a type property`);
     }
 

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -1,4 +1,4 @@
-export { Action, ActionReducer, ActionReducerMap, ActionReducerFactory, Selector } from './models';
+export { Action, ActionReducer, ActionReducerMap, ActionReducerFactory, Selector, ActionThunk, StateSelector } from './models';
 export { StoreModule } from './store_module';
 export { Store } from './store';
 export { combineReducers, compose } from './utils';

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -2,6 +2,12 @@ export interface Action {
   type: string;
 }
 
+export interface StateSelector<TState> {
+  <TResult>(keySelector: (state: TState) => TResult): TResult;
+}
+
+export type ActionThunk = Action | ((getState: StateSelector<any>) => Action | undefined);
+
 export type TypeId<T> = () => T;
 
 export type InitialState<T> = Partial<T> | TypeId<Partial<T>> | void;

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -73,8 +73,8 @@ export class Store<T> extends Observable<Readonly<T>> implements Observer<Action
     return store;
   }
 
-  dispatch<TState>(this: Store<TState>, action: ActionThunk) {
-    const result: Action | undefined = typeof action === 'function'
+  dispatch<TState, V extends ActionThunk = ActionThunk>(this: Store<TState>, action: V) {
+    const result: Action | undefined = action instanceof Function
       ? action(this.getSync.bind(this))
       : action;
 

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -2,10 +2,11 @@ import { Injectable, Provider } from '@angular/core';
 import { Observer } from 'rxjs/Observer';
 import { Observable } from 'rxjs/Observable';
 import { Operator } from 'rxjs/Operator';
+import { Subscription } from 'rxjs/Subscription';
 import { map } from 'rxjs/operator/map';
 import { pluck } from 'rxjs/operator/pluck';
 import { distinctUntilChanged } from 'rxjs/operator/distinctUntilChanged';
-import { Action, ActionReducer } from './models';
+import { Action, ActionThunk, ActionReducer } from './models';
 import { ActionsSubject } from './actions_subject';
 import { StateObservable } from './state';
 import { ReducerManager } from './reducer_manager';
@@ -14,6 +15,9 @@ import { isSelector, createSelector } from './selector';
 
 @Injectable()
 export class Store<T> extends Observable<Readonly<T>> implements Observer<Action> {
+  readonly subscriptions = new WeakMap<Store<any>, Subscription>();
+  readonly currentStates = new WeakMap<Store<any>, any>();
+
   constructor(
     state$: StateObservable,
     private actionsObserver: ActionsSubject,
@@ -51,6 +55,17 @@ export class Store<T> extends Observable<Readonly<T>> implements Observer<Action
     return distinctUntilChanged.call(mapped$);
   }
 
+  getSync<TState, TResult>(this: Store<TState>, selector?: (state: TState) => TResult): TResult {
+    if (!this.subscriptions.get(this)) {
+      this.subscriptions.set(this, this.subscribe(data => {
+        this.currentStates.set(this, data);
+      }));
+    }
+
+    const state = this.currentStates.get(this);
+    return selector ? selector(state) : state;
+  }
+
   lift<R>(operator: Operator<T, R>): Store<R> {
     const store = new Store<R>(this, this.actionsObserver, this.reducerManager);
     store.operator = operator;
@@ -58,8 +73,15 @@ export class Store<T> extends Observable<Readonly<T>> implements Observer<Action
     return store;
   }
 
-  dispatch<V extends Action = Action>(action: V) {
-    this.actionsObserver.next(action);
+  dispatch<TState>(this: Store<TState>, action: ActionThunk) {
+    const result: Action | undefined = typeof action === 'function'
+      ? action(this.getSync.bind(this))
+      : action;
+
+    if (!result) {
+      return;
+    }
+    this.next(result);
   }
 
   next(action: Action) {

--- a/modules/store/src/utils.ts
+++ b/modules/store/src/utils.ts
@@ -1,4 +1,4 @@
-import { Action, ActionReducer, ActionReducerMap, ActionReducerFactory } from './models';
+import { Action, ActionThunk, ActionReducer, ActionReducerMap, ActionReducerFactory } from './models';
 
 
 export function combineReducers<T, V extends Action = Action>(reducers: ActionReducerMap<T, V>, initialState?: Partial<T>): ActionReducer<T, V>;
@@ -54,4 +54,8 @@ export function compose(...functions: any[]) {
 
     return rest.reduceRight((composed, fn) => fn(composed), last(arg));
   }
+}
+
+export function isAction(action: Action | ActionThunk): action is Action {
+    return (action as Action).type !== undefined;
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ts-node": "^3.0.2",
     "tslib": "1.6.0",
     "tslint": "^4.4.2",
-    "typescript": "^2.3.0",
+    "typescript": "2.3.4",
     "uglify-js": "^2.8.22",
     "zone.js": "^0.8.4"
   }


### PR DESCRIPTION
Added `store.getSync` this enables the user to get synchronous data (get the current value of the selector) once.
Added thunk actions to `store.dispatch`, this will enable the user to dispatch async actions