### PR TITLE
fix(RouterStore): Stringify error from navigation error event

### DIFF
--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -248,7 +248,7 @@ export class StoreRouterConnectingModule {
     this.dispatchRouterAction(ROUTER_ERROR, {
       routerState: this.routerState,
       storeState: this.storeState,
-      event,
+      event: new NavigationError(event.id, event.url, `${event}`),
     });
   }
 


### PR DESCRIPTION
Allows errors to bubble up from navigation errors instead of being trapped in the state.

Closes #356

cc: @jbeckton