### PR TITLE
Remove trailing whitespaces and replace hard tab from document files

### DIFF
--- a/docs/effects/README.md
+++ b/docs/effects/README.md
@@ -65,7 +65,7 @@ export class AuthEffects {
   constructor(
     private http: Http,
     private actions$: Actions
-  ) {}      
+  ) {}
 }
 ```
 

--- a/docs/effects/api.md
+++ b/docs/effects/api.md
@@ -23,7 +23,7 @@ export class AppModule { }
 ### forFeature
 Registers @ngrx/effects services to run with your feature modules.
 
-**Note**: Running an effects class multiple times, either by `forRoot()` or `forFeature()`, (for example via different lazy loaded modules) will not cause Effects to run multiple times. There is no functional difference between effects loaded by `forRoot()` and `forFeature()`; the important difference between the functions is that `forRoot()` sets up the providers required for effects. 
+**Note**: Running an effects class multiple times, either by `forRoot()` or `forFeature()`, (for example via different lazy loaded modules) will not cause Effects to run multiple times. There is no functional difference between effects loaded by `forRoot()` and `forFeature()`; the important difference between the functions is that `forRoot()` sets up the providers required for effects.
 
 Usage:
 ```ts

--- a/docs/entity/adapter.md
+++ b/docs/entity/adapter.md
@@ -192,7 +192,7 @@ export function reducer(
   state = initialState,
   action: UserActions.All
 ): State {
-  switch (action.type) {        
+  switch (action.type) {
     case UserActions.ADD_USER: {
       return adapter.addOne(action.payload.user, state);
     }
@@ -215,7 +215,7 @@ export function reducer(
 
     case UserActions.DELETE_USERS: {
       return adapter.removeMany(action.payload.ids, state);
-    }    
+    }
 
     case UserActions.LOAD_USERS: {
       return adapter.addAll(action.payload.users, state);
@@ -223,11 +223,11 @@ export function reducer(
 
     case UserActions.CLEAR_USERS: {
       return adapter.removeAll({ ...state, selectedUserId: null });
-    }        
+    }
 
     default: {
       return state;
-    }    
+    }
   }
 }
 

--- a/docs/router-store/api.md
+++ b/docs/router-store/api.md
@@ -74,7 +74,7 @@ export class RouterEffects {
 
   @Effect({ dispatch: false })
   navigateForward$ = this.actions$.ofType(RouterActions.FORWARD)
-    .do(() => this.location.forward());    
+    .do(() => this.location.forward());
 
   constructor(
     private actions$: Actions,

--- a/docs/store-devtools/README.md
+++ b/docs/store-devtools/README.md
@@ -49,9 +49,9 @@ function - the monitor function configuration that you want to hook.
 
 #### `actionSanitizer`
 function which takes `action` object and id number as arguments, and should return `action` object back.
- 
+
 #### `stateSanitizer`
 function which takes `state` object and index as arguments, and should return `state` object back.
 
-#### `serialize` 
-false | configuration object - Handle the way you want to serialize your state, [more information here](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize). 
+#### `serialize`
+false | configuration object - Handle the way you want to serialize your state, [more information here](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize).

--- a/docs/store/README.md
+++ b/docs/store/README.md
@@ -37,19 +37,19 @@ export const DECREMENT = 'DECREMENT';
 export const RESET = 'RESET';
 
 export function counterReducer(state: number = 0, action: Action) {
-	switch (action.type) {
-		case INCREMENT:
-			return state + 1;
+  switch (action.type) {
+    case INCREMENT:
+      return state + 1;
 
-		case DECREMENT:
-			return state - 1;
+    case DECREMENT:
+      return state - 1;
 
-		case RESET:
-			return 0;
+    case RESET:
+      return 0;
 
-		default:
-			return state;
-	}
+    default:
+      return state;
+  }
 }
 ```
 
@@ -83,33 +83,33 @@ interface AppState {
 }
 
 @Component({
-	selector: 'my-app',
-	template: `
-		<button (click)="increment()">Increment</button>
-		<div>Current Count: {{ counter | async }}</div>
-		<button (click)="decrement()">Decrement</button>
+  selector: 'my-app',
+  template: `
+    <button (click)="increment()">Increment</button>
+    <div>Current Count: {{ counter | async }}</div>
+    <button (click)="decrement()">Decrement</button>
 
-		<button (click)="reset()">Reset Counter</button>
-	`
+    <button (click)="reset()">Reset Counter</button>
+  `
 })
 export class MyAppComponent {
-	counter: Observable<number>;
+  counter: Observable<number>;
 
-	constructor(private store: Store<AppState>) {
-		this.counter = store.select('counter');
-	}
+  constructor(private store: Store<AppState>) {
+    this.counter = store.select('counter');
+  }
 
-	increment(){
-		this.store.dispatch({ type: INCREMENT });
-	}
+  increment(){
+    this.store.dispatch({ type: INCREMENT });
+  }
 
-	decrement(){
-		this.store.dispatch({ type: DECREMENT });
-	}
+  decrement(){
+    this.store.dispatch({ type: DECREMENT });
+  }
 
-	reset(){
-		this.store.dispatch({ type: RESET });
-	}
+  reset(){
+    this.store.dispatch({ type: RESET });
+  }
 }
 ```
 

--- a/docs/store/actions.md
+++ b/docs/store/actions.md
@@ -69,7 +69,7 @@ export function reducer(state: number = 0, action: Action): State {
 
     case CounterActions.RESET: {
       return action.payload; // typed to number
-    }    
+    }
 
     default: {
       return state;

--- a/docs/store/actions.md
+++ b/docs/store/actions.md
@@ -90,32 +90,32 @@ interface AppState {
 }
 
 @Component({
-	selector: 'my-app',
-	template: `
-		<button (click)="increment()">Increment</button>
-		<div>Current Count: {{ counter | async }}</div>
-		<button (click)="decrement()">Decrement</button>
+  selector: 'my-app',
+  template: `
+    <button (click)="increment()">Increment</button>
+    <div>Current Count: {{ counter | async }}</div>
+    <button (click)="decrement()">Decrement</button>
 
-		<button (click)="reset()">Reset Counter</button>
-	`
+    <button (click)="reset()">Reset Counter</button>
+  `
 })
 export class MyAppComponent {
-	counter: Observable<number>;
+  counter: Observable<number>;
 
-	constructor(private store: Store<AppState>) {
-		this.counter = store.select('counter');
-	}
+  constructor(private store: Store<AppState>) {
+    this.counter = store.select('counter');
+  }
 
-	increment(){
-		this.store.dispatch(new Counter.Increment());
-	}
+  increment(){
+    this.store.dispatch(new Counter.Increment());
+  }
 
-	decrement(){
-		this.store.dispatch(new Counter.Decrement());
-	}
+  decrement(){
+    this.store.dispatch(new Counter.Decrement());
+  }
 
-	reset(){
-		this.store.dispatch(new Counter.Reset(3));
-	}
+  reset(){
+    this.store.dispatch(new Counter.Reset(3));
+  }
 }
 ```

--- a/docs/store/api.md
+++ b/docs/store/api.md
@@ -143,7 +143,7 @@ export const FEATURE_REDUCER_TOKEN = new InjectionToken<ActionReducerMap<fromFea
 export function getReducers(): ActionReducerMap<fromFeature.State> {
   // map of reducers
   return {
-  
+
   };
 }
 

--- a/docs/store/selectors.md
+++ b/docs/store/selectors.md
@@ -190,16 +190,16 @@ import { Store } from '@ngrx/store';
 import * as fromRoot from './reducers';
 
 @Component({
-	selector: 'my-app',
-	template: `
-		<div>Current Count: {{ counter | async }}</div>
-	`
+  selector: 'my-app',
+  template: `
+    <div>Current Count: {{ counter | async }}</div>
+  `
 })
 class MyAppComponent {
-	counter: Observable<number>;
+  counter: Observable<number>;
 
-	constructor(private store: Store<fromRoot.AppState>){
-		this.counter = store.select(fromRoot.selectFeatureCount);
-	}
+  constructor(private store: Store<fromRoot.AppState>){
+    this.counter = store.select(fromRoot.selectFeatureCount);
+  }
 }
 ```

--- a/docs/store/setup.md
+++ b/docs/store/setup.md
@@ -13,19 +13,19 @@ export const DECREMENT = 'DECREMENT';
 export const RESET = 'RESET';
 
 export function counter(state: number = 0, action: Action) {
-	switch (action.type) {
-		case INCREMENT:
-			return state + 1;
+  switch (action.type) {
+    case INCREMENT:
+      return state + 1;
 
-		case DECREMENT:
-			return state - 1;
+    case DECREMENT:
+      return state - 1;
 
-		case RESET:
-			return 0;
+    case RESET:
+      return 0;
 
-		default:
-			return state;
-	}
+    default:
+      return state;
+  }
 }
 ```
 
@@ -60,32 +60,32 @@ interface AppState {
 }
 
 @Component({
-	selector: 'my-app',
-	template: `
-		<button (click)="increment()">Increment</button>
-		<div>Current Count: {{ counter | async }}</div>
-		<button (click)="decrement()">Decrement</button>
+  selector: 'my-app',
+  template: `
+    <button (click)="increment()">Increment</button>
+    <div>Current Count: {{ counter | async }}</div>
+    <button (click)="decrement()">Decrement</button>
 
-		<button (click)="reset()">Reset Counter</button>
-	`
+    <button (click)="reset()">Reset Counter</button>
+  `
 })
 class MyAppComponent {
-	counter: Observable<number>;
+  counter: Observable<number>;
 
-	constructor(private store: Store<AppState>){
-		this.counter = store.select('counter');
-	}
+  constructor(private store: Store<AppState>){
+    this.counter = store.select('counter');
+  }
 
-	increment(){
-		this.store.dispatch({ type: INCREMENT });
-	}
+  increment(){
+    this.store.dispatch({ type: INCREMENT });
+  }
 
-	decrement(){
-		this.store.dispatch({ type: DECREMENT });
-	}
+  decrement(){
+    this.store.dispatch({ type: DECREMENT });
+  }
 
-	reset(){
-		this.store.dispatch({ type: RESET });
-	}
+  reset(){
+    this.store.dispatch({ type: RESET });
+  }
 }
 ```

--- a/docs/store/testing.md
+++ b/docs/store/testing.md
@@ -105,6 +105,6 @@ describe('My Component', () => {
     component.items$.subscribe(data => {
       expect(data.length).toBe(items.length);
     });
-  });  
+  });
 });
 ```

--- a/example-app/app/books/reducers/index.ts
+++ b/example-app/app/books/reducers/index.ts
@@ -29,9 +29,9 @@ export const reducers = {
  *
  * ```ts
  * class MyComponent {
- * 	constructor(state$: Observable<State>) {
- * 	  this.booksState$ = state$.pipe(select(getBooksState));
- * 	}
+ *   constructor(state$: Observable<State>) {
+ *     this.booksState$ = state$.pipe(select(getBooksState));
+ *   }
  * }
  * ```
  */


### PR DESCRIPTION
The contents in docs directories are useful and I often refer to it.
And I found unnecessary trailing whitespaces and hard-tabs in markdown files.

I want to remove trailing whitespaces and replace hard-tabs with 2 spaces to improve the code appearance.

please check this and feedback.
thanks.
