### PR TITLE
fix(*): packages are being bundled twice

### DIFF
--- a/build/builder.ts
+++ b/build/builder.ts
@@ -9,6 +9,7 @@ export default createBuilder([
   ['Creating UMD Bundles', tasks.createUmdBundles],
   ['Renaming package entry files', tasks.renamePackageEntryFiles],
   ['Cleaning TypeScript files', tasks.cleanTypeScriptFiles],
+  ['Cleaning JavaScript files', tasks.cleanJavaScriptFiles],
   ['Removing remaining sourcemap files', tasks.removeRemainingSourceMapFiles],
   ['Copying type definition files', tasks.copyTypeDefinitionFiles],
   ['Minifying UMD bundles', tasks.minifyUmdBundles],

--- a/build/tasks.ts
+++ b/build/tasks.ts
@@ -123,6 +123,21 @@ export async function cleanTypeScriptFiles(config: Config) {
 }
 
 /**
+ * Removes any leftover Javascript files from previous compilation steps,
+ * leaving the bundles and FESM in place
+ */
+export async function cleanJavaScriptFiles(config: Config) {
+  const jsFilesGlob = './dist/packages/**/*.js';
+  const jsExcludeFilesFlob = './dist/packages/(bundles|@ngrx)/**/*.js';
+  const filesToRemove = await util.getListOfFiles(
+    jsFilesGlob,
+    jsExcludeFilesFlob
+  );
+
+  await mapAsync(filesToRemove, util.remove);
+}
+
+/**
  * Renames the index files in each package to the name
  * of the package.
  */


### PR DESCRIPTION
Remove `JavaScript` from `src` folder as this is not required by the consumers with `Angular 4.x.x`, `@ngtools/webpack` and `paths` in `tsconfig.json` it causes the `src` to be bundled togather with the `FESM`.

Closes: #629