### PR TITLE
added missing import for `rxjs/add/operator/catch` in example doc

### DIFF
--- a/docs/effects/README.md
+++ b/docs/effects/README.md
@@ -42,6 +42,7 @@ want to use to perform a side effect.
 // ./effects/auth.ts
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/operator/catch';
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';


### PR DESCRIPTION
just a minor fix, does not compile for me otherwise .. 

typescript: `2.5.2`
rxjs: `5.4.2`
angular: `4.2.4`