### PR TITLE
feat(ErrorReporter): expose ErrorReporter as a ErrorHandler for ngrx

### DIFF
--- a/modules/effects/spec/effect_sources.spec.ts
+++ b/modules/effects/spec/effect_sources.spec.ts
@@ -32,7 +32,7 @@ describe('EffectSources', () => {
     mockErrorReporter = TestBed.get(ErrorReporter);
     effectSources = TestBed.get(EffectSources);
 
-    spyOn(mockErrorReporter, 'report');
+    spyOn(mockErrorReporter, 'handleError');
   });
 
   it('should have an "addEffects" method to push new source instances', () => {
@@ -103,7 +103,7 @@ describe('EffectSources', () => {
 
       toActions(sources$).subscribe();
 
-      expect(mockErrorReporter.report).toHaveBeenCalled();
+      expect(mockErrorReporter.handleError).toHaveBeenCalled();
     });
 
     it('should not complete the group if just one effect completes', () => {

--- a/modules/effects/src/error_reporter.ts
+++ b/modules/effects/src/error_reporter.ts
@@ -1,15 +1,37 @@
-import { Injectable, InjectionToken, Inject } from '@angular/core';
+import {
+  ErrorHandler,
+  Injectable,
+  InjectionToken,
+  Inject,
+} from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Notification } from 'rxjs/Notification';
+import { Action } from '@ngrx/store';
 import { CONSOLE } from './tokens';
 
+export interface EffectError extends Error {
+  Source: any;
+  Effect: Observable<any> | (() => Observable<any>);
+  Error: any;
+  Notification: Notification<Action | null | undefined>;
+}
+
+export interface InvalidActionError extends Error {
+  Source: any;
+  Effect: Observable<any> | (() => Observable<any>);
+  Dispatched: Action | null | undefined;
+  Notification: Notification<Action | null | undefined>;
+}
+
 @Injectable()
-export class ErrorReporter {
+export class ErrorReporter implements ErrorHandler {
   constructor(@Inject(CONSOLE) private console: any) {}
 
-  report(reason: string, details: any): void {
-    this.console.group(reason);
+  handleError(error: any): void {
+    this.console.group(error.message);
 
-    for (let key in details) {
-      this.console.error(`${key}:`, details[key]);
+    for (let key in error) {
+      this.console.error(`${key}:`, error[key]);
     }
 
     this.console.groupEnd();

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -10,4 +10,5 @@ export { EffectSources } from './effect_sources';
 export { OnRunEffects } from './on_run_effects';
 export { toPayload } from './util';
 export { EffectNotification } from './effect_notification';
+export { ErrorReporter } from './error_reporter';
 export { ROOT_EFFECTS_INIT } from './effects_root_module';


### PR DESCRIPTION
Fixes #626 

Could potentially change:
* What (if any) extra error information is exposed. Right now this information is quite specific to dumping it to the console. I think for any non-console error reporting this information (such as the instance of `Observable` and `Notification`) wouldn't be very useful.
* How that extra information is exposed. Right now it is direct properties on the `Error`, typed using interfaces extending `Error`.

In the `EffectError` case it would be nice to expose the real `Notification.error` better so custom `ErrorHandler`s will (by default) be handling the real underling error that was thrown.  Again... if we weren't building the custom `EffectError` for the console logging purposes I think just invoking `ErrorHandler.handleError(Notification.error)` would be best.

Or as an alternative (which I keep mentioning, sorry :P), avoid expanding the public API and just delete this custom error handler: https://github.com/jbedard/platform/commit/41bdf03f216fb9b55690f5fb1498d0c9429dcad6