### PR TITLE
feat(lib): Add lettable operators for Store and Effects operators

### DIFF
--- a/example-app/app/auth/containers/login-page.component.ts
+++ b/example-app/app/auth/containers/login-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 import { Authenticate } from '../models/user';
 import * as fromAuth from '../reducers';
 import * as Auth from '../actions/auth';
@@ -16,8 +16,8 @@ import * as Auth from '../actions/auth';
   styles: [],
 })
 export class LoginPageComponent implements OnInit {
-  pending$ = this.store.select(fromAuth.getLoginPagePending);
-  error$ = this.store.select(fromAuth.getLoginPageError);
+  pending$ = this.store.pipe(select(fromAuth.getLoginPagePending));
+  error$ = this.store.pipe(select(fromAuth.getLoginPageError));
 
   constructor(private store: Store<fromAuth.State>) {}
 

--- a/example-app/app/auth/effects/auth.effects.ts
+++ b/example-app/app/auth/effects/auth.effects.ts
@@ -1,12 +1,8 @@
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/exhaustMap';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/take';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { Effect, Actions } from '@ngrx/effects';
+import { Effect, Actions, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
+import { tap, map, exhaustMap, catchError } from 'rxjs/operators';
 
 import { AuthService } from '../services/auth.service';
 import {
@@ -15,31 +11,37 @@ import {
   LoginFailure,
   AuthActionTypes,
 } from '../actions/auth';
+import { User, Authenticate } from '../models/user';
 
 @Injectable()
 export class AuthEffects {
   @Effect()
-  login$ = this.actions$
-    .ofType(AuthActionTypes.Login)
-    .map((action: Login) => action.payload)
-    .exhaustMap(auth =>
+  login$ = this.actions$.pipe(
+    ofType(AuthActionTypes.Login),
+    map((action: Login) => action.payload),
+    exhaustMap((auth: Authenticate) =>
       this.authService
         .login(auth)
-        .map(user => new LoginSuccess({ user }))
-        .catch(error => of(new LoginFailure(error)))
-    );
+        .pipe(
+          map(user => new LoginSuccess({ user })),
+          catchError(error => of(new LoginFailure(error)))
+        )
+    )
+  );
 
   @Effect({ dispatch: false })
-  loginSuccess$ = this.actions$
-    .ofType(AuthActionTypes.LoginSuccess)
-    .do(() => this.router.navigate(['/']));
+  loginSuccess$ = this.actions$.pipe(
+    ofType(AuthActionTypes.LoginSuccess),
+    tap(() => this.router.navigate(['/']))
+  );
 
   @Effect({ dispatch: false })
-  loginRedirect$ = this.actions$
-    .ofType(AuthActionTypes.LoginRedirect, AuthActionTypes.Logout)
-    .do(authed => {
+  loginRedirect$ = this.actions$.pipe(
+    ofType(AuthActionTypes.LoginRedirect, AuthActionTypes.Logout),
+    tap(authed => {
       this.router.navigate(['/login']);
-    });
+    })
+  );
 
   constructor(
     private actions$: Actions,

--- a/example-app/app/auth/services/auth-guard.service.ts
+++ b/example-app/app/auth/services/auth-guard.service.ts
@@ -1,9 +1,8 @@
-import 'rxjs/add/operator/take';
-import 'rxjs/add/operator/map';
 import { Injectable } from '@angular/core';
 import { CanActivate } from '@angular/router';
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
+import { map, take } from 'rxjs/operators';
 import * as Auth from '../actions/auth';
 import * as fromAuth from '../reducers';
 
@@ -12,16 +11,17 @@ export class AuthGuard implements CanActivate {
   constructor(private store: Store<fromAuth.State>) {}
 
   canActivate(): Observable<boolean> {
-    return this.store
-      .select(fromAuth.getLoggedIn)
-      .map(authed => {
+    return this.store.pipe(
+      select(fromAuth.getLoggedIn),
+      map(authed => {
         if (!authed) {
           this.store.dispatch(new Auth.LoginRedirect());
           return false;
         }
 
         return true;
-      })
-      .take(1);
+      }),
+      take(1)
+    );
   }
 }

--- a/example-app/app/auth/services/auth.service.ts
+++ b/example-app/app/auth/services/auth.service.ts
@@ -2,12 +2,13 @@ import { Injectable } from '@angular/core';
 import { of } from 'rxjs/observable/of';
 import { _throw } from 'rxjs/observable/throw';
 import { User, Authenticate } from '../models/user';
+import { Observable } from 'rxjs/Observable';
 
 @Injectable()
 export class AuthService {
   constructor() {}
 
-  login({ username, password }: Authenticate) {
+  login({ username, password }: Authenticate): Observable<User> {
     /**
      * Simulate a failed login to display the error
      * message for the login form.

--- a/example-app/app/books/components/book-search.ts
+++ b/example-app/app/books/components/book-search.ts
@@ -1,6 +1,3 @@
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/distinctUntilChanged';
 import { Component, Output, Input, EventEmitter } from '@angular/core';
 
 @Component({

--- a/example-app/app/books/containers/collection-page.ts
+++ b/example-app/app/books/containers/collection-page.ts
@@ -1,6 +1,5 @@
-import 'rxjs/add/operator/let';
 import { Component, ChangeDetectionStrategy, OnInit } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
 import * as fromBooks from '../reducers';
@@ -36,7 +35,7 @@ export class CollectionPageComponent implements OnInit {
   books$: Observable<Book[]>;
 
   constructor(private store: Store<fromBooks.State>) {
-    this.books$ = store.select(fromBooks.getBookCollection);
+    this.books$ = store.pipe(select(fromBooks.getBookCollection));
   }
 
   ngOnInit() {

--- a/example-app/app/books/containers/find-book-page.ts
+++ b/example-app/app/books/containers/find-book-page.ts
@@ -1,7 +1,7 @@
-import 'rxjs/add/operator/take';
 import { Component, ChangeDetectionStrategy } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
+import { take } from 'rxjs/operators';
 
 import * as fromBooks from '../reducers';
 import * as book from '../actions/book';
@@ -22,10 +22,10 @@ export class FindBookPageComponent {
   error$: Observable<string>;
 
   constructor(private store: Store<fromBooks.State>) {
-    this.searchQuery$ = store.select(fromBooks.getSearchQuery).take(1);
-    this.books$ = store.select(fromBooks.getSearchResults);
-    this.loading$ = store.select(fromBooks.getSearchLoading);
-    this.error$ = store.select(fromBooks.getSearchError);
+    this.searchQuery$ = store.pipe(select(fromBooks.getSearchQuery), take(1));
+    this.books$ = store.pipe(select(fromBooks.getSearchResults));
+    this.loading$ = store.pipe(select(fromBooks.getSearchLoading));
+    this.error$ = store.pipe(select(fromBooks.getSearchError));
   }
 
   search(query: string) {

--- a/example-app/app/books/containers/selected-book-page.ts
+++ b/example-app/app/books/containers/selected-book-page.ts
@@ -1,5 +1,5 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
 import * as fromBooks from '../reducers';
@@ -23,9 +23,9 @@ export class SelectedBookPageComponent {
   isSelectedBookInCollection$: Observable<boolean>;
 
   constructor(private store: Store<fromBooks.State>) {
-    this.book$ = store.select(fromBooks.getSelectedBook);
-    this.isSelectedBookInCollection$ = store.select(
-      fromBooks.isSelectedBookInCollection
+    this.book$ = store.pipe(select(fromBooks.getSelectedBook));
+    this.isSelectedBookInCollection$ = store.pipe(
+      select(fromBooks.isSelectedBookInCollection)
     );
   }
 

--- a/example-app/app/books/containers/view-book-page.spec.ts
+++ b/example-app/app/books/containers/view-book-page.spec.ts
@@ -31,6 +31,7 @@ describe('View Book Page', () => {
           useValue: {
             select: jest.fn(),
             next: jest.fn(),
+            pipe: jest.fn(),
           },
         },
       ],

--- a/example-app/app/books/containers/view-book-page.ts
+++ b/example-app/app/books/containers/view-book-page.ts
@@ -1,9 +1,8 @@
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/pluck';
 import { Component, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs/Subscription';
+import { map } from 'rxjs/operators';
 
 import * as fromBooks from '../reducers';
 import * as book from '../actions/book';
@@ -30,7 +29,7 @@ export class ViewBookPageComponent implements OnDestroy {
 
   constructor(store: Store<fromBooks.State>, route: ActivatedRoute) {
     this.actionsSubscription = route.params
-      .map(params => new book.Select(params.id))
+      .pipe(map(params => new book.Select(params.id)))
       .subscribe(store);
   }
 

--- a/example-app/app/books/reducers/index.ts
+++ b/example-app/app/books/reducers/index.ts
@@ -30,7 +30,7 @@ export const reducers = {
  * ```ts
  * class MyComponent {
  * 	constructor(state$: Observable<State>) {
- * 	  this.booksState$ = state$.select(getBooksState);
+ * 	  this.booksState$ = state$.pipe(select(getBooksState));
  * 	}
  * }
  * ```

--- a/example-app/app/core/containers/app.ts
+++ b/example-app/app/core/containers/app.ts
@@ -1,7 +1,6 @@
-import 'rxjs/add/operator/let';
 import { Observable } from 'rxjs/Observable';
 import { Component, ChangeDetectionStrategy } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 
 import * as fromRoot from '../../reducers';
 import * as fromAuth from '../../auth/reducers';
@@ -44,8 +43,8 @@ export class AppComponent {
      * Selectors can be applied with the `select` operator which passes the state
      * tree to the provided selector
      */
-    this.showSidenav$ = this.store.select(fromRoot.getShowSidenav);
-    this.loggedIn$ = this.store.select(fromAuth.getLoggedIn);
+    this.showSidenav$ = this.store.pipe(select(fromRoot.getShowSidenav));
+    this.loggedIn$ = this.store.pipe(select(fromAuth.getLoggedIn));
   }
 
   closeSidenav() {

--- a/example-app/app/core/services/google-books.ts
+++ b/example-app/app/core/services/google-books.ts
@@ -1,7 +1,7 @@
-import 'rxjs/add/operator/map';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
+import { map } from 'rxjs/operators';
 import { Book } from '../../books/models/book';
 
 @Injectable()
@@ -13,7 +13,7 @@ export class GoogleBooksService {
   searchBooks(queryTitle: string): Observable<Book[]> {
     return this.http
       .get<{ items: Book[] }>(`${this.API_PATH}?q=${queryTitle}`)
-      .map(books => books.items || []);
+      .pipe(map(books => books.items || []));
   }
 
   retrieveBook(volumeId: string): Observable<Book> {

--- a/modules/codegen/package.json
+++ b/modules/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/codegen",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "Codegen for Ngrx and Redux actions",
   "module": "@ngrx/codegen.es5.js",
   "es2015": "@ngrx/codegen.js",

--- a/modules/effects/package.json
+++ b/modules/effects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/effects",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "Side effect model for @ngrx/store",
   "module": "@ngrx/effects.es5.js",
   "es2015": "@ngrx/effects.js",
@@ -15,8 +15,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "^4.0.0 || ^5.0.0-rc.2 || ^5.0.0",
-    "@ngrx/store": "^4.0.0",
-    "rxjs": "^5.0.0"
+    "@angular/core": "^5.0.0",
+    "@ngrx/store": "^5.0.0-alpha.0",
+    "rxjs": "^5.5.0"
   }
 }

--- a/modules/effects/spec/actions.spec.ts
+++ b/modules/effects/spec/actions.spec.ts
@@ -9,7 +9,8 @@ import {
   ScannedActionsSubject,
   ActionsSubject,
 } from '@ngrx/store';
-import { Actions } from '../';
+import { Actions, ofType } from '../';
+import { map, toArray } from 'rxjs/operators';
 
 describe('Actions', function() {
   let actions$: Actions;
@@ -64,9 +65,7 @@ describe('Actions', function() {
     const expected = actions.filter(type => type === ADD);
 
     actions$
-      .ofType(ADD)
-      .map(update => update.type)
-      .toArray()
+      .pipe(ofType(ADD), map(update => update.type), toArray())
       .subscribe({
         next(actual) {
           expect(actual).toEqual(expected);

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -3,6 +3,7 @@ import { Action, ScannedActionsSubject } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { Operator } from 'rxjs/Operator';
 import { filter } from 'rxjs/operator/filter';
+import { OperatorFunction } from 'rxjs/interfaces';
 
 @Injectable()
 export class Actions<V = Action> extends Observable<V> {
@@ -22,8 +23,14 @@ export class Actions<V = Action> extends Observable<V> {
   }
 
   ofType<V2 extends V = V>(...allowedTypes: string[]): Actions<V2> {
-    return filter.call(this, (action: Action) =>
+    return ofType<any>(...allowedTypes)(this.source as Actions<V2>);
+  }
+}
+
+export function ofType<T extends Action>(...allowedTypes: string[]) {
+  return function ofTypeOperator(source$: Actions<T>): Actions<T> {
+    return filter.call(source$, (action: Action) =>
       allowedTypes.some(type => type === action.type)
     );
-  }
+  };
 }

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -4,7 +4,7 @@ export {
   getEffectsMetadata,
 } from './effects_metadata';
 export { mergeEffects } from './effects_resolver';
-export { Actions } from './actions';
+export { Actions, ofType } from './actions';
 export { EffectsModule } from './effects_module';
 export { EffectSources } from './effect_sources';
 export { OnRunEffects } from './on_run_effects';

--- a/modules/entity/package.json
+++ b/modules/entity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/entity",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "Common utilities for entity reducers",
   "module": "@ngrx/entity.es5.js",
   "es2015": "@ngrx/entity.js",
@@ -15,8 +15,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "^4.0.0 || ^5.0.0-rc.2 || ^5.0.0",
-    "@ngrx/store": "^4.0.0",
-    "rxjs": "^5.0.0"
+    "@angular/core": "^5.0.0",
+    "@ngrx/store": "^5.0.0-alpha.0",
+    "rxjs": "^5.5.0"
   }
 }

--- a/modules/router-store/package.json
+++ b/modules/router-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/router-store",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "Bindings to connect @angular/router to @ngrx/store",
   "module": "@ngrx/router-store.es5.js",
   "es2015": "@ngrx/router-store.js",
@@ -20,10 +20,10 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": "^4.0.0 || ^5.0.0-rc.2 || ^5.0.0",
-    "@angular/core": "^4.0.0 || ^5.0.0-rc.2 || ^5.0.0",
-    "@angular/router": "^4.0.0 || ^5.0.0-rc.2 || ^5.0.0",
-    "@ngrx/store": "^4.0.0",
-    "rxjs": "^5.0.0"
+    "@angular/common": "^5.0.0",
+    "@angular/core": "^5.0.0",
+    "@angular/router": "^5.0.0",
+    "@ngrx/store": "^5.0.0-alpha.0",
+    "rxjs": "^5.5.0"
   }
 }

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -11,7 +11,7 @@ import {
   RouterStateSnapshot,
   RoutesRecognized,
 } from '@angular/router';
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 import { of } from 'rxjs/observable/of';
 import {
   DefaultRouterStateSerializer,
@@ -255,7 +255,7 @@ export class StoreRouterConnectingModule {
     this.store.subscribe(s => {
       this.storeState = s;
     });
-    this.store.select(this.stateKey).subscribe(() => {
+    this.store.pipe(select(this.stateKey)).subscribe(() => {
       this.navigateIfNeeded();
     });
   }

--- a/modules/schematics/package.json
+++ b/modules/schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/schematics",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "NgRx Schematics for Angular",
   "repository": {
     "type": "git",

--- a/modules/store-devtools/package.json
+++ b/modules/store-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/store-devtools",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "Developer tools for @ngrx/store",
   "module": "@ngrx/store-devtools.es5.js",
   "es2015": "@ngrx/store-devtools.js",
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/ngrx/platform#readme",
   "peerDependencies": {
-    "@ngrx/store": "^4.0.0",
-    "rxjs": "^5.0.0"
+    "@ngrx/store": "^5.0.0-alpha.0",
+    "rxjs": "^5.5.0"
   }
 }

--- a/modules/store/package.json
+++ b/modules/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/store",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "RxJS powered Redux for Angular apps",
   "module": "@ngrx/store.es5.js",
   "es2015": "@ngrx/store.js",
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/ngrx/platform#readme",
   "peerDependencies": {
-    "@angular/core": "^4.0.0 || ^5.0.0-rc.2 || ^5.0.0",
-    "rxjs": "^5.0.0"
+    "@angular/core": "^5.0.0",
+    "rxjs": "^5.5.0"
   }
 }

--- a/modules/store/spec/edge.spec.ts
+++ b/modules/store/spec/edge.spec.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs/Observable';
 import { todos, todoCount } from './fixtures/edge_todos';
 import { createInjector } from './helpers/injector';
-import { Store, StoreModule } from '../';
+import { Store, StoreModule, select } from '../';
 
 interface TestAppSchema {
   counter1: number;
@@ -36,12 +36,12 @@ describe('ngRx Store', () => {
       let todosNextCount = 0;
       let todosCountNextCount = 0;
 
-      store.select('todos').subscribe((todos: any[]) => {
+      store.pipe(select('todos')).subscribe((todos: any[]) => {
         todosNextCount++;
         store.dispatch({ type: 'SET_COUNT', payload: todos.length });
       });
 
-      store.select('todoCount').subscribe(count => {
+      store.pipe(select('todoCount')).subscribe(count => {
         todosCountNextCount++;
       });
 

--- a/modules/store/spec/integration.spec.ts
+++ b/modules/store/spec/integration.spec.ts
@@ -9,6 +9,7 @@ import {
   combineReducers,
   ActionReducer,
   ActionReducerMap,
+  select,
 } from '../';
 import { ReducerManager, INITIAL_STATE, State } from '../src/private_export';
 import {
@@ -142,8 +143,8 @@ describe('ngRx Integration spec', () => {
       let currentlyVisibleTodos: Todo[] = [];
 
       Observable.combineLatest(
-        store.select('visibilityFilter'),
-        store.select('todos'),
+        store.pipe(select('visibilityFilter')),
+        store.pipe(select('todos')),
         filterVisibleTodos
       ).subscribe(visibleTodos => {
         currentlyVisibleTodos = visibleTodos;
@@ -221,7 +222,7 @@ describe('ngRx Integration spec', () => {
         },
       ];
 
-      store.select(state => state).subscribe(state => {
+      store.pipe(select(state => state)).subscribe(state => {
         expect(state).toEqual(expected.shift());
       });
     });

--- a/modules/store/spec/ngc/main.ts
+++ b/modules/store/spec/ngc/main.ts
@@ -1,7 +1,7 @@
 import { NgModule, Component, InjectionToken } from '@angular/core';
 import { platformDynamicServer } from '@angular/platform-server';
 import { BrowserModule } from '@angular/platform-browser';
-import { Store, StoreModule, combineReducers } from '../../';
+import { Store, StoreModule, combineReducers, select } from '../../';
 import { counterReducer, INCREMENT, DECREMENT } from '../fixtures/counter';
 import { todos } from '../fixtures/todos';
 import { Observable } from 'rxjs/Observable';
@@ -40,7 +40,7 @@ export const reducerToken = new InjectionToken('Reducers');
 export class NgcSpecComponent {
   count: Observable<number>;
   constructor(public store: Store<AppState>) {
-    this.count = store.select(state => state.count);
+    this.count = store.pipe(select(state => state.count));
   }
   increment() {
     this.store.dispatch({ type: INCREMENT });

--- a/modules/store/spec/store.spec.ts
+++ b/modules/store/spec/store.spec.ts
@@ -2,7 +2,13 @@ import 'rxjs/add/operator/take';
 import { ReflectiveInjector } from '@angular/core';
 import { hot } from 'jasmine-marbles';
 import { createInjector } from './helpers/injector';
-import { ActionsSubject, ReducerManager, Store, StoreModule } from '../';
+import {
+  ActionsSubject,
+  ReducerManager,
+  Store,
+  StoreModule,
+  select,
+} from '../';
 import {
   counterReducer,
   INCREMENT,
@@ -83,7 +89,7 @@ describe('ngRx Store', () => {
 
       counterSteps.subscribe(action => store.dispatch(action));
 
-      const counterStateWithString = store.select('counter1');
+      const counterStateWithString = store.pipe(select('counter1'));
 
       const stateSequence = 'i-v--w--x--y--z';
       const counter1Values = { i: 0, v: 1, w: 2, x: 1, y: 0, z: 1 };
@@ -98,7 +104,7 @@ describe('ngRx Store', () => {
 
       counterSteps.subscribe(action => store.dispatch(action));
 
-      const counterStateWithFunc = store.select(s => s.counter1);
+      const counterStateWithFunc = store.pipe(select(s => s.counter1));
 
       const stateSequence = 'i-v--w--x--y--z';
       const counter1Values = { i: 0, v: 1, w: 2, x: 1, y: 0, z: 1 };
@@ -109,7 +115,7 @@ describe('ngRx Store', () => {
     });
 
     it('should correctly lift itself', () => {
-      const result = store.select('counter1');
+      const result = store.pipe(select('counter1'));
 
       expect(result instanceof Store).toBe(true);
     });
@@ -119,7 +125,7 @@ describe('ngRx Store', () => {
 
       counterSteps.subscribe(action => store.dispatch(action));
 
-      const counterState = store.select('counter1');
+      const counterState = store.pipe(select('counter1'));
 
       const stateSequence = 'i-v--w--x--y--z';
       const counter1Values = { i: 0, v: 1, w: 2, x: 1, y: 0, z: 1 };
@@ -132,7 +138,7 @@ describe('ngRx Store', () => {
 
       counterSteps.subscribe(action => dispatcher.next(action));
 
-      const counterState = store.select('counter1');
+      const counterState = store.pipe(select('counter1'));
 
       const stateSequence = 'i-v--w--x--y--z';
       const counter1Values = { i: 0, v: 1, w: 2, x: 1, y: 0, z: 1 };
@@ -145,8 +151,8 @@ describe('ngRx Store', () => {
 
       counterSteps.subscribe(action => store.dispatch(action));
 
-      const counter1State = store.select('counter1');
-      const counter2State = store.select('counter2');
+      const counter1State = store.pipe(select('counter1'));
+      const counter2State = store.pipe(select('counter2'));
 
       const stateSequence = 'i-v--w--x--y--z';
       const counter2Values = { i: 1, v: 2, w: 3, x: 2, y: 0, z: 1 };

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -7,7 +7,7 @@ export {
   Selector,
 } from './models';
 export { StoreModule } from './store_module';
-export { Store } from './store';
+export { Store, select } from './store';
 export { combineReducers, compose, createReducerFactory } from './utils';
 export { ActionsSubject, INIT } from './actions_subject';
 export {

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -65,20 +65,7 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
     pathOrMapFn: ((state: T) => any) | string,
     ...paths: string[]
   ): Store<any> {
-    let mapped$: Store<any>;
-
-    if (typeof pathOrMapFn === 'string') {
-      mapped$ = pluck.call(this, pathOrMapFn, ...paths);
-    } else if (typeof pathOrMapFn === 'function') {
-      mapped$ = map.call(this, pathOrMapFn);
-    } else {
-      throw new TypeError(
-        `Unexpected type '${typeof pathOrMapFn}' in select operator,` +
-          ` expected 'string' or 'function'`
-      );
-    }
-
-    return distinctUntilChanged.call(mapped$);
+    return select(pathOrMapFn, ...paths)(this);
   }
 
   lift<R>(operator: Operator<T, R>): Store<R> {
@@ -117,3 +104,83 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
 }
 
 export const STORE_PROVIDERS: Provider[] = [Store];
+
+export function select<T, K>(
+  mapFn: ((state: T) => K) | string
+): (source$: Observable<T>) => Store<K>;
+export function select<T, a extends keyof T>(
+  key: a
+): (source$: Store<a>) => Store<T[a]>;
+export function select<T, a extends keyof T, b extends keyof T[a]>(
+  key1: a,
+  key2: b
+): (source$: Store<T>) => Store<T[a][b]>;
+export function select<
+  T,
+  a extends keyof T,
+  b extends keyof T[a],
+  c extends keyof T[a][b]
+>(key1: a, key2: b, key3: c): (source$: Store<a>) => Store<T[a][b][c]>;
+export function select<
+  T,
+  a extends keyof T,
+  b extends keyof T[a],
+  c extends keyof T[a][b],
+  d extends keyof T[a][b][c]
+>(
+  key1: a,
+  key2: b,
+  key3: c,
+  key4: d
+): (source$: Store<a>) => Store<T[a][b][c][d]>;
+export function select<
+  T,
+  a extends keyof T,
+  b extends keyof T[a],
+  c extends keyof T[a][b],
+  d extends keyof T[a][b][c],
+  e extends keyof T[a][b][c][d]
+>(
+  key1: a,
+  key2: b,
+  key3: c,
+  key4: d,
+  key5: e
+): (source$: Store<a>) => Store<T[a][b][c][d][e]>;
+export function select<
+  T,
+  a extends keyof T,
+  b extends keyof T[a],
+  c extends keyof T[a][b],
+  d extends keyof T[a][b][c],
+  e extends keyof T[a][b][c][d],
+  f extends keyof T[a][b][c][d][e]
+>(
+  key1: a,
+  key2: b,
+  key3: c,
+  key4: d,
+  key5: e,
+  key6: f
+): (source$: Store<a>) => Store<T[a][b][c][d][e][f]>;
+export function select<T, K>(
+  pathOrMapFn: ((state: T) => any) | string,
+  ...paths: string[]
+) {
+  return function selectOperator(source$: Store<T>): Store<K> {
+    let mapped$: Store<any>;
+
+    if (typeof pathOrMapFn === 'string') {
+      mapped$ = pluck.call(source$, pathOrMapFn, ...paths);
+    } else if (typeof pathOrMapFn === 'function') {
+      mapped$ = map.call(source$, pathOrMapFn);
+    } else {
+      throw new TypeError(
+        `Unexpected type '${typeof pathOrMapFn}' in select operator,` +
+          ` expected 'string' or 'function'`
+      );
+    }
+
+    return distinctUntilChanged.call(mapped$);
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/platform",
-  "version": "4.0.0",
+  "version": "5.0.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/platform",
-  "version": "4.0.0",
+  "version": "5.0.0-alpha.0",
   "description": "monorepo for ngrx development",
   "scripts": {
     "precommit": "lint-staged",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "reflect-metadata": "^0.1.9",
     "rimraf": "^2.5.4",
     "rollup": "^0.50.0",
-    "rxjs": "^5.4.0",
+    "rxjs": "^5.5.2",
     "sorcery": "^0.10.0",
     "ts-node": "^3.1.0",
     "tslib": "1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6695,7 +6695,7 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
-rxjs@^5.0.0-beta.11, rxjs@^5.4.0:
+rxjs@^5.0.0-beta.11:
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
   dependencies:


### PR DESCRIPTION
Introduces lettable operators for `Store.select` and `Actions.ofType`. Updates minimum version of RxJS dependency. Do not squash the commits.

Closes #583 

BREAKING CHANGE:

BEFORE:

Minimum peer dependency of RxJS ^5.0.0

AFTER:

Minimum peer dependency of RxJS ^5.5.0