### PR TITLE
fix(Effects): Remove toPayload utility function

### DIFF
--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -8,6 +8,5 @@ export { Actions, ofType } from './actions';
 export { EffectsModule } from './effects_module';
 export { EffectSources } from './effect_sources';
 export { OnRunEffects } from './on_run_effects';
-export { toPayload } from './util';
 export { EffectNotification } from './effect_notification';
 export { ROOT_EFFECTS_INIT } from './effects_root_module';

--- a/modules/effects/src/util.ts
+++ b/modules/effects/src/util.ts
@@ -1,8 +1,0 @@
-import { Action } from '@ngrx/store';
-
-/**
- * @deprecated Since version 4.1. Will be deleted in version 5.0.
- */
-export function toPayload(action: Action): any {
-  return (action as any).payload;
-}


### PR DESCRIPTION
BREAKING CHANGE: toPayload function is no longer exported

BEFORE:
import { toPayload } from '@ngrx/effects';

actions$.ofType('SOME_ACTION').map(toPayload);

AFTER:

actions$.ofType('SOME_ACTION').map((action: SomeActionWithPayload) => action.payload)
