### PR TITLE
Update docs to mention know issue with devtools

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -409,6 +409,11 @@ export class AppModule {}
 
 ## @ngrx/store-devtools
 
+**NOTE:** store-devtools currently causes severe performance problems when
+used with router-store. We are working to
+[fix this](https://github.com/ngrx/platform/issues/97), but for now, avoid
+using them together.
+
 BEFORE:
 
 `app.module.ts`


### PR DESCRIPTION
The problem with devtools and router-store is pretty severe, and will get anyone who just follows the migration guide.

Until it is fixed, I suggest that we disclose the issue in the guide.