### PR TITLE
Add note about removing @ngrx/core

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,9 @@ This guide covers the changes between the ngrx projects migrating from V1.x/2.x 
 [@ngrx/router-store](#ngrxrouter-store)  
 [@ngrx/store-devtools](#ngrxstore-devtools)
 
+## @ngrx/core
+@ngrx/core is no longer used, and can conflict with @ngrx/store. You should remove it from your project.
+
 ## @ngrx/store
 
 Previously to be AOT compatible, it was required to pass a function to the `provideStore` method to compose the reducers into one root reducer. The `initialState`


### PR DESCRIPTION
ngrx/core can conflict with ngrx 4. This is a note in the migration guide to remove ngrx/core when you upgrade.

I got the following error compiling my ts before I removed ngrx/core:

`ERROR in /Users/karp/Documents/git/bgg/geekui2/node_modules/@ngrx/store/src/store.d.ts (13,5): Class 'Observable<T>' defines instance member property 'select', but extended class 'Store<T>' defines it as instance member function.`

I believe the conflicting code was here:
https://github.com/ngrx/core/blob/master/src/add/operator/select.ts