### PR TITLE
fix(createselector): memoize projector function

### DIFF
--- a/modules/store/spec/selector.spec.ts
+++ b/modules/store/spec/selector.spec.ts
@@ -44,14 +44,13 @@ describe('Selectors', () => {
     it('should call the projector function only when the value of a dependent selector change', () => {
       const firstState = { first: 'state', unchanged: 'state' };
       const secondState = { second: 'state', unchanged: 'state' };
-      const neverChangingSelector = jasmine.createSpy('unchangedSelector').and.callFake((state: any) => {
-        return state.unchanged;
-      });
+      const neverChangingSelector = jasmine
+        .createSpy('unchangedSelector')
+        .and.callFake((state: any) => {
+          return state.unchanged;
+        });
       const projectFn = jasmine.createSpy('projectionFn');
-      const selector = createSelector(
-        neverChangingSelector,
-        projectFn
-      );
+      const selector = createSelector(neverChangingSelector, projectFn);
 
       selector(firstState);
       selector(secondState);

--- a/modules/store/spec/selector.spec.ts
+++ b/modules/store/spec/selector.spec.ts
@@ -41,6 +41,24 @@ describe('Selectors', () => {
       expect(projectFn).toHaveBeenCalledWith(countOne, countTwo);
     });
 
+    it('should call the projector function only when the value of a dependent selector change', () => {
+      const firstState = { first: 'state', unchanged: 'state' };
+      const secondState = { second: 'state', unchanged: 'state' };
+      const neverChangingSelector = jasmine.createSpy('unchangedSelector').and.callFake((state: any) => {
+        return state.unchanged;
+      });
+      const projectFn = jasmine.createSpy('projectionFn');
+      const selector = createSelector(
+        neverChangingSelector,
+        projectFn
+      );
+
+      selector(firstState);
+      selector(secondState);
+
+      expect(projectFn).toHaveBeenCalledTimes(1);
+    });
+
     it('should memoize the function', () => {
       const firstState = { first: 'state' };
       const secondState = { second: 'state' };


### PR DESCRIPTION
This is a fix for: https://github.com/ngrx/platform/issues/226

With this fix, the projector function is memoized as well. 