### PR TITLE
fix(Entity): Avoid for..in iteration in sorted state adapter

### DIFF
--- a/modules/entity/spec/sorted_state_adapter.spec.ts
+++ b/modules/entity/spec/sorted_state_adapter.spec.ts
@@ -11,6 +11,20 @@ describe('Sorted State Adapter', () => {
   let adapter: EntityStateAdapter<BookModel>;
   let state: EntityState<BookModel>;
 
+  beforeAll(() => {
+    Object.defineProperty(Array.prototype, 'unwantedField', {
+      enumerable: true,
+      configurable: true,
+      value: 'This should not appear anywhere',
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(Array.prototype, 'unwantedField', {
+      value: undefined,
+    });
+  });
+
   beforeEach(() => {
     adapter = createEntityAdapter({
       selectId: (book: BookModel) => book.id,

--- a/modules/entity/src/sorted_state_adapter.ts
+++ b/modules/entity/src/sorted_state_adapter.ts
@@ -116,8 +116,7 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
     const added: T[] = [];
     const updated: Update<T>[] = [];
 
-    for (let index in updates) {
-      const update = updates[index];
+    for (const update of updates) {
       if (update.id in state.entities) {
         updated.push(update);
       } else {


### PR DESCRIPTION
I have just noticed that the changes in commit f871540f67191195a347297f1208e8f821d511cc introduced to the sorted state adapter the same problem I have already fixed in the unsorted state adapter. So I'm adding the reproducer to those tests as well.

Just one question: Where can we expect these fixes to be released? Is there going to be version `5.0.2` anytime soon?