### PR TITLE
chore(Example): Added ngrx-store-freeze meta-reducer to example app

### DIFF
--- a/example-app/app/reducers/index.ts
+++ b/example-app/app/reducers/index.ts
@@ -10,6 +10,13 @@ import { RouterStateUrl } from '../shared/utils';
 import * as fromRouter from '@ngrx/router-store';
 
 /**
+ * storeFreeze prevents state from being mutated. When mutation occurs, an
+ * exception will be thrown. This is useful during development mode to
+ * ensure that none of the reducers accidentally mutates the state.
+ */
+import { storeFreeze } from 'ngrx-store-freeze';
+
+/**
  * Every reducer module's default export is the reducer function itself. In
  * addition, each module should export a type or interface that describes
  * the state of the reducer plus any selector functions. The `* as`
@@ -53,7 +60,7 @@ export function logger(reducer: ActionReducer<State>): ActionReducer<State> {
  * that will be composed to form the root meta-reducer.
  */
 export const metaReducers: MetaReducer<State>[] = !environment.production
-  ? [logger]
+  ? [logger, storeFreeze]
   : [];
 
 /**


### PR DESCRIPTION
Previously, the router state snapshot prevented the use of the `ngrx-store-freeze` due to circular references. With a custom serializer in place, an example of freezing the state can be added back to the example app.

Closes #327, #240 