### PR TITLE
chore: fix contributors link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Reactive libraries for Angular
 ## Contributing
 Please read [contributing guidelines here](./CONTRIBUTING.md).
 
-<a href="graphs/contributors"><img src="https://opencollective.com/ngrx/contributors.svg?width=890" /></a>
+<a href="https://github.com/ngrx/platform/graphs/contributors"><img src="https://opencollective.com/ngrx/contributors.svg?width=890" /></a>
 
 
 ## Backers


### PR DESCRIPTION
Current link does not work. It contains */blob/master* at the moment (I think if another branch will be active link will be changed too).

Any ideas how to save relativeness of link but make it working?