### PR TITLE
docs(MIGRATION.md); add store-devtools warning to the top

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,8 @@
 # Migration Guide
 
+**note:** `store-devtools` currently causes severe performance problems when used with `router-store`.
+If you depend on `store-devtools` and `router-store` we advice not to update until [the issue](https://github.com/ngrx/platform/issues/97) is resolved.
+
 ## Documentation
 
 Links to the current documentation for ngrx 4.x


### PR DESCRIPTION
please don't let this "warning" be the last thing in the migration document.