### PR TITLE
make ofType method type safe

### DIFF
--- a/modules/effects/spec/actions.spec.ts
+++ b/modules/effects/spec/actions.spec.ts
@@ -72,4 +72,28 @@ describe('Actions', function() {
     actions.forEach(action => dispatcher.next({ type: action }));
     dispatcher.complete();
   });
+
+  it('should let you specify type with ofType', function() {
+    const ACTIONTYPE = 'ActionWithNumberType';
+    class ActionWithNumber implements Action {
+      readonly type = ACTIONTYPE;
+      constructor(public payload: number) {}
+    }
+
+    const increment = (x: number) => x + 1;
+
+    // The real test here is that this compiles, with the compiler understanding that
+    // payload is a number
+    actions$
+      .ofType<ActionWithNumber>(ACTIONTYPE)
+      .map(action => increment(action.payload))
+      .subscribe({
+        next(actual) {
+          expect(actual).toEqual(2);
+        },
+      });
+
+    dispatcher.next(new ActionWithNumber(1));
+    dispatcher.complete();
+  });
 });

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -21,7 +21,7 @@ export class Actions<V = Action> extends Observable<V> {
     return observable;
   }
 
-  ofType(...allowedTypes: string[]): Actions<V> {
+  ofType<T extends V = V>(...allowedTypes: string[]): Actions<T> {
     return filter.call(this, (action: Action) =>
       allowedTypes.some(type => type === action.type)
     );


### PR DESCRIPTION
This pull request makes the actions `ofType()` method more type safe, allowing you to optionally specify the type of the action. This is possible because of the default generic parameters added to TypeScript in 2.3. https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html

Something hacky like this:
```typescript
@Effect()
add$: Observable<Action> = this.actions$
	.ofType( subscriptions.ADD )
	.map( action => <AddAction>action )
	.let( this.addUserService.withLatestUserFlat )
```
becomes
```typescript
@Effect()
add$: Observable<Action> = this.actions$
	.ofType<AddAction>( subscriptions.ADD )
	.let( this.addUserService.withLatestUserFlat )
```

This may be something of a stopgap--hopefully, eventually typescript will be able to infer the return type from the filtering code itself, but who knows if that feature is ever coming.

Sorry, the test may be a bit more verbose than necessary--I had some trouble figuring out the best way to test it.