### PR TITLE
Another change to keep closure compiler happy

### DIFF
--- a/modules/store/src/reducer_manager.ts
+++ b/modules/store/src/reducer_manager.ts
@@ -40,7 +40,7 @@ export class ReducerManager extends BehaviorSubject<ActionReducer<any, any>>
   }: StoreFeature<any, any>) {
     const reducer =
       typeof reducers === 'function'
-        ? (state = initialState, action: any) => reducers(state, action)
+        ? (state, action: any) => reducers(state || initialState, action)
         : createReducerFactory(reducerFactory, metaReducers)(
             reducers,
             initialState

--- a/modules/store/src/reducer_manager.ts
+++ b/modules/store/src/reducer_manager.ts
@@ -40,7 +40,7 @@ export class ReducerManager extends BehaviorSubject<ActionReducer<any, any>>
   }: StoreFeature<any, any>) {
     const reducer =
       typeof reducers === 'function'
-        ? (state, action: any) => reducers(state || initialState, action)
+        ? (state: any, action: any) => reducers(state || initialState, action)
         : createReducerFactory(reducerFactory, metaReducers)(
             reducers,
             initialState


### PR DESCRIPTION
According to closure compiler, you cannot have non-optional arguments after optional ones.