### PR TITLE
updated to fix incorrect --group flag

### DIFF
--- a/docs/schematics/effect.md
+++ b/docs/schematics/effect.md
@@ -63,7 +63,7 @@ Generate a `UserEffects` file within a `user` folder and register it with the `u
 
 ```sh
 ng generate module User --flat false
-ng generate effect user/User -m user.module.ts --group
+ng generate effect user/User -m user.module.ts
 ```
 
 Generate a `UserEffects` file within a nested `effects` folder


### PR DESCRIPTION
Based on the description of the command `... in the same folder` there should not have been a `--group` flag on the edited line.