### PR TITLE
Issue 303 PR: Recommended migration doc change.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,7 +43,7 @@ import { compose } from '@ngrx/store';
 
 ### Action interface
 
-The `payload` property has been removed from the `Action` interface. As a result `payload` will no longer be included in the typing for `Actions` in your IDE.  Of course `Actions` may still recieve a `payload` but as an optional parameter.
+The optional property `payload` has been removed from the `Action` interface. As a result `payload` is no longer be included in the typing for `Actions` (i.e. will not show as a property in your IDE).  `Actions` may still recieve a `payload`, just don't be supprised when your IDE does not hint that you provide one.
 
 ### Registering Reducers
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,7 +43,17 @@ import { compose } from '@ngrx/store';
 
 ### Action interface
 
-The optional property `payload` has been removed from the `Action` interface. As a result `payload` is no longer be included in the typing for `Actions` (i.e. will not show as a property in your IDE).  `Actions` may still recieve a `payload`, just don't be supprised when your IDE does not hint that you provide one.
+The optional property `payload` has been removed from the `Action` interface. To maintain previous behavior the `payload` may be added back to the Action interface (this approach may be helpful in migrating).  The intent of this change is to require `payload` or other properties to be typed.
+
+SAME AS BEFORE:
+export interface UnsafeAction implements Action {
+  payload?: any;
+}
+
+AFTER:
+export interface ActionWithPayload<T> extends Action {
+  payload: T;
+}
 
 ### Registering Reducers
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,41 +43,7 @@ import { compose } from '@ngrx/store';
 
 ### Action interface
 
-The `payload` property has been removed from the `Action` interface.
-
-BEFORE:
-```ts
-import 'rxjs/add/operator/map';
-import { Action } from '@ngrx/store';
-import { Observable } from 'rxjs/Observable';
-import { Effect, Actions } from '@ngrx/effects';
-
-@Injectable()
-export class MyEffects {
-  @Effect() someEffect$: Observable<Action> = this.actions$.ofType(UserActions.LOGIN)
-    .map(action => action.payload)
-    .map(() => new AnotherAction())
-
-  constructor(private actions$: Actions) {}
-}
-```
-
-AFTER:
-```ts
-import 'rxjs/add/operator/map';
-import { Action } from '@ngrx/store';
-import { Observable } from 'rxjs/Observable';
-import { Effect, Actions } from '@ngrx/effects';
-
-@Injectable()
-export class MyEffects {
-  @Effect() someEffect$: Observable<Action> = this.actions$.ofType(UserActions.LOGIN)
-    .map((action: UserActions.Login) => action.payload)
-    .map(() => new AnotherAction())
-
-  constructor(private actions$: Actions) {}
-}
-```
+The `payload` property has been removed from the `Action` interface. As a result `payload` will no longer be included in the typing for `Actions` in your IDE.  Of course `Actions` may still recieve a `payload` but as an optional parameter.
 
 ### Registering Reducers
 


### PR DESCRIPTION
TL;DR  I conclude removal of the Before and After example removes a source of confusion.  
Payload property has been removed from the Action interface.  I really like the "Before" and "After" concept of this migration guide however in this case, the change seems to me to be only observable via intellisense or IDE.  I may well be wrong, but I just don't see how the change is reflected in the Before and After Case provided.  I think do think that users need to understand that when a payload is appropriate it may be added, but that the Action interface will no longer enforce inclusion of a payload property.

In the future I will be more proactive with my pull requests as I hope to be an increasingly active member this and other Repos that I frequent.  (Newbie).  

Many thanks for the great work 
Steve