### PR TITLE
chore(RouterStore): add documentation on custom RouterStateSerializer

### DIFF
--- a/docs/router-store/api.md
+++ b/docs/router-store/api.md
@@ -104,6 +104,7 @@ import {
 
 export interface RouterStateUrl {
   url: string;
+  params: Params;
   queryParams: Params;
 }
 
@@ -113,12 +114,18 @@ export interface State {
 
 export class CustomSerializer implements RouterStateSerializer<RouterStateUrl> {
   serialize(routerState: RouterStateSnapshot): RouterStateUrl {
+    let route = routerState.root;
+    while (route.firstChild) {
+      route = route.firstChild;
+    }
+
     const { url } = routerState;
     const queryParams = routerState.root.queryParams;
+    const params = route.params;
 
     // Only return an object including the URL and query params
     // instead of the entire snapshot
-    return { url, queryParams };
+    return { url, params, queryParams };
   }
 }
 

--- a/docs/router-store/api.md
+++ b/docs/router-store/api.md
@@ -123,7 +123,7 @@ export class CustomSerializer implements RouterStateSerializer<RouterStateUrl> {
     const queryParams = routerState.root.queryParams;
     const params = route.params;
 
-    // Only return an object including the URL and query params
+    // Only return an object including the URL, params and query params
     // instead of the entire snapshot
     return { url, params, queryParams };
   }


### PR DESCRIPTION
Hi!

I was facing the same issue as describe [here](https://github.com/ngrx/platform/issues/382)(getting `params` object from the url) and spent some time finding this thread. I found that it could be useful to add the information to the documentation.

Have a great day! 