### PR TITLE
Add ofClass method to Actions

### DIFF
--- a/modules/effects/spec/actions.spec.ts
+++ b/modules/effects/spec/actions.spec.ts
@@ -72,4 +72,36 @@ describe('Actions', function() {
     actions.forEach(action => dispatcher.next({ type: action }));
     dispatcher.complete();
   });
+
+  it('should let you filter out actions by class', function() {
+    class AddAction {
+      type = ADD;
+    }
+
+    class SubtractAction {
+      type = SUBTRACT;
+    }
+
+    const AddActionInstance = new AddAction();
+    const SubtractActionInstance = new SubtractAction();
+
+    const actionInstances = [
+      AddActionInstance,
+      AddActionInstance,
+      SubtractActionInstance,
+      AddActionInstance,
+      SubtractActionInstance,
+    ];
+
+    const expected = [ADD, ADD, ADD];
+
+    actions$.ofClass(AddAction).map(update => update.type).toArray().subscribe({
+      next(actual) {
+        expect(actual).toEqual(expected);
+      },
+    });
+
+    actionInstances.forEach(action => dispatcher.next(action));
+    dispatcher.complete();
+  });
 });

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -27,7 +27,23 @@ export class Actions<V = Action> extends Observable<V> {
     );
   }
 
-  ofClass<T extends V>(...allowedClasses: (new () => T)[]): Actions<T> {
+  ofClass<T1 extends V>(a: new () => T1): Actions<T1>;
+  ofClass<T1 extends V, T2 extends V>(
+    a: new () => T1,
+    b: new () => T2
+  ): Actions<T1 | T2>;
+  ofClass<T1 extends V, T2 extends V, T3 extends V>(
+    a: new () => T1,
+    b: new () => T2,
+    c: new () => T3
+  ): Actions<T1 | T2 | T3>;
+  ofClass<T1 extends V, T2 extends V, T3 extends V, T4 extends V>(
+    a: new () => T1,
+    b: new () => T2,
+    c: new () => T3,
+    d: new () => T4
+  ): Actions<T1 | T2 | T3 | T4>;
+  ofClass(...allowedClasses: (new () => any)[]): Actions<V> {
     return filter.call(this, (action: Action) =>
       allowedClasses.some(allowedClass => action instanceof allowedClass)
     );

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -26,4 +26,10 @@ export class Actions<V = Action> extends Observable<V> {
       allowedTypes.some(type => type === action.type)
     );
   }
+
+  ofClass<T extends V>(...allowedClasses: (new () => T)[]): Actions<T> {
+    return filter.call(this, (action: Action) =>
+      allowedClasses.some(allowedClass => action instanceof allowedClass)
+    );
+  }
 }


### PR DESCRIPTION
This adds an `ofClass` method to `Actions`, similar to the `ofType` method.

It allows you to filter actions that are classes in a type safe way:
`$actions.ofClass(MyAction)` This is a bit simpler than the current method: `$actions.ofType<MyAction>(MY_ACTION_TYPE)`, and will work well with the `toPayloadTyped` function proposed in #157.

I should add that, while it seems to work, I'm sort of pushing the limits of my TypeScript understanding here, and I'm not 100% certain this is right. In particular, there may be an issue with the type inference and that spread operator; if that doesn't work right, I'm pretty certain that we could do ofClass with a single class and not have that issue.
In that case, ofClass would instead look like:
```typescript
ofClass<T extends V>(allowedClass: new () => T): Actions<T> {
  return  action instanceof allowedClass;
  );
}
```
I'm not sure I can think of many use cases for filtering on multiple classes with ofClass, but if it works, there is no reason not to keep that functionality. 