### PR TITLE
Remove dependency on ngrx selector from store.ts

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -139,9 +139,3 @@ export function createFeatureSelector<T>(
 
   return Object.assign(memoized, { release: reset });
 }
-
-export function isSelector(v: any): v is MemoizedSelector<any, any> {
-  return (
-    typeof v === 'function' && v.release && typeof v.release === 'function'
-  );
-}

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -9,7 +9,6 @@ import { Action, ActionReducer } from './models';
 import { ActionsSubject } from './actions_subject';
 import { StateObservable } from './state';
 import { ReducerManager } from './reducer_manager';
-import { isSelector, createSelector } from './selector';
 
 @Injectable()
 export class Store<T> extends Observable<T> implements Observer<Action> {
@@ -70,10 +69,8 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
 
     if (typeof pathOrMapFn === 'string') {
       mapped$ = pluck.call(this, pathOrMapFn, ...paths);
-    } else if (typeof pathOrMapFn === 'function' && isSelector(pathOrMapFn)) {
-      mapped$ = map.call(this, pathOrMapFn);
     } else if (typeof pathOrMapFn === 'function') {
-      mapped$ = map.call(this, createSelector(s => s, pathOrMapFn));
+      mapped$ = map.call(this, pathOrMapFn);
     } else {
       throw new TypeError(
         `Unexpected type '${typeof pathOrMapFn}' in select operator,` +


### PR DESCRIPTION
See issue #118.
This PR removes the dependency on ngrx selector in store.ts. The previous implementation would have been incompatible with using reselect in place of the ngrx implementation of `createSelector()`. It also would have forced memoization of selectors, even in cases where memoization might have caused a performance penalty.

I also removed the `isSelector()` function, which was not used anywhere else in the codebase, and would have been confusing in that it would have returned false for selectors that were created by reselect (I believe).