### PR TITLE
feat(Store/Effects): Make toPayload type safe

### DIFF
--- a/modules/effects/spec/actions.spec.ts
+++ b/modules/effects/spec/actions.spec.ts
@@ -3,6 +3,7 @@ import 'rxjs/add/operator/toArray';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/observable/of';
 import { ReflectiveInjector } from '@angular/core';
+import { toPayload } from '@ngrx/effects';
 import {
   Action,
   StoreModule,
@@ -70,6 +71,30 @@ describe('Actions', function() {
     });
 
     actions.forEach(action => dispatcher.next({ type: action }));
+    dispatcher.complete();
+  });
+
+  it('should let you specify types with ofType and infer the type with toPayload', function() {
+    const ACTIONTYPE = 'ActionWithNumberType';
+    class ActionWithNumber implements Action {
+      readonly type = ACTIONTYPE;
+      constructor(public payload: number) {}
+    }
+
+    const increment = (x: number) => x + 1;
+
+    actions$
+      .ofType<ActionWithNumber>(ACTIONTYPE)
+      .map(toPayload)
+      // Note: at this point the compiler knows the actual type of payload--it is not just "any"
+      .map(payload => increment(payload))
+      .subscribe({
+        next(actual) {
+          expect(actual).toEqual(2);
+        },
+      });
+
+    dispatcher.next(new ActionWithNumber(1));
     dispatcher.complete();
   });
 });

--- a/modules/effects/src/util.ts
+++ b/modules/effects/src/util.ts
@@ -1,5 +1,5 @@
-import { Action } from '@ngrx/store';
+import { Action, ActionWithPayload } from '@ngrx/store';
 
-export function toPayload(action: Action): any {
+export function toPayload<T = any>(action: ActionWithPayload<T> | Action): T {
   return (action as any).payload;
 }

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -3,6 +3,7 @@ export {
   ActionReducer,
   ActionReducerMap,
   ActionReducerFactory,
+  ActionWithPayload,
   Selector,
 } from './models';
 export { StoreModule } from './store_module';

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -1,6 +1,9 @@
 export interface Action {
   type: string;
 }
+export interface ActionWithPayload<T> extends Action {
+  payload: T;
+}
 
 export type TypeId<T> = () => T;
 


### PR DESCRIPTION
This is a followup for PR #157, and should probably replace it.

It makes the `toPayload()` function type safe, such that it infers the type of the payload, as long as either the type is specified when `ofType` is called, or the new `ofClass` method (see #160, assuming it is merged) is used to filter the action.

It still requires the addition of the ActionWithPayload interface, but the user shouldn't have to declare their actions with that interface (although it might be best to do so)--it should be able to be inferred.
