### PR TITLE
fix(utils): fix createReducerFactory breaking initial state with meta reducers

### DIFF
--- a/modules/store/spec/modules.spec.ts
+++ b/modules/store/spec/modules.spec.ts
@@ -119,6 +119,39 @@ describe(`Store Modules`, () => {
     });
   });
 
+  describe(`: With initial state`, () => {
+    const initialState: RootState = { fruit: 'banana' };
+    const reducerMap: ActionReducerMap<RootState> = { fruit: rootFruitReducer };
+    const noopMetaReducer = (r: Function) => (state: any, action: any) => {
+      return r(state, action);
+    };
+
+    const testWithMetaReducers = (metaReducers: any[]) => () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [
+            StoreModule.forRoot(reducerMap, { initialState, metaReducers }),
+          ],
+        });
+        store = TestBed.get(Store);
+      });
+      it('should have initial state', () => {
+        store.take(1).subscribe((s: any) => {
+          expect(s).toEqual(initialState);
+        });
+      });
+    };
+
+    describe(
+      'should add initial state with no meta reducers',
+      testWithMetaReducers([])
+    );
+    describe(
+      'should add initial state with a simple no-op meta reducer',
+      testWithMetaReducers([noopMetaReducer])
+    );
+  });
+
   describe(`: Nested`, () => {
     @NgModule({
       imports: [StoreModule.forFeature('a', featureAReducer)],

--- a/modules/store/src/utils.ts
+++ b/modules/store/src/utils.ts
@@ -89,7 +89,7 @@ export function createReducerFactory(
   metaReducers?: ActionReducer<any, any>[]
 ): ActionReducerFactory<any, any> {
   if (Array.isArray(metaReducers) && metaReducers.length > 0) {
-    return compose.apply(null, [...metaReducers, reducerFactory]);
+    return compose(...metaReducers)(reducerFactory) as any;
   }
 
   return reducerFactory;


### PR DESCRIPTION
Corrects the usage of the compose method to eventually return a function that allows multiple parameters.

Closes #247