### PR TITLE
feat(StoreDevtools): Add support for ActionSanitizer and StateSanitizer

### DIFF
--- a/modules/store-devtools/spec/extension.spec.ts
+++ b/modules/store-devtools/spec/extension.spec.ts
@@ -2,13 +2,12 @@ import { Action } from '@ngrx/store';
 import { of } from 'rxjs/observable/of';
 
 import { LiftedState } from '../';
-import { DevtoolsExtension, ReduxDevtoolsExtension } from '../src/extension';
 import {
-  createConfig,
-  noActionSanitizer,
-  noMonitor,
-  noStateSanitizer,
-} from '../src/instrument';
+  DevtoolsExtension,
+  ReduxDevtoolsExtension,
+  ReduxDevtoolsExtensionConnection,
+} from '../src/extension';
+import { createConfig, noMonitor } from '../src/instrument';
 
 describe('DevtoolsExtension', () => {
   let reduxDevtoolsExtension: ReduxDevtoolsExtension;
@@ -32,8 +31,8 @@ describe('DevtoolsExtension', () => {
       const defaultOptions = {
         maxAge: false,
         monitor: noMonitor,
-        actionSanitizer: noActionSanitizer,
-        stateSanitizer: noStateSanitizer,
+        actionSanitizer: undefined,
+        stateSanitizer: undefined,
         name: 'NgRx Store DevTools',
         serialize: false,
         logOnly: false,

--- a/modules/store-devtools/spec/extension.spec.ts
+++ b/modules/store-devtools/spec/extension.spec.ts
@@ -2,11 +2,7 @@ import { Action } from '@ngrx/store';
 import { of } from 'rxjs/observable/of';
 
 import { LiftedState } from '../';
-import {
-  DevtoolsExtension,
-  ReduxDevtoolsExtension,
-  ReduxDevtoolsExtensionConnection,
-} from '../src/extension';
+import { DevtoolsExtension, ReduxDevtoolsExtension } from '../src/extension';
 import { createConfig, noMonitor } from '../src/instrument';
 
 describe('DevtoolsExtension', () => {

--- a/modules/store-devtools/spec/store.spec.ts
+++ b/modules/store-devtools/spec/store.spec.ts
@@ -710,7 +710,7 @@ describe('Store Devtools', () => {
       const liftedState = fixture.getLiftedState();
       const sanitizedLiftedState = fixture.devtools.getSanitizedState(
         liftedState,
-        devtoolsOptions
+        devtoolsOptions.stateSanitizer
       );
       const originalAction =
         liftedState.actionsById[liftedState.nextActionId - 1];

--- a/modules/store-devtools/spec/store.spec.ts
+++ b/modules/store-devtools/spec/store.spec.ts
@@ -610,4 +610,136 @@ describe('Store Devtools', () => {
       expect(fixture.getLiftedState()).toEqual(exportedState);
     });
   });
+
+  describe('Action and State Sanitizer', () => {
+    let fixture: Fixture<number>;
+
+    const SANITIZED_TOKEN = 'SANITIZED_ACTION';
+    const SANITIZED_COUNTER = 42;
+    const testActionSanitizer = (action: Action, id: number) => {
+      return { type: SANITIZED_TOKEN };
+    };
+    const incrementActionSanitizer = (action: Action, id: number) => {
+      return { type: 'INCREMENT' };
+    };
+    const testStateSanitizer = (state: any, index: number) => {
+      return { state: SANITIZED_COUNTER };
+    };
+
+    afterEach(() => {
+      fixture.cleanup();
+    });
+
+    it('should function normally with no sanitizers', () => {
+      fixture = createStore(counter);
+
+      fixture.store.dispatch({ type: 'INCREMENT' });
+
+      const liftedState = fixture.getLiftedState();
+      const currentLiftedState =
+        liftedState.computedStates[liftedState.currentStateIndex];
+      expect(Object.keys(liftedState.actionsById).length).toBe(
+        Object.keys(liftedState.sanitizedActionsById).length
+      );
+      expect(liftedState.actionsById).toEqual(liftedState.sanitizedActionsById);
+      expect(currentLiftedState.state).toEqual({ state: 1 });
+      expect(currentLiftedState.sanitizedState).toBeUndefined();
+    });
+
+    it('should run the action sanitizer on actions', () => {
+      fixture = createStore(counter, {
+        actionSanitizer: testActionSanitizer,
+      });
+
+      fixture.store.dispatch({ type: 'INCREMENT' });
+      fixture.store.dispatch({ type: 'DECREMENT' });
+
+      const liftedState = fixture.getLiftedState();
+      const sanitizedAction =
+        liftedState.sanitizedActionsById[liftedState.nextActionId - 1];
+      const sanitizedAction2 =
+        liftedState.sanitizedActionsById[liftedState.nextActionId - 2];
+      const action = liftedState.actionsById[liftedState.nextActionId - 1];
+      const action2 = liftedState.actionsById[liftedState.nextActionId - 2];
+
+      expect(liftedState.actionsById).not.toEqual(
+        liftedState.sanitizedActionsById
+      );
+      expect(sanitizedAction.action).toEqual({ type: SANITIZED_TOKEN });
+      expect(sanitizedAction2.action).toEqual({ type: SANITIZED_TOKEN });
+      expect(action.action).toEqual({ type: 'DECREMENT' });
+      expect(action2.action).toEqual({ type: 'INCREMENT' });
+    });
+
+    it('should run the state sanitizer on store state', () => {
+      fixture = createStore(counter, {
+        stateSanitizer: testStateSanitizer,
+      });
+
+      let liftedState = fixture.getLiftedState();
+      let currentLiftedState =
+        liftedState.computedStates[liftedState.currentStateIndex];
+      expect(fixture.getState()).toBe(0);
+      expect(currentLiftedState.state).toEqual({ state: 0 });
+      expect(currentLiftedState.sanitizedState).toBeDefined();
+      expect(currentLiftedState.sanitizedState).toEqual({
+        state: SANITIZED_COUNTER,
+      });
+
+      fixture.store.dispatch({ type: 'INCREMENT' });
+
+      liftedState = fixture.getLiftedState();
+      currentLiftedState =
+        liftedState.computedStates[liftedState.currentStateIndex];
+      expect(fixture.getState()).toBe(1);
+      expect(currentLiftedState.state).toEqual({ state: 1 });
+      expect(currentLiftedState.sanitizedState).toEqual({
+        state: SANITIZED_COUNTER,
+      });
+    });
+
+    it('should run transparently to produce a new lifted store state', () => {
+      const devtoolsOptions: Partial<StoreDevtoolsConfig> = {
+        actionSanitizer: testActionSanitizer,
+        stateSanitizer: testStateSanitizer,
+      };
+      fixture = createStore(counter, devtoolsOptions);
+
+      fixture.store.dispatch({ type: 'INCREMENT' });
+
+      const liftedState = fixture.getLiftedState();
+      const sanitizedLiftedState = fixture.devtools.getSanitizedState(
+        liftedState,
+        devtoolsOptions
+      );
+      const originalAction =
+        liftedState.actionsById[liftedState.nextActionId - 1];
+      const originalState =
+        liftedState.computedStates[liftedState.currentStateIndex];
+      const sanitizedAction =
+        sanitizedLiftedState.actionsById[liftedState.nextActionId - 1];
+      const sanitizedState =
+        sanitizedLiftedState.computedStates[liftedState.currentStateIndex];
+
+      expect(originalAction.action).toEqual({ type: 'INCREMENT' });
+      expect(originalState.state).toEqual({ state: 1 });
+      expect(sanitizedAction.action).toEqual({ type: SANITIZED_TOKEN });
+      expect(sanitizedState.state).toEqual({ state: SANITIZED_COUNTER });
+    });
+
+    it('sanitized actions should not affect the store state', () => {
+      fixture = createStore(counter, {
+        actionSanitizer: incrementActionSanitizer,
+      });
+
+      fixture.store.dispatch({ type: 'DECREMENT' });
+      fixture.store.dispatch({ type: 'DECREMENT' });
+
+      const liftedState = fixture.getLiftedState();
+      expect(fixture.getState()).toBe(-2);
+      expect(
+        liftedState.computedStates[liftedState.currentStateIndex].state
+      ).toEqual({ state: -2 });
+    });
+  });
 });

--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -1,11 +1,14 @@
 import { ActionReducer, Action } from '@ngrx/store';
 import { InjectionToken, Type } from '@angular/core';
 
+export type ActionSanitizer = (action: Action, id: number) => Action;
+export type StateSanitizer = (state: any, index: number) => any;
+
 export class StoreDevtoolsConfig {
   maxAge: number | false;
   monitor: ActionReducer<any, any>;
-  actionSanitizer?: <A extends Action>(action: A, id: number) => A;
-  stateSanitizer?: <S>(state: S, index: number) => S;
+  actionSanitizer?: ActionSanitizer;
+  stateSanitizer?: StateSanitizer;
   name?: string;
   serialize?: boolean;
   logOnly?: boolean;

--- a/modules/store-devtools/src/devtools.ts
+++ b/modules/store-devtools/src/devtools.ts
@@ -28,7 +28,11 @@ import {
   ComputedState,
 } from './reducer';
 import * as Actions from './actions';
-import { StoreDevtoolsConfig, STORE_DEVTOOLS_CONFIG } from './config';
+import {
+  StoreDevtoolsConfig,
+  STORE_DEVTOOLS_CONFIG,
+  StateSanitizer,
+} from './config';
 
 @Injectable()
 export class DevtoolsDispatcher extends ActionsSubject {}
@@ -78,7 +82,7 @@ export class StoreDevtools implements Observer<any> {
           // Extension should be sent the sanitized lifted state
           extension.notify(
             action,
-            this.getSanitizedState(reducedLiftedState, config)
+            this.getSanitizedState(reducedLiftedState, config.stateSanitizer)
           );
 
           return { state: reducedLiftedState, action };
@@ -110,8 +114,8 @@ export class StoreDevtools implements Observer<any> {
    * Restructures the lifted state passed in to prepare for sending to the
    * Redux Devtools Extension
    */
-  getSanitizedState(state: LiftedState, config: Partial<StoreDevtoolsConfig>) {
-    const sanitizedComputedStates = config.stateSanitizer
+  getSanitizedState(state: LiftedState, stateSanitizer?: StateSanitizer) {
+    const sanitizedComputedStates = stateSanitizer
       ? state.computedStates.map((entry: ComputedState) => ({
           state: entry.sanitizedState,
           error: entry.error,

--- a/modules/store-devtools/src/instrument.ts
+++ b/modules/store-devtools/src/instrument.ts
@@ -64,14 +64,6 @@ export function noMonitor(): null {
   return null;
 }
 
-export function noActionSanitizer(): null {
-  return null;
-}
-
-export function noStateSanitizer(): null {
-  return null;
-}
-
 export const DEFAULT_NAME = 'NgRx Store DevTools';
 
 export function createConfig(
@@ -80,8 +72,8 @@ export function createConfig(
   const DEFAULT_OPTIONS: StoreDevtoolsConfig = {
     maxAge: false,
     monitor: noMonitor,
-    actionSanitizer: noActionSanitizer,
-    stateSanitizer: noStateSanitizer,
+    actionSanitizer: undefined,
+    stateSanitizer: undefined,
     name: DEFAULT_NAME,
     serialize: false,
     logOnly: false,


### PR DESCRIPTION
Continuing the work from #544 and requested by #604, this PR actually adds the sanitization functionality to @ngrx/store-devtools.

Unfortunately, simply passing `actionSanitizer` and `stateSanitizer` to the Redux Devtools Extension does not work, since the `send(action, state)` function exposed by its API does not sanitize anything if the `action` passed in is `null`, which is the current behaviour. As a result, it is necessary to sanitize within ngrx Devtools itself, and then pass that into the extension.

This implementation deliberately avoids mutating the lifted state's `actionsByIds` and `computedStates` properties, but instead creates a sanitized copy of them. This prevents the possibility of a sanitized action from changing the store state if, for example, its sanitized type coincided with a real action's type within the application.

### Testing
In `app.module.ts`:
```typescript
StoreDevtoolsModule.instrument({
  actionSanitizer: (action: Action, id: number) => {
    return { type: 'SANITIZED_ACTION' };
  },
  stateSanitizer: (state: any, index: number) => {
    return { ...state, extra: 'SANITIZED_STATE' };
  }
})
```
Open Chrome, confirm that it appears, while app and time travel seem to work fine.