### PR TITLE
improvement(Effects): Type parameter on ofType

### DIFF
--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -21,7 +21,7 @@ export class Actions<V = Action> extends Observable<V> {
     return observable;
   }
 
-  ofType(...allowedTypes: string[]): Actions<V> {
+  ofType<V2 extends V = V>(...allowedTypes: string[]): Actions<V2> {
     return filter.call(this, (action: Action) =>
       allowedTypes.some(type => type === action.type)
     );


### PR DESCRIPTION
On a simple effect, having to type an action like that is not too much of trouble:
```typescript
@Effect()
someEffect$: Observable<Action> = this.actions$
  .ofType(MyActions.SOME_ACTION)
  .map((action: MyActions.SomeAction) => ...);
```

But when we start using `withLatestFrom` and some `filter` for example, it can become quite repetitive to define the type:
```
@Effect()
someEffect$: Observable<Action> = this.actions$
  .ofType(MyActions.SOME_ACTION)
  .withLatestFrom(this.store$.select(state => state.someProp))
  .filter(([action, someProp]: [MyActions.SomeAction, SomePropType]) => ...)
  .map(([action, someProp]: [MyActions.SomeAction, SomePropType]) => ...);
```
In the filter, we do not know the type of the action but we do know the type of the prop selected from the store (which we have to define type again). Once more, we have to do that in `map`.

Instead, having something like that might be cleaner:
```
@Effect()
someEffect$: Observable<Action> = this.actions$
  .ofType<MyActions.SomeAction>(MyActions.SOME_ACTION)
  .withLatestFrom(this.store$.select(state => state.someProp))
  .filter(([action, someProp]) => ...)
  .map(([action, someProp]) => ...);
```