### PR TITLE
Clarify difference between forRoot and forFeature

### DIFF
--- a/docs/effects/api.md
+++ b/docs/effects/api.md
@@ -23,7 +23,7 @@ export class AppModule { }
 ### forFeature
 Registers @ngrx/effects services to run with your feature modules.
 
-**Note**: Running an effects class multiple times (for example via different lazy loaded modules) will not cause Effects to run multiple times.
+**Note**: Running an effects class multiple times, either by `forRoot()` or `forFeature()`, (for example via different lazy loaded modules) will not cause Effects to run multiple times. There is no functional difference between effects loaded by `forRoot()` and `forFeature()`; the important difference between the functions is that `forRoot()` sets up the providers required for effects. 
 
 Usage:
 ```ts


### PR DESCRIPTION
Adding effects via `forRoot()` and `forFeature()` is functionally identical. This PR makes that clearer in the docs.