### PR TITLE
fix(RouterStore): Fix cancelled navigation with async guard (fixes #354)

### DIFF
--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -186,6 +186,8 @@ export class StoreRouterConnectingModule {
   private setUpStoreStateListener(): void {
     this.store.subscribe(s => {
       this.storeState = s;
+    });
+    this.store.select('routerReducer').subscribe(() => {
       this.navigateIfNeeded();
     });
   }


### PR DESCRIPTION
Fix for #354, see more details there.
Contains unit test which fails without the fix.