### PR TITLE
fix(*): package code is bundled twice from `src` and `es5` file

### DIFF
--- a/build/builder.ts
+++ b/build/builder.ts
@@ -9,6 +9,7 @@ export default createBuilder([
   ['Creating UMD Bundles', tasks.createUmdBundles],
   ['Renaming package entry files', tasks.renamePackageEntryFiles],
   ['Cleaning TypeScript files', tasks.cleanTypeScriptFiles],
+  ['Cleaning JavaScript files', tasks.cleanJavaScriptFiles],
   ['Removing remaining sourcemap files', tasks.removeRemainingSourceMapFiles],
   ['Copying type definition files', tasks.copyTypeDefinitionFiles],
   ['Minifying UMD bundles', tasks.minifyUmdBundles],

--- a/build/tasks.ts
+++ b/build/tasks.ts
@@ -123,6 +123,21 @@ export async function cleanTypeScriptFiles(config: Config) {
 }
 
 /**
+ * Removes any leftover Javascript files from previous compilation steps,
+ * leaving the bundles and FESM in place
+ */
+export async function cleanJavaScriptFiles(config: Config) {
+  const jsFilesGlob = './dist/packages/**/*.js';
+  const jsExcludeFilesFlob = './dist/packages/(bundles|@ngrx)/**/*.js';
+  const filesToRemove = await util.getListOfFiles(
+    jsFilesGlob,
+    jsExcludeFilesFlob
+  );
+
+  await mapAsync(filesToRemove, util.remove);
+}
+
+/**
  * Renames the index files in each package to the name
  * of the package.
  */


### PR DESCRIPTION
At the moment both the `src` and `FESM` are being bundled, at least when using Angular 4.

Remove `JavaScript` from `src` folder as this is not required by the consumers and in some cases with `Angular 4.x.x` and `@ngtools/webpack` it causes the `src` to be bundled togather with the `FESM`.

With Angular 4 and Webpack the javascript in `src` is being used rather than the FESM.

Relates: https://github.com/ngrx/platform/issues/184#issuecomment-319649909

Somewhat this is an urgent fix as currently we are blocked by this.