### PR TITLE
Add note on devtools/router-store incompatibility

### DIFF
--- a/docs/store-devtools/README.md
+++ b/docs/store-devtools/README.md
@@ -12,6 +12,12 @@ Install @ngrx/store-devtools from npm:
 
 `npm install github:ngrx/store-devtools-builds` OR `yarn add github:ngrx/store-devtools-builds`
 
+### Warning
+store-devtools currently causes severe performance problems when
+used with router-store. We are working to
+[fix this](https://github.com/ngrx/platform/issues/97), but for now, avoid
+using them together.
+
 
 ## Instrumentation
 ### Instrumentation with the Chrome / Firefox Extension


### PR DESCRIPTION
There is a note about this problem in the migration guide, but anyone who is new to the project may miss the migration guide. A note belongs in the devtools docs as well.