### PR TITLE
example-app: Update actions types to use enum instead of const

### DIFF
--- a/example-app/app/auth/actions/auth.ts
+++ b/example-app/app/auth/actions/auth.ts
@@ -1,39 +1,41 @@
 import { Action } from '@ngrx/store';
 import { User, Authenticate } from '../models/user';
 
-export const LOGIN = '[Auth] Login';
-export const LOGOUT = '[Auth] Logout';
-export const LOGIN_SUCCESS = '[Auth] Login Success';
-export const LOGIN_FAILURE = '[Auth] Login Failure';
-export const LOGIN_REDIRECT = '[Auth] Login Redirect';
+export enum AuthActionTypes {
+  Login = '[Auth] Login',
+  Logout = '[Auth] Logout',
+  LoginSuccess = '[Auth] Login Success',
+  LoginFailure = '[Auth] Login Failure',
+  LoginRedirect = '[Auth] Login Redirect',
+}
 
 export class Login implements Action {
-  readonly type = LOGIN;
+  readonly type = AuthActionTypes.Login;
 
   constructor(public payload: Authenticate) {}
 }
 
 export class LoginSuccess implements Action {
-  readonly type = LOGIN_SUCCESS;
+  readonly type = AuthActionTypes.LoginSuccess;
 
   constructor(public payload: { user: User }) {}
 }
 
 export class LoginFailure implements Action {
-  readonly type = LOGIN_FAILURE;
+  readonly type = AuthActionTypes.LoginFailure;
 
   constructor(public payload: any) {}
 }
 
 export class LoginRedirect implements Action {
-  readonly type = LOGIN_REDIRECT;
+  readonly type = AuthActionTypes.LoginRedirect;
 }
 
 export class Logout implements Action {
-  readonly type = LOGOUT;
+  readonly type = AuthActionTypes.Logout;
 }
 
-export type Actions =
+export type AuthActions =
   | Login
   | LoginSuccess
   | LoginFailure

--- a/example-app/app/auth/effects/auth.effects.ts
+++ b/example-app/app/auth/effects/auth.effects.ts
@@ -9,29 +9,34 @@ import { Effect, Actions } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
 
 import { AuthService } from '../services/auth.service';
