### PR TITLE
docs: fix selection of state using arrow function

### DIFF
--- a/docs/store/README.md
+++ b/docs/store/README.md
@@ -96,7 +96,7 @@ export class MyAppComponent {
 	counter: Observable<number>;
 
 	constructor(private store: Store<AppState>) {
-		this.counter = store.select<number>('counter');
+		this.counter = store.select<number>((state: AppState) => state.counter);
 	}
 
 	increment(){

--- a/docs/store/README.md
+++ b/docs/store/README.md
@@ -96,7 +96,7 @@ export class MyAppComponent {
 	counter: Observable<number>;
 
 	constructor(private store: Store<AppState>) {
-		this.counter = store.select<number>((state: AppState) => state.counter);
+		this.counter = store.select('counter');
 	}
 
 	increment(){


### PR DESCRIPTION
The select method from the Store expects a function, when I put the `this.counter = store.select<number>('counter');` the compiler says: `Argument of type '"counter"' is not assignable to parameter of type '(state: AppState) => string'.`