### PR TITLE
chore(build): Exclude testing files from being removed

### DIFF
--- a/build/builder.ts
+++ b/build/builder.ts
@@ -17,4 +17,5 @@ export default createBuilder([
   ['Copying documents', tasks.copyDocs],
   ['Copying package.json files', tasks.copyPackageJsonFiles],
   ['Removing "./dist/packages" Folder', tasks.removePackagesFolder],
+  ['Removing summary files', tasks.removeSummaryFiles],
 ]);

--- a/build/util.ts
+++ b/build/util.ts
@@ -39,7 +39,7 @@ export function writeFile(target: string, contents: string) {
 
 export function getListOfFiles(
   globPath: string,
-  exclude?: string
+  exclude?: string | string[]
 ): Promise<string[]> {
   return new Promise((resolve, reject) => {
     const options = exclude ? { ignore: exclude } : {};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "precommit": "lint-staged",
     "bootstrap": "lerna bootstrap",
     "build": "ts-node ./build/index.ts",
-    "postbuild": "rimraf **/dist/**/*.ngsummary.json",
     "deploy:builds": "ts-node ./build/deploy-build.ts",
     "test:unit": "node ./tests.js",
     "test": "nyc yarn run test:unit",


### PR DESCRIPTION
Fixes a regression introduced when javascript files were removed from the build output.

Closes #678 
