### PR TITLE
Add example for createSelector with multiple selector functions

### DIFF
--- a/docs/store/selectors.md
+++ b/docs/store/selectors.md
@@ -27,6 +27,53 @@ export const selectFeature = (state: AppState) => state.feature;
 export const selectFeatureCount = createSelector(selectFeature, (state: FeatureState) => state.counter);
 ```
 
+
+### Example with multiple state slices
+
+The `createSelector` can be used to select some data from the state based on several slices of the same state.
+
+For example, imagine you have a `selectedUser` object in the state. You also have an `allBooks` array of book objects.
+
+And you want to be able to show only the books that belong to your `selectedUser` if there is one. Otherwise you want to show them all. 
+
+You can use the `createSelector` to achieve just that. Your visible books will always be up to date even if you update them in `allBooks` and they will always show the books that belong to your user if there is one selected, and will show all the books when there is no user selected.
+
+It will behave like if you had another portion of the state that is magically synchronized with the rest of your state. But it is actually just some of your state filtered by another section of the state.
+
+```ts
+// reducers.ts
+import { createSelector } from '@ngrx/store';
+
+export interface User {
+  id: number;
+  name: string;
+}
+
+export interface Book {
+  id: number;
+  userId: number;
+  name: string;
+}
+
+export interface AppState {
+  selectedUser: User;
+  allBooks: Book[];
+}
+
+export const selectUser = (state: AppState) => state.selectedUser;
+export const selectAllBooks = (state: AppState) => state.allBooks;
+
+export const selectVisibleBooks = createSelector(selectUser, selectAllBooks, (selectedUser: User, allBooks: Books[]) => {
+  if (selectedUser && allBooks) {
+    return allBooks.filter((book: Book) => book.userId === selectedUser.id);
+  } else {
+    return allBooks;
+  }
+});
+```
+
+You can imagine how this could be extended to create complex state selections, based on several parts of your state. Actually, you can use `createSelector` with up to 8 selector functions (the example above uses just 2 selector functions).
+
 ## createFeatureSelector
 
 The `createFeatureSelector` is a convenience method for returning a top level feature state. It returns a typed selector function for a feature slice of state.

--- a/docs/store/selectors.md
+++ b/docs/store/selectors.md
@@ -28,17 +28,19 @@ export const selectFeatureCount = createSelector(selectFeature, (state: FeatureS
 ```
 
 
-### Example with multiple state slices
+### Using selectors for multiple pieces of state
 
 The `createSelector` can be used to select some data from the state based on several slices of the same state.
 
+The `createSelector` function can take up to 8 selector function for more complete state selections.
+
 For example, imagine you have a `selectedUser` object in the state. You also have an `allBooks` array of book objects.
 
-And you want to be able to show only the books that belong to your `selectedUser` if there is one. Otherwise you want to show them all. 
+And you want to show all books for the current user.
 
 You can use the `createSelector` to achieve just that. Your visible books will always be up to date even if you update them in `allBooks` and they will always show the books that belong to your user if there is one selected, and will show all the books when there is no user selected.
 
-It will behave like if you had another portion of the state that is magically synchronized with the rest of your state. But it is actually just some of your state filtered by another section of the state.
+The result will be just some of your state filtered by another section of the state. And it will be always up to date.
 
 ```ts
 // reducers.ts
@@ -71,8 +73,6 @@ export const selectVisibleBooks = createSelector(selectUser, selectAllBooks, (se
   }
 });
 ```
-
-You can imagine how this could be extended to create complex state selections, based on several parts of your state. Actually, you can use `createSelector` with up to 8 selector functions (the example above uses just 2 selector functions).
 
 ## createFeatureSelector
 


### PR DESCRIPTION
Add an example extending the `createSelector` documentation explaining how to use it with multiple state slices.

It wasn't obvious to me how powerful `createSelector` could be until @nicobytes pointed it out.