### PR TITLE
fix(StoreDevtools): Recompute state history when reducers are updated

### DIFF
--- a/modules/store-devtools/src/reducer.ts
+++ b/modules/store-devtools/src/reducer.ts
@@ -413,6 +413,12 @@ export function liftReducerWith(
             options.stateSanitizer
           );
 
+          // Recompute state history with latest reducer and update action
+          computedStates = computedStates.map(cmp => ({
+            ...cmp,
+            state: reducer(cmp.state, liftedAction),
+          }));
+
           currentStateIndex = minInvalidatedStateIndex;
 
           if (options.maxAge && stagedActionIds.length > options.maxAge) {


### PR DESCRIPTION
This fixes the issue with time-traveling to previous states before the reducers were updated. Each state history item will be recomputed with the latest reducer.