### PR TITLE
fix(RouterStore): Match RouterAction type parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ __build__/**
 
 # IDE #
 .idea/
+*.iml
 *.swp
 !/typings/custom.d.ts
 .vscode/

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -86,7 +86,7 @@ export type RouterErrorAction<T, V = RouterStateSnapshot> = {
  * An union type of router actions.
  */
 export type RouterAction<T, V = RouterStateSnapshot> =
-  | RouterNavigationAction<T>
+  | RouterNavigationAction<V>
   | RouterCancelAction<T, V>
   | RouterErrorAction<T, V>;
 
@@ -97,7 +97,7 @@ export type RouterReducerState<T = RouterStateSnapshot> = {
 
 export function routerReducer<T = RouterStateSnapshot>(
   state: RouterReducerState<T>,
-  action: RouterAction<any>
+  action: RouterAction<any, T>
 ): RouterReducerState<T> {
   switch (action.type) {
     case ROUTER_NAVIGATION:


### PR DESCRIPTION
I am sending a fix for the bug reported as #561.

You should probably consider better names for type parameters (for example `R` for router state and `S` for store state) since now `T` and `V` are used quite wildly in the code and every time they mean something different. But I did not want to do such big changes.