### PR TITLE
fix(Store): Add type signature for metareducer

### DIFF
--- a/docs/store/api.md
+++ b/docs/store/api.md
@@ -49,11 +49,11 @@ export function getInitialState() {
 configuration option to provide an array of meta-reducers that are composed from right to left.
 
 ```ts
-import { StoreModule, combineReducers, compose } from '@ngrx/store';
+import { StoreModule, ActionReducer } from '@ngrx/store';
 import { reducers } from './reducers';
 
 // console.log all actions
-function debug(reducer) {
+export function debug(reducer: ActionReducer<any>): ActionReducer<any> {
   return function(state, action) {
     console.log('state', state);
     console.log('action', action);
@@ -62,7 +62,7 @@ function debug(reducer) {
   }
 }
 
-const metaReducers = [debug];
+export const metaReducers = [debug];
 
 @NgModule({
   imports: [

--- a/example-app/app/reducers/index.ts
+++ b/example-app/app/reducers/index.ts
@@ -3,6 +3,7 @@ import {
   createSelector,
   createFeatureSelector,
   ActionReducer,
+  MetaReducer,
 } from '@ngrx/store';
 import { environment } from '../../environments/environment';
 import * as fromRouter from '@ngrx/router-store';
@@ -36,7 +37,7 @@ export const reducers: ActionReducerMap<State> = {
 };
 
 // console.log all actions
-export function logger(reducer: ActionReducer<State>): ActionReducer<any, any> {
+export function logger(reducer: ActionReducer<State>): ActionReducer<State> {
   return function(state: State, action: any): State {
     console.log('state', state);
     console.log('action', action);
@@ -50,7 +51,7 @@ export function logger(reducer: ActionReducer<State>): ActionReducer<any, any> {
  * the root meta-reducer. To add more meta-reducers, provide an array of meta-reducers
  * that will be composed to form the root meta-reducer.
  */
-export const metaReducers: ActionReducer<any, any>[] = !environment.production
+export const metaReducers: MetaReducer<State>[] = !environment.production
   ? [logger]
   : [];
 

--- a/modules/store/spec/utils.spec.ts
+++ b/modules/store/spec/utils.spec.ts
@@ -5,6 +5,7 @@ import {
   combineReducers,
   compose,
   createReducerFactory,
+  MetaReducer
 } from '@ngrx/store';
 
 describe(`Store utils`, () => {
@@ -88,7 +89,7 @@ describe(`Store utils`, () => {
     const initialState: FruitState = { fruit: 'apple' };
 
     const runWithExpectations = (
-      metaReducers: any[],
+      metaReducers: MetaReducer<FruitState>[],
       initialState: any,
       expectedState: any
     ) => () => {

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -3,6 +3,7 @@ export {
   ActionReducer,
   ActionReducerMap,
   ActionReducerFactory,
+  MetaReducer,
   Selector,
 } from './models';
 export { StoreModule } from './store_module';

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -21,12 +21,16 @@ export interface ActionReducerFactory<T, V extends Action = Action> {
   ): ActionReducer<T, V>;
 }
 
+export type MetaReducer<T, V extends Action = Action> = (
+  reducer: ActionReducer<T, V>
+) => ActionReducer<T, V>;
+
 export interface StoreFeature<T, V extends Action = Action> {
   key: string;
   reducers: ActionReducerMap<T, V> | ActionReducer<T, V>;
   reducerFactory: ActionReducerFactory<T, V>;
   initialState?: InitialState<T>;
-  metaReducers?: ActionReducer<any, any>[];
+  metaReducers?: MetaReducer<T, V>[];
 }
 
 export interface Selector<T, V> {

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -13,6 +13,7 @@ import {
   ActionReducerFactory,
   StoreFeature,
   InitialState,
+  MetaReducer,
 } from './models';
 import { compose, combineReducers, createReducerFactory } from './utils';
 import {
@@ -82,7 +83,7 @@ export class StoreFeatureModule implements OnDestroy {
 export type StoreConfig<T, V extends Action = Action> = {
   initialState?: InitialState<T>;
   reducerFactory?: ActionReducerFactory<T, V>;
-  metaReducers?: ActionReducer<T, V>[];
+  metaReducers?: MetaReducer<T, V>[];
 };
 
 @NgModule({})

--- a/modules/store/src/utils.ts
+++ b/modules/store/src/utils.ts
@@ -3,6 +3,7 @@ import {
   ActionReducer,
   ActionReducerMap,
   ActionReducerFactory,
+  MetaReducer,
 } from './models';
 
 export function combineReducers<T, V extends Action = Action>(
@@ -84,10 +85,10 @@ export function compose(...functions: any[]) {
   };
 }
 
-export function createReducerFactory(
-  reducerFactory: ActionReducerFactory<any, any>,
-  metaReducers?: ActionReducer<any, any>[]
-): ActionReducerFactory<any, any> {
+export function createReducerFactory<T, V extends Action = Action>(
+  reducerFactory: ActionReducerFactory<T, V>,
+  metaReducers?: MetaReducer<T, V>[]
+): ActionReducerFactory<T, V> {
   if (Array.isArray(metaReducers) && metaReducers.length > 0) {
     return compose(...metaReducers)(reducerFactory) as ActionReducerFactory<
       any,


### PR DESCRIPTION
Fixes the type signature issue for the array of metareducers. Each function should take a reducer and return a new reducer function.

Closes #264, Related to #170