### PR TITLE
Fix devtools compiler warning.

### DIFF
--- a/example-app/app/app.module.ts
+++ b/example-app/app/app.module.ts
@@ -58,7 +58,7 @@ import { environment } from '../environments/environment';
 
     /**
      * EffectsModule.forRoot() is imported once in the root module and
-     * sets up the effects class to be initialized immediately when the 
+     * sets up the effects class to be initialized immediately when the
      * application starts.
      *
      * See: https://github.com/ngrx/platform/blob/master/docs/effects/api.md#forroot

--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -1,7 +1,7 @@
 import { ActionReducer } from '@ngrx/store';
 import { InjectionToken, Type } from '@angular/core';
 
-export interface StoreDevtoolsConfig {
+export class StoreDevtoolsConfig {
   maxAge: number | false;
   monitor: ActionReducer<any, any>;
 }


### PR DESCRIPTION
Fixes example-app compiler warning:
```
WARNING in ./modules/store-devtools/src/devtools.ts
"126:562-581 export 'StoreDevtoolsConfig' was not found in './config'
```
