### PR TITLE
fix(Store): Use existing reducers when not using an InjectionToken

### DIFF
--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -107,9 +107,11 @@ export class StoreModule {
           deps: [_INITIAL_STATE],
         },
         { provide: _INITIAL_REDUCERS, useValue: reducers },
-        reducers instanceof InjectionToken
-          ? [{ provide: _STORE_REDUCERS, useExisting: reducers }]
-          : [],
+        {
+          provide: _STORE_REDUCERS,
+          useExisting:
+            reducers instanceof InjectionToken ? reducers : _INITIAL_REDUCERS,
+        },
         {
           provide: INITIAL_REDUCERS,
           deps: [


### PR DESCRIPTION
Closes #250, Also fixes similar AOT issue in #116