### PR TITLE
fix build error on windows

### DIFF
--- a/build/util.ts
+++ b/build/util.ts
@@ -12,7 +12,7 @@ export type BaseFn = (command: string) => string;
 
 export function copy(target: string, destination: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    fsExtra.copy(target, destination, err => {
+    fsExtra.copy(target, path.resolve(destination), err => {
       if (err) return reject(err);
       resolve();
     });


### PR DESCRIPTION
Copying schematic files gives:  
Error: ENOENT: no such file or directory,  
cause path not created recursive by `fsExtra.copy`

#660