### PR TITLE
Improve performance for sorted entity adapter

### DIFF
--- a/modules/entity/src/sorted_state_adapter.ts
+++ b/modules/entity/src/sorted_state_adapter.ts
@@ -20,102 +20,89 @@ export function createSortedStateAdapter<T>(
   );
 
   function addOneMutably(entity: T, state: R): boolean {
-    const key = selectId(entity);
-
-    if (key in state.entities) {
-      return false;
-    }
-
-    const insertAt = findTargetIndex(state, entity);
-    state.ids.splice(insertAt, 0, key);
-    state.entities[key] = entity;
-
-    return true;
+    return addManyMutably([entity], state);
   }
 
   function addManyMutably(newModels: T[], state: R): boolean {
-    let didMutate = false;
+    const models = newModels.filter(
+      model => !(selectId(model) in state.entities)
+    );
 
-    for (let index in newModels) {
-      didMutate = addOneMutably(newModels[index], state) || didMutate;
-    }
-
-    return didMutate;
+    return merge(models, state);
   }
 
   function addAllMutably(models: T[], state: R): boolean {
-    const sortedModels = models.sort(sort);
-
     state.entities = {};
-    state.ids = sortedModels.map(model => {
-      const id = selectId(model);
-      state.entities[id] = model;
-      return id;
-    });
+    state.ids = [];
 
-    return true;
+    return addManyMutably(models, state);
   }
 
   function updateOneMutably(update: Update<T>, state: R): boolean {
+    return updateManyMutably([update], state);
+  }
+
+  function takeUpdatedModel(models: T[], update: Update<T>, state: R): void {
     if (!(update.id in state.entities)) {
-      return false;
+      return;
     }
 
     const original = state.entities[update.id];
-    const updated: T = Object.assign({}, original, update.changes);
-    const updatedKey = selectId(updated);
-    const result = sort(original, updated);
+    const updated = Object.assign({}, original, update.changes);
 
-    if (result === 0) {
-      if (updatedKey !== update.id) {
-        delete state.entities[update.id];
-        const index = state.ids.indexOf(update.id);
-        state.ids[index] = updatedKey;
-      }
+    delete state.entities[update.id];
 
-      state.entities[updatedKey] = updated;
-
-      return true;
-    }
-
-    const index = state.ids.indexOf(update.id);
-    state.ids.splice(index, 1);
-    state.ids.splice(findTargetIndex(state, updated), 0, updatedKey);
-
-    if (updatedKey !== update.id) {
-      delete state.entities[update.id];
-    }
-
-    state.entities[updatedKey] = updated;
-
-    return true;
+    models.push(updated);
   }
 
   function updateManyMutably(updates: Update<T>[], state: R): boolean {
-    let didMutate = false;
+    const models: T[] = [];
 
-    for (let index in updates) {
-      didMutate = updateOneMutably(updates[index], state) || didMutate;
-    }
+    updates.forEach(update => takeUpdatedModel(models, update, state));
 
-    return didMutate;
+    return merge(models, state);
   }
 
-  function findTargetIndex(state: R, model: T) {
-    if (state.ids.length === 0) {
-      return 0;
+  function merge(models: T[], state: R): boolean {
+    if (models.length === 0) {
+      return false;
     }
 
-    for (let i = 0; i < state.ids.length; i++) {
-      const entity = state.entities[state.ids[i]];
-      const isSmaller = sort(model, entity) < 0;
+    models.sort(sort);
 
-      if (isSmaller) {
-        return i;
+    state.ids = state.ids.filter(id => id in state.entities);
+
+    const ids: string[] = [];
+
+    let i = 0;
+    let j = 0;
+
+    while (i < models.length && j < state.ids.length) {
+      const model = models[i];
+      const modelId = selectId(model);
+      const entityId = state.ids[j];
+      const entity = state.entities[entityId];
+
+      if (sort(model, entity) <= 0) {
+        ids.push(modelId);
+        i++;
+      } else {
+        ids.push(entityId);
+        j++;
       }
     }
 
-    return state.ids.length - 1;
+    if (i < models.length) {
+      state.ids = ids.concat(models.slice(i).map(selectId));
+    } else {
+      state.ids = ids.concat(state.ids.slice(j));
+    }
+
+    models.forEach((model, i) => {
+      state.entities[selectId(model)] = model;
+    });
+
+    return true;
   }
 
   return {


### PR DESCRIPTION
Prior to this fix, collection methods in sorted_state_adapter
ran in quadratic time, because they iterated over the collection
with single-item mutators, each of which also running in linear time.

Now, we first collect all modifications (each in constant time),
then sort them in linearithmic time, and finally merge
them with the existing sorted array linearly.

As a result, we can improve performance of collection methods
to N + M log M, where N is the number of existing items
and M is the number of modifications.

Single-item methods are now expressed through those
for collections, still running linearly.