### PR TITLE
refactor(Devtools): Show complex structures in monitor

### DIFF
--- a/example-app/app/app.module.ts
+++ b/example-app/app/app.module.ts
@@ -42,7 +42,7 @@ import { environment } from '../environments/environment';
     /**
      * @ngrx/router-store keeps router state up-to-date in the store.
      */
-    // StoreRouterConnectingModule,
+    StoreRouterConnectingModule,
 
     /**
      * Store devtools instrument the store retaining past versions of state

--- a/example-app/app/routes.ts
+++ b/example-app/app/routes.ts
@@ -6,7 +6,7 @@ export const routes: Routes = [
   { path: '', redirectTo: '/books', pathMatch: 'full' },
   {
     path: 'books',
-    loadChildren: 'app/books/books.module#BooksModule',
+    loadChildren: './books/books.module#BooksModule',
     canActivate: [AuthGuard],
   },
   { path: '**', component: NotFoundPageComponent },

--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -35,7 +35,7 @@ export interface ReduxDevtoolsExtension {
   send(
     action: any,
     state: any,
-    shouldStringify?: boolean,
+    options?: boolean | { serialize: boolean | object },
     instanceId?: string
   ): void;
 }
@@ -60,7 +60,12 @@ export class DevtoolsExtension {
       return;
     }
 
-    this.devtoolsExtension.send(null, state, false, this.instanceId);
+    this.devtoolsExtension.send(
+      null,
+      state,
+      { serialize: false },
+      this.instanceId
+    );
   }
 
   private createChangesObservable(): Observable<any> {


### PR DESCRIPTION
This will not serialize the data before sending it to the Devtools extension, allowing it to handle complex structures including circular references from the RouterState when using @ngrx/router-store.

Closes #61 