### PR TITLE
docs(RouterStore): type signature of ROUTER_NAVIGATION action

### DIFF
--- a/docs/router-store/README.md
+++ b/docs/router-store/README.md
@@ -14,13 +14,23 @@ Install @ngrx/router-store from npm:
 
 ## Usage
 
-During the navigation, before any guards or resolvers run, the router will dispatch a ROUTER_NAVIGATION action, which has the following signature:
+During the navigation, before any guards or resolvers run, the router will dispatch a `ROUTER_NAVIGATION` action, which has the signature `RouterNavigationAction`:
 
 ```ts
-export type RouterNavigationPayload<T> = {
-  routerState: T,
-  event: RoutesRecognized
-}
+/**
+ * Payload of ROUTER_NAVIGATION.
+ */
+export declare type RouterNavigationPayload<T> = {
+    routerState: T;
+    event: RoutesRecognized;
+};
+/**
+ * An action dispatched when the router navigates.
+ */
+export declare type RouterNavigationAction<T = RouterStateSnapshot> = {
+    type: typeof ROUTER_NAVIGATION;
+    payload: RouterNavigationPayload<T>;
+};
 ```
 
 - Reducers receive this action. Throwing an error in the reducer cancels navigation.


### PR DESCRIPTION
Readme is a little bit mis-leading here. It tells that the signature of the action is `RouterNavigationPayload`. In fact, it is a `RouterNavigationAction` with a payload of the above type.