### PR TITLE
fix(Build): fix build with space in path

### DIFF
--- a/build/util.ts
+++ b/build/util.ts
@@ -176,5 +176,5 @@ export function getBottomLevelName(packageName: string) {
 }
 
 export function baseDir(...dirs: string[]): string {
-  return path.resolve(__dirname, '../', ...dirs);
+  return `"${path.resolve(__dirname, '../', ...dirs)}"`;
 }


### PR DESCRIPTION
Closes #234.

Tested on windows, with and without a space in path.
