### PR TITLE
fix(Entity): Do not add Array.prototype properties to store

### DIFF
--- a/modules/entity/spec/unsorted_state_adapter.spec.ts
+++ b/modules/entity/spec/unsorted_state_adapter.spec.ts
@@ -11,6 +11,20 @@ describe('Unsorted State Adapter', () => {
   let adapter: EntityStateAdapter<BookModel>;
   let state: EntityState<BookModel>;
 
+  beforeAll(() => {
+    Object.defineProperty(Array.prototype, 'unwantedField', {
+      enumerable: true,
+      configurable: true,
+      value: 'This should not appear anywhere',
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(Array.prototype, 'unwantedField', {
+      value: undefined,
+    });
+  });
+
   beforeEach(() => {
     adapter = createEntityAdapter({
       selectId: (book: BookModel) => book.id,

--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -25,9 +25,8 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
   function addManyMutably(entities: any[], state: any): DidMutate {
     let didMutate = false;
 
-    for (let index in entities) {
-      didMutate =
-        addOneMutably(entities[index], state) !== DidMutate.None || didMutate;
+    for (const entity of entities) {
+      didMutate = addOneMutably(entity, state) !== DidMutate.None || didMutate;
     }
 
     return didMutate ? DidMutate.Both : DidMutate.None;


### PR DESCRIPTION
I have tried to fix issue #781 and verified the problem is really no longer there by building my application (where I can always reproduce the problem) with a version of `@ngrx/entity` containing these changes.