### PR TITLE
docs(api): fix imports typo to show imports from correct package

### DIFF
--- a/docs/router-store/api.md
+++ b/docs/router-store/api.md
@@ -9,13 +9,12 @@ To use the time-traveling debugging in the Devtools, you must return an object c
 
 ```ts
 import { StoreModule, ActionReducerMap } from '@ngrx/store';
-import { Params } from '@angular/router';
+import { Params, RouterStateSnapshot } from '@angular/router';
 import {
   StoreRouterConnectingModule,
   routerReducer,
   RouterReducerState,
-  RouterStateSerializer,
-  RouterStateSnapshot
+  RouterStateSerializer
 } from '@ngrx/router-store';
 
 export interface RouterStateUrl {


### PR DESCRIPTION
Move `RouterStateSnapshot` to import from `@angular/router` instead of `@ngrx/router-store` in the `api.md` docs.