### PR TITLE
fix(prettier) ignore node_modules if glob path begins with dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "example:test": "jest --watch",
     "example:build:prod": "yarn build && yarn run copy:dist && yarn cli -- build -prod --base-href \"/platform/example-app/\" --output-path \"./example-dist/example-app\"",
     "ci": "yarn run build && yarn run test && nyc report --reporter=text-lcov | coveralls",
-    "prettier": "prettier --parser typescript --single-quote --trailing-comma es5 --write \"./**/*.ts\"",
+    "prettier": "prettier --parser typescript --single-quote --trailing-comma es5 --write \"**/*.ts\"",
     "watch:tests": "chokidar 'modules/**/*.ts' --initial -c 'nyc --reporter=text --reporter=html yarn run test:unit'",
     "postinstall": "opencollective postinstall",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",


### PR DESCRIPTION
Its depends from 
https://github.com/isaacs/node-glob/issues/309

If we use glob path begin ./ , then we include 'node_modules' folders (exists in modules packages).
This affects only OS - such as Linux, MacOS.
