### PR TITLE
fix(Devtools): Ensure Store is loaded eagerly

### DIFF
--- a/modules/store-devtools/spec/integration.spec.ts
+++ b/modules/store-devtools/spec/integration.spec.ts
@@ -1,0 +1,41 @@
+import { NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { StoreModule, Store, ActionsSubject } from '@ngrx/store';
+import { StoreDevtoolsModule, StoreDevtools } from '@ngrx/store-devtools';
+
+describe('Devtools Integration', () => {
+  let store: Store<any>;
+
+  @NgModule({
+    imports: [StoreModule.forFeature('a', (state: any, action: any) => state)],
+  })
+  class EagerFeatureModule {}
+
+  @NgModule({
+    imports: [
+      StoreModule.forRoot({}),
+      EagerFeatureModule,
+      StoreDevtoolsModule.instrument(),
+    ],
+  })
+  class RootModule {}
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RootModule],
+    });
+  });
+
+  it('should load the store eagerly', () => {
+    let error = false;
+
+    try {
+      let store = TestBed.get(Store);
+      store.subscribe();
+    } catch (e) {
+      error = true;
+    }
+
+    expect(error).toBeFalsy();
+  });
+});

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -41,14 +41,15 @@ import {
   ScannedActionsSubject,
 } from './scanned_actions_subject';
 import { STATE_PROVIDERS } from './state';
-import { STORE_PROVIDERS } from './store';
+import { STORE_PROVIDERS, Store } from './store';
 
 @NgModule({})
 export class StoreRootModule {
   constructor(
     actions$: ActionsSubject,
     reducer$: ReducerObservable,
-    scannedActions$: ScannedActionsSubject
+    scannedActions$: ScannedActionsSubject,
+    store: Store<any>
   ) {}
 }
 
@@ -57,7 +58,8 @@ export class StoreFeatureModule implements OnDestroy {
   constructor(
     @Inject(STORE_FEATURES) private features: StoreFeature<any, any>[],
     @Inject(FEATURE_REDUCERS) private featureReducers: ActionReducerMap<any>[],
-    private reducerManager: ReducerManager
+    private reducerManager: ReducerManager,
+    root: StoreRootModule
   ) {
     features
       .map((feature, index) => {


### PR DESCRIPTION
Depending on the order if your `NgModule` or `ModuleWithProvider` imports, the `Store` could get initialized after a feature state is loaded, causing the state to be undefined when using the Devtools. This fix creates an explicit instantiation order for `Store` being instantiated first, so the init action is always dispatched first to initialize the state.

Closes #624, #741 