### PR TITLE
chore(StoreDevtools): improve documentation and example

### DIFF
--- a/docs/store-devtools/README.md
+++ b/docs/store-devtools/README.md
@@ -26,9 +26,14 @@ import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 @NgModule({
   imports: [
     StoreModule.forRoot(reducers),
-    // Note that you must instrument after importing StoreModule
+    // Note that you must instrument after importing StoreModule (config is optional)
     StoreDevtoolsModule.instrument({
       maxAge: 25 //  Retains last 25 states
+      // name: 'devtool title name' // default to 'NgRx Store DevTools'
+      // monitor: () => null,
+      // actionSanitizer: () => null,
+      // stateSanitizer: () => null,
+      // serialize: false,
     })
   ]
 })

--- a/docs/store-devtools/README.md
+++ b/docs/store-devtools/README.md
@@ -29,13 +29,29 @@ import { StoreDevtoolsModule } from '@ngrx/store-devtools';
     // Note that you must instrument after importing StoreModule (config is optional)
     StoreDevtoolsModule.instrument({
       maxAge: 25 //  Retains last 25 states
-      // name: 'devtool title name' // default to 'NgRx Store DevTools'
-      // monitor: () => null,
-      // actionSanitizer: () => null,
-      // stateSanitizer: () => null,
-      // serialize: false,
     })
   ]
 })
 export class AppModule { }
 ```
+
+### Available options
+When you call the instrumentation, you can give an optional configuration object:
+
+#### `maxAge`
+number (>1) | false - maximum allowed actions to be stored in the history tree. The oldest actions are removed once maxAge is reached. It's critical for performance. Default is `false` (infinite).
+
+#### `name`
+string - the instance name to be showed on the monitor page. Default value is _NgRx Store DevTools_.
+
+#### `monitor`:
+function - the monitor function configuration that you what to hook.
+
+#### `actionSanitizer`
+function which takes `action` object and id number as arguments, and should return `action` object back.
+ 
+#### `stateSanitizer`
+function which takes `state` object and index as arguments, and should return `state` object back.
+
+#### `serialize` 
+false | configuration object - Handle the way you want to serialize your state, [more information here](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize). 

--- a/example-app/app/app.module.ts
+++ b/example-app/app/app.module.ts
@@ -57,7 +57,11 @@ import { environment } from '../environments/environment';
      *
      * See: https://github.com/zalmoxisus/redux-devtools-extension
      */
-    !environment.production ? StoreDevtoolsModule.instrument() : [],
+    !environment.production
+      ? StoreDevtoolsModule.instrument({
+          name: 'NgRx Book Store DevTools',
+        })
+      : [],
 
     /**
      * EffectsModule.forRoot() is imported once in the root module and


### PR DESCRIPTION
Hi!

This adds all information needed to be able to pass a valid configuration object into `StoreDevtoolsModule.instrument()` in the documentation. Adds a small update to the example, showing that the devtool name can be changed.

Have a great day!