### PR TITLE
WIP: Add an ng_package rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,11 +35,10 @@ node_repositories(package_json = ["//:package.json"])
 
 ####################################
 # Fetch and install the TypeScript rules
-http_archive(
+git_repository(
     name = "build_bazel_rules_typescript",
-    url = "https://github.com/bazelbuild/rules_typescript/archive/0.10.1.zip",
-    strip_prefix = "rules_typescript-0.10.1",
-    sha256 = "a2c81776a4a492ff9f878f9705639f5647bef345f7f3e1da09c9eeb8dec80485",
+    remote = "git@github.com:alexeagle/rules_typescript.git",
+    commit = "623565514d6bad77d9310f2658bf8457eb4979bb",
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")
@@ -68,11 +67,20 @@ local_repository(
     path = "node_modules/@angular/bazel",
 )
 
+git_repository(
+    name = "angular_devkit",
+    remote = "git@github.com:alexeagle/devkit.git",
+    commit = "2a2bcb7650394fd4d6c5c999e744b9fbf78e5719",
+)
+
 local_repository(
     name = "rxjs",
     path = "node_modules/rxjs/src",
 )
 
+load("@angular//:index.bzl", "ng_setup_workspace")
+
+ng_setup_workspace()
 
 ####################################
 # Bazel will fetch its own dependencies from npm.

--- a/modules/store/BUILD
+++ b/modules/store/BUILD
@@ -1,6 +1,6 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "ng_module", "ng_package")
 
-ts_library(
+ng_module(
     name = "store",
     srcs = glob([
         "*.ts",
@@ -9,4 +9,10 @@ ts_library(
     module_name = "@ngrx/store",
     visibility = ["//visibility:public"],
     deps = ["@rxjs"],
+)
+
+ng_package(
+    name = "npm_package",
+    deps = [":store"],
+    entry_point = "modules/store/index.js",
 )

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@angular/animations": "^5.0.0",
+    "@angular/bazel": "alexeagle/bazel-builds#510158e7992f91276f2c147552c9492b32fc85ce",
     "@angular/cli": "^1.5.0",
     "@angular/common": "^5.0.0",
     "@angular/compiler": "^5.0.0",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,9 +1,24 @@
 """Re-export of some bazel rules with repository-wide defaults."""
 load("@build_bazel_rules_typescript//:defs.bzl", _ts_library = "ts_library")
+load("@angular//:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
+
+DEFAULT_NODE_MODULES = "@ngrx_compiletime_deps//:node_modules"
 
 def ts_library(tsconfig = None, node_modules = None, **kwargs):
   if not tsconfig:
     tsconfig = "//:tsconfig.json"
   if not node_modules:
-    node_modules = "@ngrx_compiletime_deps//:node_modules"
+    node_modules = DEFAULT_NODE_MODULES
   _ts_library(tsconfig = tsconfig, node_modules = node_modules, **kwargs)
+
+def ng_module(tsconfig = None, node_modules = None, **kwargs):
+  if not tsconfig:
+    tsconfig = "//:tsconfig.json"
+  if not node_modules:
+    node_modules = DEFAULT_NODE_MODULES
+  _ng_module(tsconfig = tsconfig, node_modules = node_modules, **kwargs)
+
+def ng_package(node_modules = None, **kwargs):
+  if not node_modules:
+    node_modules = DEFAULT_NODE_MODULES
+  _ng_package(node_modules = node_modules, **kwargs)

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,12 @@
   dependencies:
     tslib "^1.7.1"
 
+"@angular/bazel@alexeagle/bazel-builds#a208b5a8b555ecae0a4b5496a00b45aa181d12de":
+  version "6.0.0-beta.4-f693be3"
+  resolved "https://codeload.github.com/alexeagle/bazel-builds/tar.gz/a208b5a8b555ecae0a4b5496a00b45aa181d12de"
+  dependencies:
+    "@types/node" "6.0.84"
+
 "@angular/cdk@^2.0.0-beta.12":
   version "2.0.0-beta.12"
   resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-2.0.0-beta.12.tgz#3a243cb62b93f4e039120ba70f900dc9e235622e"
@@ -236,6 +242,10 @@
 "@types/node@*", "@types/node@^7.0.5":
   version "7.0.34"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.34.tgz#eed5c95291a9dddff6b9f5a72ca342b1e72f0ba2"
+
+"@types/node@6.0.84":
+  version "6.0.84"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.84.tgz#193ffe5a9f42864d425ffd9739d95b753c6a1eab"
 
 "@types/node@^6.0.46":
   version "6.0.68"


### PR DESCRIPTION
This should build the npm distribution for @ngrx/store.

Requires a bunch of fixes:
- angular/compiler-cli later than 6.0.0-beta.4 - it's unreleased, plus there's a problem with the snapshot published (missing stuff) so this points to my fork
  alexeagle/compiler-cli-builds
- angular/bazel-builds doesn't have ng_package yet because it hasn't landed. I crafted a distributable version on
  alexeagle/bazel-builds
  but this includes some fixes that need to be upstreamed
- rules_typescript needs minor fixes to pick up fix for https://github.com/mozilla/source-map/issues/273
- tsickle will need fixes due to the source-map update

Also this doesn't work yet, not sure if this is a tsickle bug?
```
ERROR: /Users/alexeagle/Projects/ngrx-new/modules/store/BUILD:3:1: Compiling Angular templates (ngc) //modules/store:store failed (Exit 1)
Error: TypeError: Cannot read property 'emitNode' of undefined
    at getOrCreateEmitNode (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/typescript/lib/typescript.js:49322:19)
    at getOrCreateEmitNode (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/typescript/lib/typescript.js:49331:17)
    at Object.setEmitFlags (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/typescript/lib/typescript.js:49350:9)
    at resetNodeTextRangeToPreventDuplicateComments (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/tsickle/src/transformer_util.js:297:12)
    at Object.visitNodeWithSynthesizedComments (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/tsickle/src/transformer_util.js:286:16)
    at visitNode (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/tsickle/src/transformer_sourcemap.js:41:43)
    at visitNode (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/typescript/lib/typescript.js:51053:23)
    at Object.visitEachChild (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/typescript/lib/typescript.js:51355:170)
    at visitNodeImpl (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/tsickle/src/transformer_sourcemap.js:82:27)
    at Object.visitNodeWithSynthesizedComments (/private/var/tmp/_bazel_alexeagle/ec6027f1e574c571ac1849238a5f8d26/external/angular_bazel_runtime_deps/node_modules/tsickle/src/transformer_util.js:281:20)

Target //modules/store:npm_package failed to build
```