### PR TITLE
feat(Store/Effects) Add toPayloadTyped function

### DIFF
--- a/modules/effects/spec/actions.spec.ts
+++ b/modules/effects/spec/actions.spec.ts
@@ -3,6 +3,7 @@ import 'rxjs/add/operator/toArray';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/observable/of';
 import { ReflectiveInjector } from '@angular/core';
+import { toPayload, toPayloadTyped } from '@ngrx/effects';
 import {
   Action,
   StoreModule,
@@ -70,6 +71,30 @@ describe('Actions', function() {
     });
 
     actions.forEach(action => dispatcher.next({ type: action }));
+    dispatcher.complete();
+  });
+
+  it('should let you specify types with ofType and infer the type with toPayloadType', function() {
+    const ACTIONTYPE = 'ActionWithNumberType';
+    class ActionWithNumber implements Action {
+      readonly type = ACTIONTYPE;
+      constructor(public payload: number) {}
+    }
+
+    const increment = (x: number) => x + 1;
+
+    actions$
+      .ofType<ActionWithNumber>(ACTIONTYPE)
+      .map(toPayloadTyped)
+      // Note: at this point the compiler knows the actual type of payload--it is not just "any"
+      .map(payload => increment(payload))
+      .subscribe({
+        next(actual) {
+          expect(actual).toEqual(2);
+        },
+      });
+
+    dispatcher.next(new ActionWithNumber(1));
     dispatcher.complete();
   });
 });

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -4,4 +4,4 @@ export { Actions } from './actions';
 export { EffectsModule } from './effects_module';
 export { EffectSources } from './effect_sources';
 export { OnRunEffects } from './on_run_effects';
-export { toPayload } from './util';
+export { toPayload, toPayloadTyped } from './util';

--- a/modules/effects/src/util.ts
+++ b/modules/effects/src/util.ts
@@ -1,5 +1,9 @@
-import { Action } from '@ngrx/store';
+import { Action, ActionWithPayload } from '@ngrx/store';
 
 export function toPayload(action: Action): any {
   return (action as any).payload;
+}
+
+export function toPayloadTyped<T>(action: ActionWithPayload<T>): T {
+  return action.payload;
 }

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -3,6 +3,7 @@ export {
   ActionReducer,
   ActionReducerMap,
   ActionReducerFactory,
+  ActionWithPayload,
   Selector,
 } from './models';
 export { StoreModule } from './store_module';

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -2,6 +2,10 @@ export interface Action {
   type: string;
 }
 
+export interface ActionWithPayload<T> {
+  payload: T;
+}
+
 export type TypeId<T> = () => T;
 
 export type InitialState<T> = Partial<T> | TypeId<Partial<T>> | void;

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -2,7 +2,7 @@ export interface Action {
   type: string;
 }
 
-export interface ActionWithPayload<T> {
+export interface ActionWithPayload<T> extends Action {
   payload: T;
 }
 


### PR DESCRIPTION
(Third time's a charm)
For discussion, this may require some refinement.

But with the newly type safe version of `ofType`, this opens up the option of a type safe version of `toPayload` as well. I wasn't able to retrofit `toPayload` without breaking previous behavior, unfortunately (maybe someone who knows typescript better than my can give it a go?), but I was able to implement a separate `toPayloadTyped`, which infers the type of the payload based on the Action.

Is this useful? Is there an even cleaner way to implement it?

Note that this doesn't require that a user declare that their actions implement `ActionWithPayload` (It is probably best to do so, but Typescript can infer that), but it DOES require that they declare the type of their action when they call `ofType`. 