### PR TITLE
chore(Platform): fix type def files search path

### DIFF
--- a/build/tasks.ts
+++ b/build/tasks.ts
@@ -158,7 +158,7 @@ export async function removeRemainingSourceMapFiles(config: Config) {
 export async function copyTypeDefinitionFiles(config: Config) {
   const packages = util.getTopLevelPackages(config);
   const files = await util.getListOfFiles(
-    `./dist/packages/?(${packages.join('|')})/**/*`
+    `./dist/packages/?(${packages.join('|')})/**/*.*`
   );
 
   await mapAsync(files, async file => {


### PR DESCRIPTION
Hi,

as I mentioned on Gitter I'm currently studying the build process of ngrx which you have set up for another project of mine. During that phase the build process broke a couple of times on the `copyTypeDefinitionFiles` step giving sometimes random errors on files. Some people (like @og-carefree) also mentioned it in the Gitter Channel: 

![image](https://user-images.githubusercontent.com/542458/28831480-f57f56be-76d9-11e7-916c-5a2cac5faafa.png)

After applying this fix the error didn't happen to me any more, so it should hopefully be ok now :)