### PR TITLE
There is no @ngrx/action, but @ngrx/store

### DIFF
--- a/docs/entity/adapter.md
+++ b/docs/entity/adapter.md
@@ -101,7 +101,7 @@ export interface User {
 `user.actions.ts`
 
 ```ts
-import { Action } from '@ngrx/action';
+import { Action } from '@ngrx/store';
 import { User } from './user.model';
 
 export const LOAD_USERS = '[User] Load Users';


### PR DESCRIPTION
Example run into error, because there is no @ngrx/action package. The Action interface comes from @ngrx/store.