### PR TITLE
Rename EntityAdapter option sort to sortComparer

### DIFF
--- a/docs/entity/adapter.md
+++ b/docs/entity/adapter.md
@@ -7,7 +7,7 @@ returned adapter provides many [methods](#adapter-methods) for performing operat
 against the collection type. The method takes an object for configuration with 2 properties.
 
  - `selectId`: A `method` for selecting the primary id for the collection
- - `sort`: A compare function used to [sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) the collection. The comparer function is only needed if the collection needs to be sorted before being displayed. Set to `false` to use leave the collection unsorted, which is more performant during CRUD operations.
+ - `sortComparer`: A compare function used to [sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) the collection. The comparer function is only needed if the collection needs to be sorted before being displayed. Set to `false` to use leave the collection unsorted, which is more performant during CRUD operations.
 
 Usage:
 
@@ -31,7 +31,7 @@ export function sortByName(a: User, b: User): number {
 
 export const adapter: EntityAdapter<User> = createEntityAdapter<User>({
   selectId: (user: User) => user.id,
-  sort: sortByName,
+  sortComparer: sortByName,
 });
 ```
 

--- a/example-app/app/books/reducers/books.ts
+++ b/example-app/app/books/reducers/books.ts
@@ -20,12 +20,12 @@ export interface State extends EntityState<Book> {
  * functions for single or multiple operations
  * against the dictionary of records. The configuration
  * object takes a record id selector function and
- * a sort option whether to sort the records when performing
- * operations
+ * a sortComparer option which is set to a compare
+ * function if the records are to be sorted.
  */
 export const adapter: EntityAdapter<Book> = createEntityAdapter<Book>({
   selectId: (book: Book) => book.id,
-  sort: false,
+  sortComparer: false,
 });
 
 /** getInitialState returns the default initial state

--- a/modules/entity/spec/sorted_state_adapter.spec.ts
+++ b/modules/entity/spec/sorted_state_adapter.spec.ts
@@ -14,7 +14,7 @@ describe('Sorted State Adapter', () => {
   beforeEach(() => {
     adapter = createEntityAdapter({
       selectId: (book: BookModel) => book.id,
-      sort: (a, b) => a.title.localeCompare(b.title),
+      sortComparer: (a, b) => a.title.localeCompare(b.title),
     });
 
     state = { ids: [], entities: {} };

--- a/modules/entity/src/create_adapter.ts
+++ b/modules/entity/src/create_adapter.ts
@@ -12,14 +12,17 @@ import { createUnsortedStateAdapter } from './unsorted_state_adapter';
 
 export function createEntityAdapter<T>(options: {
   selectId: IdSelector<T>;
-  sort?: false | Comparer<T>;
+  sortComparer?: false | Comparer<T>;
 }): EntityAdapter<T> {
-  const { selectId, sort }: EntityDefinition<T> = { sort: false, ...options };
+  const { selectId, sortComparer }: EntityDefinition<T> = {
+    sortComparer: false,
+    ...options,
+  };
 
   const stateFactory = createInitialStateFactory<T>();
   const selectorsFactory = createSelectorsFactory<T>();
-  const stateAdapter = sort
-    ? createSortedStateAdapter(selectId, sort)
+  const stateAdapter = sortComparer
+    ? createSortedStateAdapter(selectId, sortComparer)
     : createUnsortedStateAdapter(selectId);
 
   return {

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -22,7 +22,7 @@ export interface EntityState<T> {
 
 export interface EntityDefinition<T> {
   selectId: IdSelector<T>;
-  sort: false | Comparer<T>;
+  sortComparer: false | Comparer<T>;
 }
 
 export interface EntityStateAdapter<T> {


### PR DESCRIPTION
See issue #370.

Because there has been no official release of ngrx/platform yet, now seems to be the time to make this change.