### PR TITLE
Update gitter link to ngrx/platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Reactive libraries for Angular
 
 ## Support
 
-[![Backers on Open Collective](https://opencollective.com/ngrx/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/ngrx/sponsors/badge.svg)](#sponsors) [![Join the chat at https://gitter.im/ngrx/store](https://badges.gitter.im/ngrx/store.svg)](https://gitter.im/ngrx/store?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![Backers on Open Collective](https://opencollective.com/ngrx/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/ngrx/sponsors/badge.svg)](#sponsors) [![Join the chat at https://gitter.im/ngrx/store](https://badges.gitter.im/ngrx/platform.svg)](https://gitter.im/ngrx/platform?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 
 ## Packages


### PR DESCRIPTION
There is a new gitter channel. We should direct people to it.