### PR TITLE
feat(Schematics): Add option to group feature blueprints in folders

### DIFF
--- a/modules/schematics/src/action/index.spec.ts
+++ b/modules/schematics/src/action/index.spec.ts
@@ -13,6 +13,8 @@ describe('Action Schematic', () => {
     path: 'app',
     sourceDir: 'src',
     spec: false,
+    group: false,
+    flat: true,
   };
 
   it('should create one file', () => {
@@ -43,5 +45,14 @@ describe('Action Schematic', () => {
       const fileContent = fileEntry.content.toString();
       expect(fileContent).toMatch(/export enum FooActionTypes/);
     }
+  });
+
+  it('should group within an "actions" folder if group is set', () => {
+    const tree = schematicRunner.runSchematic('action', {
+      ...defaultOptions,
+      group: true,
+    });
+    expect(tree.files.length).toEqual(1);
+    expect(tree.files[0]).toEqual('/src/app/actions/foo.actions.ts');
   });
 });

--- a/modules/schematics/src/action/index.ts
+++ b/modules/schematics/src/action/index.ts
@@ -25,7 +25,11 @@ export default function(options: ActionOptions): Rule {
   const templateSource = apply(url('./files'), [
     options.spec ? noop() : filter(path => !path.endsWith('__spec.ts')),
     template({
-      'if-flat': (s: string) => (options.flat ? '' : s),
+      'if-flat': (s: string) =>
+        stringUtils.group(
+          options.flat ? '' : s,
+          options.group ? 'actions' : ''
+        ),
       ...stringUtils,
       ...(options as object),
       dot: () => '.',

--- a/modules/schematics/src/action/schema.d.ts
+++ b/modules/schematics/src/action/schema.d.ts
@@ -8,4 +8,5 @@ export interface Schema {
    */
   spec?: boolean;
   flat?: boolean;
+  group?: boolean;
 }

--- a/modules/schematics/src/action/schema.json
+++ b/modules/schematics/src/action/schema.json
@@ -27,6 +27,11 @@
       "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a dir is created."
+    },
+    "group": {
+      "type": "boolean",
+      "default": false,
+      "description": "Group actions file within 'actions' folder"
     }
   },
   "required": [

--- a/modules/schematics/src/effect/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
+++ b/modules/schematics/src/effect/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect } from '@ngrx/effects';
-<% if(feature) { %>import { <%= classify(name) %>Actions, <%= classify(name) %>ActionTypes } from './<%= dasherize(name) %>.actions';<% } %>
+<% if(feature) { %>import { <%= classify(name) %>Actions, <%= classify(name) %>ActionTypes } from '<%= featurePath(group, "actions") %><%= dasherize(name) %>.actions';<% } %>
 
 @Injectable()
 export class <%= classify(name) %>Effects {

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -22,6 +22,7 @@ describe('Effect Schematic', () => {
     flat: false,
     feature: false,
     root: false,
+    group: false,
   };
 
   let appTree: Tree;
@@ -172,5 +173,15 @@ describe('Effect Schematic', () => {
     const content = getFileContent(tree, '/src/app/store.module.ts');
 
     expect(content).not.toMatch(/EffectsModule\.forRoot\(\[FooEffects\]\)/);
+  });
+
+  it('should group within an "effects" folder if group is set', () => {
+    const options = { ...defaultOptions, flat: true, spec: false, group: true };
+
+    const tree = schematicRunner.runSchematic('effect', options, appTree);
+    const files = tree.files;
+    expect(
+      files.indexOf('/src/app/effects/foo.effects.ts')
+    ).toBeGreaterThanOrEqual(0);
   });
 });

--- a/modules/schematics/src/effect/index.ts
+++ b/modules/schematics/src/effect/index.ts
@@ -61,6 +61,7 @@ function addImportToNgModule(options: EffectOptions): Rule {
 
     const effectsPath =
       `/${options.sourceDir}/${options.path}/` +
+      (options.group ? 'effects/' : '') +
       (options.flat ? '' : stringUtils.dasherize(options.name) + '/') +
       stringUtils.dasherize(options.name) +
       '.effects';
@@ -108,7 +109,11 @@ export default function(options: EffectOptions): Rule {
       options.spec ? noop() : filter(path => !path.endsWith('__spec.ts')),
       template({
         ...stringUtils,
-        'if-flat': (s: string) => (options.flat ? '' : s),
+        'if-flat': (s: string) =>
+          stringUtils.group(
+            options.flat ? '' : s,
+            options.group ? 'effects' : ''
+          ),
         ...(options as object),
         dot: () => '.',
       }),

--- a/modules/schematics/src/effect/schema.d.ts
+++ b/modules/schematics/src/effect/schema.d.ts
@@ -17,4 +17,5 @@ export interface Schema {
   module?: string;
   root?: boolean;
   feature?: boolean;
+  group?: boolean;
 }

--- a/modules/schematics/src/effect/schema.json
+++ b/modules/schematics/src/effect/schema.json
@@ -44,7 +44,12 @@
       "type": "boolean",
       "default": false,
       "description": "Flag to indicate if part of a feature schematic."
-    }    
+    },
+    "group": {
+      "type": "boolean",
+      "default": false,
+      "description": "Group effects file within 'effects' folder"
+    }
   },
   "required": [
     "name"

--- a/modules/schematics/src/feature/index.spec.ts
+++ b/modules/schematics/src/feature/index.spec.ts
@@ -17,6 +17,7 @@ describe('Feature Schematic', () => {
     sourceDir: 'src',
     module: '',
     spec: true,
+    group: false,
   };
 
   it('should create all files of a feature', () => {
@@ -32,6 +33,28 @@ describe('Feature Schematic', () => {
     expect(files.indexOf('/src/app/foo.effects.ts')).toBeGreaterThanOrEqual(0);
     expect(
       files.indexOf('/src/app/foo.effects.spec.ts')
+    ).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should create all files of a feature within grouped folders if group is set', () => {
+    const options = { ...defaultOptions, group: true };
+
+    const tree = schematicRunner.runSchematic('feature', options);
+    const files = tree.files;
+    expect(
+      files.indexOf('/src/app/actions/foo.actions.ts')
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf('/src/app/reducers/foo.reducer.ts')
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf('/src/app/reducers/foo.reducer.spec.ts')
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf('/src/app/effects/foo.effects.ts')
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf('/src/app/effects/foo.effects.spec.ts')
     ).toBeGreaterThanOrEqual(0);
   });
 });

--- a/modules/schematics/src/feature/index.ts
+++ b/modules/schematics/src/feature/index.ts
@@ -27,6 +27,7 @@ export default function(options: FeatureOptions): Rule {
     return chain([
       schematic('action', {
         flat: options.flat,
+        group: options.group,
         name: options.name,
         path: options.path,
         sourceDir: options.sourceDir,
@@ -34,6 +35,7 @@ export default function(options: FeatureOptions): Rule {
       }),
       schematic('reducer', {
         flat: options.flat,
+        group: options.group,
         module: options.module,
         name: options.name,
         path: options.path,
@@ -44,6 +46,7 @@ export default function(options: FeatureOptions): Rule {
       }),
       schematic('effect', {
         flat: options.flat,
+        group: options.group,
         module: options.module,
         name: options.name,
         path: options.path,

--- a/modules/schematics/src/feature/schema.d.ts
+++ b/modules/schematics/src/feature/schema.d.ts
@@ -6,4 +6,5 @@ export interface Schema {
   flat?: boolean;
   spec?: boolean;
   reducers?: string;
+  group?: boolean;
 }

--- a/modules/schematics/src/feature/schema.json
+++ b/modules/schematics/src/feature/schema.json
@@ -35,6 +35,11 @@
       "type": "string",
       "description": "Specifies the reducers file.",
       "aliases": ["r"]
+    },
+    "group": {
+      "type": "boolean",
+      "default": false,
+      "description": "Group actions, reducers and effects within relative subfolders"
     }
   },
   "required": [

--- a/modules/schematics/src/reducer/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.reducer.ts
+++ b/modules/schematics/src/reducer/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.reducer.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-<% if(feature) { %>import { <%= classify(name) %>Actions, <%= classify(name) %>ActionTypes } from './<%= dasherize(name) %>.actions';<% } %>
+<% if(feature) { %>import { <%= classify(name) %>Actions, <%= classify(name) %>ActionTypes } from '<%= featurePath(group, "actions") %><%= dasherize(name) %>.actions';<% } %>
 
 export interface State {
 

--- a/modules/schematics/src/reducer/index.spec.ts
+++ b/modules/schematics/src/reducer/index.spec.ts
@@ -89,4 +89,13 @@ describe('Reducer Schematic', () => {
 
     expect(reducers).toMatch(/foo\: fromFoo.reducer/);
   });
+
+  it('should group within a "reducers" folder if group is set', () => {
+    const tree = schematicRunner.runSchematic('reducer', {
+      ...defaultOptions,
+      group: true,
+    });
+    expect(tree.files.length).toEqual(1);
+    expect(tree.files[0]).toEqual('/src/app/reducers/foo.reducer.ts');
+  });
 });

--- a/modules/schematics/src/reducer/index.ts
+++ b/modules/schematics/src/reducer/index.ts
@@ -49,7 +49,11 @@ export default function(options: ReducerOptions): Rule {
       options.spec ? noop() : filter(path => !path.endsWith('__spec.ts')),
       template({
         ...stringUtils,
-        'if-flat': (s: string) => (options.flat ? '' : s),
+        'if-flat': (s: string) =>
+          stringUtils.group(
+            options.flat ? '' : s,
+            options.group ? 'reducers' : ''
+          ),
         ...(options as object),
         dot: () => '.',
       }),

--- a/modules/schematics/src/reducer/schema.d.ts
+++ b/modules/schematics/src/reducer/schema.d.ts
@@ -14,4 +14,5 @@ export interface Schema {
   module?: string;
   feature?: boolean;
   reducers?: string;
+  group?: boolean;
 }

--- a/modules/schematics/src/reducer/schema.json
+++ b/modules/schematics/src/reducer/schema.json
@@ -42,6 +42,11 @@
       "type": "string",
       "description": "Specifies the reducers file.",
       "aliases": ["r"]
+    },
+    "group": {
+      "type": "boolean",
+      "default": false,
+      "description": "Group reducer file within 'reducers' folder"
     }
   },
   "required": [

--- a/modules/schematics/src/strings.ts
+++ b/modules/schematics/src/strings.ts
@@ -134,10 +134,10 @@ export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.substr(1);
 }
 
-export function uppercase(str: string): string {
-  return str.toUpperCase();
+export function group(path: string, group: string | undefined) {
+  return group ? `${group}/${path}` : path;
 }
 
-export function lowercase(str: string): string {
-  return str.toLowerCase();
+export function featurePath(group: boolean | undefined, path: string) {
+  return group ? `../${path}/` : './';
 }

--- a/modules/schematics/src/utility/ngrx-utils.ts
+++ b/modules/schematics/src/utility/ngrx-utils.ts
@@ -38,6 +38,7 @@ export function addReducerToState(options: ReducerOptions): Rule {
 
     const reducerPath =
       `/${options.sourceDir}/${options.path}/` +
+      (options.group ? 'reducers/' : '') +
       (options.flat ? '' : stringUtils.dasherize(options.name) + '/') +
       stringUtils.dasherize(options.name) +
       '.reducer';
@@ -216,6 +217,7 @@ export function addReducerImportToNgModule(options: ReducerOptions): Rule {
 
     const reducerPath =
       `/${options.sourceDir}/${options.path}/` +
+      (options.group ? 'reducers/' : '') +
       (options.flat ? '' : stringUtils.dasherize(options.name) + '/') +
       stringUtils.dasherize(options.name) +
       '.reducer';


### PR DESCRIPTION
Adds a `group` option to the feature blueprint that generates each blueprint (action, effect, reducer) within its respective sub-folder (actions, effects, reducers).

Related to #674 