### PR TITLE
fix(Entity): Properly iterate over array in upsert

### DIFF
--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -132,8 +132,7 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
     const added: T[] = [];
     const updated: any[] = [];
 
-    for (let index in updates) {
-      const update = updates[index];
+    for (const update of updates) {
       if (update.id in state.entities) {
         updated.push(update);
       } else {


### PR DESCRIPTION
It seems that commit f871540f67191195a347297f1208e8f821d511cc introduced again the same problem I have fixed in d537758639016918fe71a70c3b92f06bf10a6dd7. My previous pull request was not rebased on the latest changes and so it caused failing tests after it was merged.