-import * as Auth from '../actions/auth';
+import {
+  Login,
+  LoginSuccess,
+  LoginFailure,
+  AuthActionTypes,
+} from '../actions/auth';
 
 @Injectable()
 export class AuthEffects {
   @Effect()
   login$ = this.actions$
-    .ofType(Auth.LOGIN)
-    .map((action: Auth.Login) => action.payload)
+    .ofType(AuthActionTypes.Login)
+    .map((action: Login) => action.payload)
     .exhaustMap(auth =>
       this.authService
         .login(auth)
-        .map(user => new Auth.LoginSuccess({ user }))
-        .catch(error => of(new Auth.LoginFailure(error)))
+        .map(user => new LoginSuccess({ user }))
+        .catch(error => of(new LoginFailure(error)))
     );
 
   @Effect({ dispatch: false })
   loginSuccess$ = this.actions$
-    .ofType(Auth.LOGIN_SUCCESS)
+    .ofType(AuthActionTypes.LoginSuccess)
     .do(() => this.router.navigate(['/']));
 
   @Effect({ dispatch: false })
   loginRedirect$ = this.actions$
-    .ofType(Auth.LOGIN_REDIRECT, Auth.LOGOUT)
+    .ofType(AuthActionTypes.LoginRedirect, AuthActionTypes.Logout)
     .do(authed => {
       this.router.navigate(['/login']);
     });

--- a/example-app/app/auth/reducers/auth.ts
+++ b/example-app/app/auth/reducers/auth.ts
@@ -1,4 +1,4 @@
-import * as auth from '../actions/auth';
+import { AuthActions, AuthActionTypes } from './../actions/auth';
 import { User } from '../models/user';
 
 export interface State {
@@ -11,9 +11,9 @@ export const initialState: State = {
   user: null,
 };
 
-export function reducer(state = initialState, action: auth.Actions): State {
+export function reducer(state = initialState, action: AuthActions): State {
   switch (action.type) {
-    case auth.LOGIN_SUCCESS: {
+    case AuthActionTypes.LoginSuccess: {
       return {
         ...state,
         loggedIn: true,
@@ -21,7 +21,7 @@ export function reducer(state = initialState, action: auth.Actions): State {
       };
     }
 
-    case auth.LOGOUT: {
+    case AuthActionTypes.Logout: {
       return initialState;
     }
 

--- a/example-app/app/auth/reducers/login-page.ts
+++ b/example-app/app/auth/reducers/login-page.ts
@@ -1,4 +1,4 @@
-import * as auth from '../actions/auth';
+import { AuthActionTypes, AuthActions } from './../actions/auth';
 
 export interface State {
   error: string | null;
@@ -10,9 +10,9 @@ export const initialState: State = {
   pending: false,
 };
 
-export function reducer(state = initialState, action: auth.Actions): State {
+export function reducer(state = initialState, action: AuthActions): State {
   switch (action.type) {
-    case auth.LOGIN: {
+    case AuthActionTypes.Login: {
       return {
         ...state,
         error: null,
@@ -20,7 +20,7 @@ export function reducer(state = initialState, action: auth.Actions): State {
       };
     }
 
-    case auth.LOGIN_SUCCESS: {
+    case AuthActionTypes.LoginSuccess: {
       return {
         ...state,
         error: null,
@@ -28,7 +28,7 @@ export function reducer(state = initialState, action: auth.Actions): State {
       };
     }
 
-    case auth.LOGIN_FAILURE: {
+    case AuthActionTypes.LoginFailure: {
       return {
         ...state,
         error: action.payload,

--- a/example-app/app/books/actions/book.ts
+++ b/example-app/app/books/actions/book.ts
@@ -1,11 +1,13 @@
 import { Action } from '@ngrx/store';
 import { Book } from '../models/book';
 
-export const SEARCH = '[Book] Search';
-export const SEARCH_COMPLETE = '[Book] Search Complete';
-export const SEARCH_ERROR = '[Book] Search Error';
-export const LOAD = '[Book] Load';
-export const SELECT = '[Book] Select';
+export enum BookActionTypes {
+  Search = '[Book] Search',
+  SearchComplete = '[Book] Search Complete',
+  SearchError = '[Book] Search Error',
+  Load = '[Book] Load',
+  Select = '[Book] Select',
+}
 
 /**
  * Every action is comprised of at least a type and an optional
@@ -15,31 +17,31 @@ export const SELECT = '[Book] Select';
  * See Discriminated Unions: https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions
  */
 export class Search implements Action {
-  readonly type = SEARCH;
+  readonly type = BookActionTypes.Search;
 
   constructor(public payload: string) {}
 }
 
 export class SearchComplete implements Action {
-  readonly type = SEARCH_COMPLETE;
+  readonly type = BookActionTypes.SearchComplete;
 
   constructor(public payload: Book[]) {}
 }
 
 export class SearchError implements Action {
-  readonly type = SEARCH_ERROR;
+  readonly type = BookActionTypes.SearchError;
 
   constructor(public payload: string) {}
 }
 
 export class Load implements Action {
-  readonly type = LOAD;
+  readonly type = BookActionTypes.Load;
 
   constructor(public payload: Book) {}
 }
 
 export class Select implements Action {
-  readonly type = SELECT;
+  readonly type = BookActionTypes.Select;
 
   constructor(public payload: string) {}
 }
@@ -48,4 +50,4 @@ export class Select implements Action {
  * Export a type alias of all actions in this action group
  * so that reducers can easily compose action types
  */
-export type Actions = Search | SearchComplete | SearchError | Load | Select;
+export type BookActions = Search | SearchComplete | SearchError | Load | Select;

--- a/example-app/app/books/actions/collection.ts
+++ b/example-app/app/books/actions/collection.ts
@@ -1,33 +1,35 @@
 import { Action } from '@ngrx/store';
 import { Book } from '../models/book';
 
-export const ADD_BOOK = '[Collection] Add Book';
-export const ADD_BOOK_SUCCESS = '[Collection] Add Book Success';
-export const ADD_BOOK_FAIL = '[Collection] Add Book Fail';
-export const REMOVE_BOOK = '[Collection] Remove Book';
-export const REMOVE_BOOK_SUCCESS = '[Collection] Remove Book Success';
-export const REMOVE_BOOK_FAIL = '[Collection] Remove Book Fail';
-export const LOAD = '[Collection] Load';
-export const LOAD_SUCCESS = '[Collection] Load Success';
-export const LOAD_FAIL = '[Collection] Load Fail';
+export enum CollectionActionTypes {
+  AddBook = '[Collection] Add Book',
+  AddBookSuccess = '[Collection] Add Book Success',
+  AddBookFail = '[Collection] Add Book Fail',
+  RemoveBook = '[Collection] Remove Book',
+  RemoveBookSuccess = '[Collection] Remove Book Success',
+  RemoveBookFail = '[Collection] Remove Book Fail',
+  Load = '[Collection] Load',
+  LoadSuccess = '[Collection] Load Success',
+  LoadFail = '[Collection] Load Fail',
+}
 
 /**
  * Add Book to Collection Actions
  */
 export class AddBook implements Action {
-  readonly type = ADD_BOOK;
+  readonly type = CollectionActionTypes.AddBook;
 
   constructor(public payload: Book) {}
 }
 
 export class AddBookSuccess implements Action {
-  readonly type = ADD_BOOK_SUCCESS;
+  readonly type = CollectionActionTypes.AddBookSuccess;
 
   constructor(public payload: Book) {}
 }
 
 export class AddBookFail implements Action {
-  readonly type = ADD_BOOK_FAIL;
+  readonly type = CollectionActionTypes.AddBookFail;
 
   constructor(public payload: Book) {}
 }
@@ -36,19 +38,19 @@ export class AddBookFail implements Action {
  * Remove Book from Collection Actions
  */
 export class RemoveBook implements Action {
-  readonly type = REMOVE_BOOK;
+  readonly type = CollectionActionTypes.RemoveBook;
 
   constructor(public payload: Book) {}
 }
 
 export class RemoveBookSuccess implements Action {
-  readonly type = REMOVE_BOOK_SUCCESS;
+  readonly type = CollectionActionTypes.RemoveBookSuccess;
 
   constructor(public payload: Book) {}
 }
 
 export class RemoveBookFail implements Action {
-  readonly type = REMOVE_BOOK_FAIL;
+  readonly type = CollectionActionTypes.RemoveBookFail;
 
   constructor(public payload: Book) {}
 }
@@ -57,22 +59,22 @@ export class RemoveBookFail implements Action {
  * Load Collection Actions
  */
 export class Load implements Action {
-  readonly type = LOAD;
+  readonly type = CollectionActionTypes.Load;
 }
 
 export class LoadSuccess implements Action {
-  readonly type = LOAD_SUCCESS;
+  readonly type = CollectionActionTypes.LoadSuccess;
 
   constructor(public payload: Book[]) {}
 }
 
 export class LoadFail implements Action {
-  readonly type = LOAD_FAIL;
+  readonly type = CollectionActionTypes.LoadFail;
 
   constructor(public payload: any) {}
 }
 
-export type Actions =
+export type CollectionActions =
   | AddBook
   | AddBookSuccess
   | AddBookFail

--- a/example-app/app/books/effects/book.ts
+++ b/example-app/app/books/effects/book.ts
@@ -14,7 +14,13 @@ import { empty } from 'rxjs/observable/empty';
 import { of } from 'rxjs/observable/of';
 
 import { GoogleBooksService } from '../../core/services/google-books';
-import * as book from '../actions/book';
+import {
+  BookActionTypes,
+  BookActions,
+  SearchComplete,
+  SearchError,
+  Search,
+} from '../actions/book';
 import { Book } from '../models/book';
 
 export const SEARCH_DEBOUNCE = new InjectionToken<number>('Search Debounce');
@@ -37,7 +43,7 @@ export const SEARCH_SCHEDULER = new InjectionToken<Scheduler>(
 export class BookEffects {
   @Effect()
   search$: Observable<Action> = this.actions$
-    .ofType<book.Search>(book.SEARCH)
+    .ofType<Search>(BookActionTypes.Search)
     .debounceTime(this.debounce || 300, this.scheduler || async)
     .map(action => action.payload)
     .switchMap(query => {
@@ -45,13 +51,13 @@ export class BookEffects {
         return empty();
       }
 
-      const nextSearch$ = this.actions$.ofType(book.SEARCH).skip(1);
+      const nextSearch$ = this.actions$.ofType(BookActionTypes.Search).skip(1);
 
       return this.googleBooks
         .searchBooks(query)
         .takeUntil(nextSearch$)
-        .map((books: Book[]) => new book.SearchComplete(books))
-        .catch(err => of(new book.SearchError(err)));
+        .map((books: Book[]) => new SearchComplete(books))
+        .catch(err => of(new SearchError(err)));
     });
 
   constructor(

--- a/example-app/app/books/effects/collection.ts
+++ b/example-app/app/books/effects/collection.ts
@@ -1,3 +1,4 @@
+import { Load } from './../actions/book';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/switchMap';
@@ -11,7 +12,18 @@ import { Observable } from 'rxjs/Observable';
 import { defer } from 'rxjs/observable/defer';
 import { of } from 'rxjs/observable/of';
 
-import * as collection from '../actions/collection';
+import {
+  CollectionActions,
+  LoadFail,
+  LoadSuccess,
+  AddBookSuccess,
+  AddBookFail,
+  CollectionActionTypes,
+  RemoveBook,
+  RemoveBookFail,
+  RemoveBookSuccess,
+  AddBook,
+} from './../actions/collection';
 import { Book } from '../models/book';
 
 @Injectable()
@@ -33,35 +45,35 @@ export class CollectionEffects {
 
   @Effect()
   loadCollection$: Observable<Action> = this.actions$
-    .ofType(collection.LOAD)
+    .ofType(CollectionActionTypes.Load)
     .switchMap(() =>
       this.db
         .query('books')
         .toArray()
-        .map((books: Book[]) => new collection.LoadSuccess(books))
-        .catch(error => of(new collection.LoadFail(error)))
+        .map((books: Book[]) => new LoadSuccess(books))
+        .catch(error => of(new LoadFail(error)))
     );
 
   @Effect()
   addBookToCollection$: Observable<Action> = this.actions$
-    .ofType(collection.ADD_BOOK)
-    .map((action: collection.AddBook) => action.payload)
+    .ofType(CollectionActionTypes.AddBook)
+    .map((action: AddBook) => action.payload)
     .mergeMap(book =>
       this.db
         .insert('books', [book])
-        .map(() => new collection.AddBookSuccess(book))
-        .catch(() => of(new collection.AddBookFail(book)))
+        .map(() => new AddBookSuccess(book))
+        .catch(() => of(new AddBookFail(book)))
     );
 
   @Effect()
   removeBookFromCollection$: Observable<Action> = this.actions$
-    .ofType(collection.REMOVE_BOOK)
-    .map((action: collection.RemoveBook) => action.payload)
+    .ofType(CollectionActionTypes.RemoveBook)
+    .map((action: RemoveBook) => action.payload)
     .mergeMap(book =>
       this.db
         .executeWrite('books', 'delete', [book.id])
-        .map(() => new collection.RemoveBookSuccess(book))
-        .catch(() => of(new collection.RemoveBookFail(book)))
+        .map(() => new RemoveBookSuccess(book))
+        .catch(() => of(new RemoveBookFail(book)))
     );
 
   constructor(private actions$: Actions, private db: Database) {}

--- a/example-app/app/books/reducers/books.ts
+++ b/example-app/app/books/reducers/books.ts
@@ -1,8 +1,11 @@
 import { createSelector } from '@ngrx/store';
 import { createEntityAdapter, EntityAdapter, EntityState } from '@ngrx/entity';
 import { Book } from '../models/book';
-import * as book from '../actions/book';
-import * as collection from '../actions/collection';
+import { BookActions, BookActionTypes } from '../actions/book';
+import {
+  CollectionActions,
+  CollectionActionTypes,
+} from '../actions/collection';
 
 /**
  * @ngrx/entity provides a predefined interface for handling
@@ -38,11 +41,11 @@ export const initialState: State = adapter.getInitialState({
 
 export function reducer(
   state = initialState,
-  action: book.Actions | collection.Actions
+  action: BookActions | CollectionActions
 ): State {
   switch (action.type) {
-    case book.SEARCH_COMPLETE:
-    case collection.LOAD_SUCCESS: {
+    case BookActionTypes.SearchComplete:
+    case CollectionActionTypes.LoadSuccess: {
       return {
         /**
          * The addMany function provided by the created adapter
@@ -56,7 +59,7 @@ export function reducer(
       };
     }
 
-    case book.LOAD: {
+    case BookActionTypes.Load: {
       return {
         /**
          * The addOne function provided by the created adapter
@@ -70,7 +73,7 @@ export function reducer(
       };
     }
 
-    case book.SELECT: {
+    case BookActionTypes.Select: {
       return {
         ...state,
         selectedBookId: action.payload,

--- a/example-app/app/books/reducers/collection.ts
+++ b/example-app/app/books/reducers/collection.ts
@@ -1,4 +1,7 @@
-import * as collection from '../actions/collection';
+import {
+  CollectionActionTypes,
+  CollectionActions,
+} from './../actions/collection';
 
 export interface State {
   loaded: boolean;
@@ -14,17 +17,17 @@ const initialState: State = {
 
 export function reducer(
   state = initialState,
-  action: collection.Actions
+  action: CollectionActions
 ): State {
   switch (action.type) {
-    case collection.LOAD: {
+    case CollectionActionTypes.Load: {
       return {
         ...state,
         loading: true,
       };
     }
 
-    case collection.LOAD_SUCCESS: {
+    case CollectionActionTypes.LoadSuccess: {
       return {
         loaded: true,
         loading: false,
@@ -32,8 +35,8 @@ export function reducer(
       };
     }
 
-    case collection.ADD_BOOK_SUCCESS:
-    case collection.REMOVE_BOOK_FAIL: {
+    case CollectionActionTypes.AddBookSuccess:
+    case CollectionActionTypes.RemoveBookFail: {
       if (state.ids.indexOf(action.payload.id) > -1) {
         return state;
       }
@@ -44,8 +47,8 @@ export function reducer(
       };
     }
 
-    case collection.REMOVE_BOOK_SUCCESS:
-    case collection.ADD_BOOK_FAIL: {
+    case CollectionActionTypes.RemoveBookSuccess:
+    case CollectionActionTypes.AddBookFail: {
       return {
         ...state,
         ids: state.ids.filter(id => id !== action.payload.id),

--- a/example-app/app/books/reducers/search.ts
+++ b/example-app/app/books/reducers/search.ts
@@ -1,4 +1,4 @@
-import * as book from '../actions/book';
+import { BookActionTypes, BookActions } from '../actions/book';
 
 export interface State {
   ids: string[];
@@ -14,9 +14,9 @@ const initialState: State = {
   query: '',
 };
 
-export function reducer(state = initialState, action: book.Actions): State {
+export function reducer(state = initialState, action: BookActions): State {
   switch (action.type) {
-    case book.SEARCH: {
+    case BookActionTypes.Search: {
       const query = action.payload;
 
       if (query === '') {
@@ -36,7 +36,7 @@ export function reducer(state = initialState, action: book.Actions): State {
       };
     }
 
-    case book.SEARCH_COMPLETE: {
+    case BookActionTypes.SearchComplete: {
       return {
         ids: action.payload.map(book => book.id),
         loading: false,
@@ -45,7 +45,7 @@ export function reducer(state = initialState, action: book.Actions): State {
       };
     }
 
-    case book.SEARCH_ERROR: {
+    case BookActionTypes.SearchError: {
       return {
         ...state,
         loading: false,

--- a/example-app/app/core/actions/layout.ts
+++ b/example-app/app/core/actions/layout.ts
@@ -1,14 +1,16 @@
 import { Action } from '@ngrx/store';
 
-export const OPEN_SIDENAV = '[Layout] Open Sidenav';
-export const CLOSE_SIDENAV = '[Layout] Close Sidenav';
+export enum LayoutActionTypes {
+  OpenSidenav = '[Layout] Open Sidenav',
+  CloseSidenav = '[Layout] Close Sidenav',
+}
 
 export class OpenSidenav implements Action {
-  readonly type = OPEN_SIDENAV;
+  readonly type = LayoutActionTypes.OpenSidenav;
 }
 
 export class CloseSidenav implements Action {
-  readonly type = CLOSE_SIDENAV;
+  readonly type = LayoutActionTypes.CloseSidenav;
 }
 
-export type Actions = OpenSidenav | CloseSidenav;
+export type LayoutActions = OpenSidenav | CloseSidenav;

--- a/example-app/app/core/reducers/layout.ts
+++ b/example-app/app/core/reducers/layout.ts
@@ -1,4 +1,4 @@
-import * as layout from '../actions/layout';
+import { LayoutActionTypes, LayoutActions } from '../actions/layout';
 
 export interface State {
   showSidenav: boolean;
@@ -8,14 +8,17 @@ const initialState: State = {
   showSidenav: false,
 };
 
-export function reducer(state = initialState, action: layout.Actions): State {
+export function reducer(
+  state: State = initialState,
+  action: LayoutActions
+): State {
   switch (action.type) {
-    case layout.CLOSE_SIDENAV:
+    case LayoutActionTypes.CloseSidenav:
       return {
         showSidenav: false,
       };
 
-    case layout.OPEN_SIDENAV:
+    case LayoutActionTypes.OpenSidenav:
       return {
         showSidenav: true,
       };


### PR DESCRIPTION
Suggestion, update actions types to use enum instead of const in example-app. See Issue #597 .

I've only updated two files as an example, but can update the rest if approved. Let me know what you think.