### PR TITLE
Example App: interface can extend only interface or class

### DIFF
--- a/modules/entity/src/entity_state.ts
+++ b/modules/entity/src/entity_state.ts
@@ -1,4 +1,4 @@
-import { EntityState, EntityStateStr, EntityStateNum } from './models';
+import { EntityState } from './models';
 
 export function getInitialEntityState<V>(): EntityState<V> {
   return {

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -40,17 +40,10 @@ export type UpdateNum<T> = {
 
 export type Update<T> = UpdateStr<T> | UpdateNum<T>;
 
-export interface EntityStateStr<T> {
-  ids: string[];
+export interface EntityState<T> {
+  ids: Array<string | number>;
   entities: Dictionary<T>;
 }
-
-export interface EntityStateNum<T> {
-  ids: number[];
-  entities: Dictionary<T>;
-}
-
-export type EntityState<T> = EntityStateStr<T> | EntityStateNum<T>;
 
 export interface EntityDefinition<T> {
   selectId: IdSelector<T>;

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -41,7 +41,7 @@ export type UpdateNum<T> = {
 export type Update<T> = UpdateStr<T> | UpdateNum<T>;
 
 export interface EntityState<T> {
-  ids: Array<string | number>;
+  ids: string[] | number[];
   entities: Dictionary<T>;
 }
 


### PR DESCRIPTION
## The problem

An interface may only extend a class or another interface.
<img width="959" alt="screen shot 2017-10-08 at 12 28 37 pm" src="https://user-images.githubusercontent.com/7429101/31313122-6054141e-ac24-11e7-8d8a-a6e89ec94638.png">


## The solution

Instead of splitting the interface `EntityState` into two separate interfaces we can have a unified one.