### PR TITLE
Boost the provideMockActions example for @ngrx/effects testing

### DIFF
--- a/docs/effects/testing.md
+++ b/docs/effects/testing.md
@@ -7,13 +7,18 @@ Provides a mock test provider of the `Actions` Observable for testing effects. T
 marble tests and tests using the `subscribe` method on an Observable. The mock Actions will deliver a new Observable
 to subscribe to for each test.
 
+Details on marble tests and their syntax, as shown in the `hot` and `cold` methods, can be found in [Writing Marble Tests](https://github.com/ReactiveX/rxjs/blob/master/doc/writing-marble-tests.md).
+
 Usage:
 ```ts
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { hot, cold } from 'jasmine-marbles';
+import { Observable } from 'rxjs/Observable';
+
 import { MyEffects } from './my-effects';
+import * as MyActions from '../actions/my-actions';
 
 describe('My Effects', () => {
   let effects: MyEffects;
@@ -21,6 +26,9 @@ describe('My Effects', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [
+        // any modules needed
+      ],
       providers: [
         MyEffects,
         provideMockActions(() => actions),
@@ -32,9 +40,12 @@ describe('My Effects', () => {
   });
 
   it('should work', () => {
-    actions = hot('--a-', { a: SomeAction });
+    const action = new MyActions.ExampleAction();
+    const completion = new MyActions.ExampleActionSuccess();
 
-    const expected = cold('--b', { b: AnotherAction });
+    // Refer to 'Writing Marble Tests' for details on '--a-' syntax
+    actions = hot('--a-', { a: action });
+    const expected = cold('--b', { b: completion });
 
     expect(effects.someSource$).toBeObservable(expected);
   });


### PR DESCRIPTION
* Add link to article that describes the mechanics and syntax used for marble testing and refer to it within the body of the example.
* Add imports that increase the clarity of the example flow: Observable and MyActions.
* Add 'imports' property to Testing module configuration for further completeness.
* Showcase an example of how Actions are created for the test and how they are used - the semantics of the Action names help paint a flow of the timeline and what is to be tested.