### PR TITLE
doc - remove wrong generic type

### DIFF
--- a/docs/store/actions.md
+++ b/docs/store/actions.md
@@ -86,7 +86,7 @@ export class MyAppComponent {
 	counter: Observable<number>;
 
 	constructor(private store: Store<AppState>) {
-		this.counter = store.select<number>('counter');
+		this.counter = store.select('counter');
 	}
 
 	increment(){


### PR DESCRIPTION
when forcing type that is not `keyof state' on select, typescript expects the parameter to be a map function