### PR TITLE
fix(effects) : handle case if no args is defined in annotations

### DIFF
--- a/modules/effects/spec/effects_metadata.spec.ts
+++ b/modules/effects/spec/effects_metadata.spec.ts
@@ -29,6 +29,7 @@ describe('Effect Metadata', () => {
           return {
             a: [{ type: Effect, args: [{ dispatch: false }] }],
             b: [{ type: Effect, args: [] }],
+            c: [{ type: Effect }],
           };
         }
       }
@@ -38,6 +39,7 @@ describe('Effect Metadata', () => {
       expect(getSourceMetadata(mock)).toEqual([
         { propertyName: 'a', dispatch: false },
         { propertyName: 'b', dispatch: true },
+        { propertyName: 'c', dispatch: true },
       ]);
     });
 
@@ -56,7 +58,7 @@ describe('Effect Metadata', () => {
 
   describe('getSourceProto', () => {
     it('should get the prototype for an instance of a source', () => {
-      class Fixture {}
+      class Fixture { }
       const instance = new Fixture();
 
       const proto = getSourceForInstance(instance);

--- a/modules/effects/src/effects_metadata.ts
+++ b/modules/effects/src/effects_metadata.ts
@@ -28,7 +28,7 @@ function getStaticMetadataEntry(metadataEntry: any, propertyName: string) {
     .filter((entry: any) => entry.type === Effect)
     .map((entry: any) => {
       let dispatch = true;
-      if (entry.args.length) {
+      if (entry.args && entry.args.length) {
         dispatch = !!entry.args[0].dispatch;
       }
       return { propertyName, dispatch };


### PR DESCRIPTION
Hi all,

this PR solves the problem of effects defined in package library, and compiled following the Angular Package Format , for instance: 

if I have this effect : 
```
@Effect()
  loadModels$: Observable<CMSActions> = this.actions$
    .ofType(CMS_ACTIONS.LOAD_MODELS)
    .map(toPayload)
    .map(models => new LoadModelsSuccessAction(models));

```

Compiled the propDecorators look like this : 

```
CMSEffects.propDecorators = {
    'loadModels$': [{ type: Effect },]
};
```

which causes the following error in this [line](https://github.com/ngrx/platform/blob/master/modules/effects/src/effects_metadata.ts#L31) 

```
ERROR Error: Uncaught (in promise): TypeError: Cannot read property 'length' of undefined
```

Also it seems that the args attribute is marked as optional see this [line](https://github.com/angular/angular/blob/14fd78fd85b3dd230742eaaeab65f75226f37167/packages/core/src/reflection/reflection_capabilities.ts#L245)

Thanks to the ngrx team for their work :)!