### PR TITLE
fix(effects): allow downleveled annotations

### DIFF
--- a/modules/effects/spec/effects_metadata.spec.ts
+++ b/modules/effects/spec/effects_metadata.spec.ts
@@ -23,6 +23,24 @@ describe('Effect Metadata', () => {
       ]);
     });
 
+    it('should get the effects metadata for a downleveled class instance', () => {
+      class Fixture {
+        static get propDecorators() {
+          return {
+            a: [{ type: Effect, args: [{ dispatch: false }] }],
+            b: [{ type: Effect, args: [] }],
+          };
+        }
+      }
+
+      const mock = new Fixture();
+
+      expect(getSourceMetadata(mock)).toEqual([
+        { propertyName: 'a', dispatch: false },
+        { propertyName: 'b', dispatch: true },
+      ]);
+    });
+
     it('should return an empty array if the class has not been decorated', () => {
       class Fixture {
         a: any;


### PR DESCRIPTION
tldr: applications using Google Closure Compiler with Angular's `ngc` can opt into downleveling specifically marked decorators into static properties. This change enables that usage.

closes #93 