### PR TITLE
Update instrument initialization options

### DIFF
--- a/example-app/app/app.module.ts
+++ b/example-app/app/app.module.ts
@@ -59,7 +59,7 @@ import { environment } from '../environments/environment';
      */
     !environment.production
       ? StoreDevtoolsModule.instrument({
-          name: 'NgRx Book Store DevTools',
+          maxAge: 5,
         })
       : [],
 


### PR DESCRIPTION
As `StoreDevtoolsModule.instrument()` parameter type has changed in latest version of `@ngrx/store-devtools` - `name` option is no more applicable.