### PR TITLE
Add missing comma in example in README.md

### DIFF
--- a/docs/effects/README.md
+++ b/docs/effects/README.md
@@ -53,7 +53,7 @@ export class AuthEffects {
     mergeMap(action =>
       this.http.post('/auth', action.payload).pipe(
         // If successful, dispatch success action with result
-        map(data => ({ type: 'LOGIN_SUCCESS', payload: data }))
+        map(data => ({ type: 'LOGIN_SUCCESS', payload: data })),
         // If request fails, dispatch failed action
         catchError(() => of({ type: 'LOGIN_FAILED' }))
       )


### PR DESCRIPTION
If you copy/pasted that code it would raise a static error for that missing comma