### PR TITLE
refactor(Example): Unify the form of the actions import name

### DIFF
--- a/example-app/app/auth/actions/auth.ts
+++ b/example-app/app/auth/actions/auth.ts
@@ -35,7 +35,7 @@ export class Logout implements Action {
   readonly type = AuthActionTypes.Logout;
 }
 
-export type AuthActions =
+export type AuthActionsUnion =
   | Login
   | LoginSuccess
   | LoginFailure

--- a/example-app/app/auth/containers/login-page.component.spec.ts
+++ b/example-app/app/auth/containers/login-page.component.spec.ts
@@ -5,7 +5,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { StoreModule, Store, combineReducers } from '@ngrx/store';
 import { LoginPageComponent } from './login-page.component';
 import { LoginFormComponent } from '../components/login-form.component';
-import * as Auth from '../actions/auth';
+import * as AuthActions from '../actions/auth';
 import * as fromAuth from '../reducers';
 
 describe('Login Page', () => {
@@ -57,7 +57,7 @@ describe('Login Page', () => {
 
   it('should dispatch a login event on submit', () => {
     const $event: any = {};
-    const action = new Auth.Login($event);
+    const action = new AuthActions.Login($event);
 
     instance.onSubmit($event);
 

--- a/example-app/app/auth/containers/login-page.component.ts
+++ b/example-app/app/auth/containers/login-page.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Authenticate } from '../models/user';
 import * as fromAuth from '../reducers';
-import * as Auth from '../actions/auth';
+import * as AuthActions from '../actions/auth';
 
 @Component({
   selector: 'bc-login-page',
@@ -24,6 +24,6 @@ export class LoginPageComponent implements OnInit {
   ngOnInit() {}
 
   onSubmit($event: Authenticate) {
-    this.store.dispatch(new Auth.Login($event));
+    this.store.dispatch(new AuthActions.Login($event));
   }
 }

--- a/example-app/app/auth/reducers/auth.ts
+++ b/example-app/app/auth/reducers/auth.ts
@@ -1,4 +1,4 @@
-import { AuthActions, AuthActionTypes } from './../actions/auth';
+import { AuthActionsUnion, AuthActionTypes } from './../actions/auth';
 import { User } from '../models/user';
 
 export interface State {
@@ -11,7 +11,7 @@ export const initialState: State = {
   user: null,
 };
 
-export function reducer(state = initialState, action: AuthActions): State {
+export function reducer(state = initialState, action: AuthActionsUnion): State {
   switch (action.type) {
     case AuthActionTypes.LoginSuccess: {
       return {

--- a/example-app/app/auth/reducers/login-page.ts
+++ b/example-app/app/auth/reducers/login-page.ts
@@ -1,4 +1,4 @@
-import { AuthActionTypes, AuthActions } from './../actions/auth';
+import { AuthActionTypes, AuthActionsUnion } from './../actions/auth';
 
 export interface State {
   error: string | null;
@@ -10,7 +10,7 @@ export const initialState: State = {
   pending: false,
 };
 
-export function reducer(state = initialState, action: AuthActions): State {
+export function reducer(state = initialState, action: AuthActionsUnion): State {
   switch (action.type) {
     case AuthActionTypes.Login: {
       return {

--- a/example-app/app/auth/services/auth-guard.service.spec.ts
+++ b/example-app/app/auth/services/auth-guard.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import { StoreModule, Store, combineReducers } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 import { AuthGuard } from './auth-guard.service';
-import * as Auth from '../actions/auth';
+import * as AuthActions from '../actions/auth';
 import * as fromRoot from '../../reducers';
 import * as fromAuth from '../reducers';
 
@@ -34,7 +34,7 @@ describe('Auth Guard', () => {
 
   it('should return true if the user state is logged in', () => {
     const user: any = {};
-    const action = new Auth.LoginSuccess({ user });
+    const action = new AuthActions.LoginSuccess({ user });
     store.dispatch(action);
 
     const expected = cold('(a|)', { a: true });

--- a/example-app/app/auth/services/auth-guard.service.ts
+++ b/example-app/app/auth/services/auth-guard.service.ts
@@ -3,7 +3,7 @@ import { CanActivate } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { map, take } from 'rxjs/operators';
-import * as Auth from '../actions/auth';
+import * as AuthActions from '../actions/auth';
 import * as fromAuth from '../reducers';
 
 @Injectable()
@@ -15,7 +15,7 @@ export class AuthGuard implements CanActivate {
       select(fromAuth.getLoggedIn),
       map(authed => {
         if (!authed) {
-          this.store.dispatch(new Auth.LoginRedirect());
+          this.store.dispatch(new AuthActions.LoginRedirect());
           return false;
         }
 

--- a/example-app/app/books/actions/book.ts
+++ b/example-app/app/books/actions/book.ts
@@ -50,4 +50,9 @@ export class Select implements Action {
  * Export a type alias of all actions in this action group
  * so that reducers can easily compose action types
  */
-export type BookActions = Search | SearchComplete | SearchError | Load | Select;
+export type BookActionsUnion =
+  | Search
+  | SearchComplete
+  | SearchError
+  | Load
+  | Select;

--- a/example-app/app/books/actions/collection.ts
+++ b/example-app/app/books/actions/collection.ts
@@ -74,7 +74,7 @@ export class LoadFail implements Action {
   constructor(public payload: any) {}
 }
 
-export type CollectionActions =
+export type CollectionActionsUnion =
   | AddBook
   | AddBookSuccess
   | AddBookFail

--- a/example-app/app/books/containers/collection-page.spec.ts
+++ b/example-app/app/books/containers/collection-page.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MatCardModule, MatInputModule } from '@angular/material';
 import { BookPreviewListComponent } from '../components/book-preview-list';
 import { BookPreviewComponent } from '../components/book-preview';
-import * as collection from '../actions/collection';
+import * as CollectionActions from '../actions/collection';
 import * as fromBooks from '../reducers';
 import { EllipsisPipe } from '../../shared/pipes/ellipsis';
 import { AddCommasPipe } from '../../shared/pipes/add-commas';
@@ -52,7 +52,7 @@ describe('Collection Page', () => {
   });
 
   it('should dispatch a collection.Load on init', () => {
-    const action = new collection.Load();
+    const action = new CollectionActions.Load();
 
     fixture.detectChanges();
 

--- a/example-app/app/books/containers/collection-page.ts
+++ b/example-app/app/books/containers/collection-page.ts
@@ -3,7 +3,7 @@ import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
 import * as fromBooks from '../reducers';
-import * as collection from '../actions/collection';
+import * as CollectionActions from '../actions/collection';
 import { Book } from '../models/book';
 
 @Component({
@@ -39,6 +39,6 @@ export class CollectionPageComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.store.dispatch(new collection.Load());
+    this.store.dispatch(new CollectionActions.Load());
   }
 }

--- a/example-app/app/books/containers/find-book-page.spec.ts
+++ b/example-app/app/books/containers/find-book-page.spec.ts
@@ -16,7 +16,7 @@ import { EllipsisPipe } from '../../shared/pipes/ellipsis';
 import { BookAuthorsComponent } from '../components/book-authors';
 import { AddCommasPipe } from '../../shared/pipes/add-commas';
 import { FindBookPageComponent } from './find-book-page';
-import * as book from '../actions/book';
+import * as BookActions from '../actions/book';
 import * as fromBooks from '../reducers';
 
 describe('Find Book Page', () => {
@@ -63,7 +63,7 @@ describe('Find Book Page', () => {
 
   it('should dispatch a book.Search action on search', () => {
     const $event: string = 'book name';
-    const action = new book.Search($event);
+    const action = new BookActions.Search($event);
 
     instance.search($event);
 

--- a/example-app/app/books/containers/find-book-page.ts
+++ b/example-app/app/books/containers/find-book-page.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs/Observable';
 import { take } from 'rxjs/operators';
 
 import * as fromBooks from '../reducers';
-import * as book from '../actions/book';
+import * as BookActions from '../actions/book';
 import { Book } from '../models/book';
 
 @Component({
@@ -29,6 +29,6 @@ export class FindBookPageComponent {
   }
 
   search(query: string) {
-    this.store.dispatch(new book.Search(query));
+    this.store.dispatch(new BookActions.Search(query));
   }
 }

--- a/example-app/app/books/containers/selected-book-page.spec.ts
+++ b/example-app/app/books/containers/selected-book-page.spec.ts
@@ -4,7 +4,7 @@ import { combineReducers, Store, StoreModule } from '@ngrx/store';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatCardModule } from '@angular/material';
 
-import * as collection from '../actions/collection';
+import * as CollectionActions from '../actions/collection';
 import * as fromBooks from '../reducers';
 import { BookDetailComponent } from '../components/book-detail';
 import { Book, generateMockBook } from '../models/book';
@@ -48,7 +48,7 @@ describe('Selected Book Page', () => {
 
   it('should dispatch a collection.AddBook action when addToCollection is called', () => {
     const $event: Book = generateMockBook();
-    const action = new collection.AddBook($event);
+    const action = new CollectionActions.AddBook($event);
 
     instance.addToCollection($event);
 
@@ -57,7 +57,7 @@ describe('Selected Book Page', () => {
 
   it('should dispatch a collection.RemoveBook action on removeFromCollection', () => {
     const $event: Book = generateMockBook();
-    const action = new collection.RemoveBook($event);
+    const action = new CollectionActions.RemoveBook($event);
 
     instance.removeFromCollection($event);
 

--- a/example-app/app/books/containers/selected-book-page.ts
+++ b/example-app/app/books/containers/selected-book-page.ts
@@ -3,7 +3,7 @@ import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
 import * as fromBooks from '../reducers';
-import * as collection from '../actions/collection';
+import * as CollectionActions from '../actions/collection';
 import { Book } from '../models/book';
 
 @Component({
@@ -30,10 +30,10 @@ export class SelectedBookPageComponent {
   }
 
   addToCollection(book: Book) {
-    this.store.dispatch(new collection.AddBook(book));
+    this.store.dispatch(new CollectionActions.AddBook(book));
   }
 
   removeFromCollection(book: Book) {
-    this.store.dispatch(new collection.RemoveBook(book));
+    this.store.dispatch(new CollectionActions.RemoveBook(book));
   }
 }

--- a/example-app/app/books/containers/view-book-page.spec.ts
+++ b/example-app/app/books/containers/view-book-page.spec.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { MatCardModule } from '@angular/material';
 
 import { ViewBookPageComponent } from './view-book-page';
-import * as book from '../actions/book';
+import * as BookActions from '../actions/book';
 import * as fromBooks from '../reducers';
 import { SelectedBookPageComponent } from './selected-book-page';
 import { BookDetailComponent } from '../components/book-detail';
@@ -56,7 +56,7 @@ describe('View Book Page', () => {
   });
 
   it('should dispatch a book.Select action on init', () => {
-    const action = new book.Select('2');
+    const action = new BookActions.Select('2');
     params.next({ id: '2' });
 
     fixture.detectChanges();

--- a/example-app/app/books/containers/view-book-page.ts
+++ b/example-app/app/books/containers/view-book-page.ts
@@ -5,7 +5,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { map } from 'rxjs/operators';
 
 import * as fromBooks from '../reducers';
-import * as book from '../actions/book';
+import * as BookActions from '../actions/book';
 
 /**
  * Note: Container components are also reusable. Whether or not
@@ -29,7 +29,7 @@ export class ViewBookPageComponent implements OnDestroy {
 
   constructor(store: Store<fromBooks.State>, route: ActivatedRoute) {
     this.actionsSubscription = route.params
-      .pipe(map(params => new book.Select(params.id)))
+      .pipe(map(params => new BookActions.Select(params.id)))
       .subscribe(store);
   }
 

--- a/example-app/app/books/effects/book.ts
+++ b/example-app/app/books/effects/book.ts
@@ -10,7 +10,6 @@ import { of } from 'rxjs/observable/of';
 import { GoogleBooksService } from '../../core/services/google-books';
 import {
   BookActionTypes,
-  BookActions,
   SearchComplete,
   SearchError,
   Search,

--- a/example-app/app/books/effects/collection.spec.ts
+++ b/example-app/app/books/effects/collection.spec.ts
@@ -5,7 +5,7 @@ import { cold, hot } from 'jasmine-marbles';
 import { CollectionEffects } from './collection';
 import { Database } from '@ngrx/db';
 import { Book } from '../models/book';
-import * as collection from '../actions/collection';
+import * as CollectionActions from '../actions/collection';
 import { Observable } from 'rxjs/Observable';
 
 export class TestActions extends Actions {
@@ -61,8 +61,8 @@ describe('CollectionEffects', () => {
 
   describe('loadCollection$', () => {
     it('should return a collection.LoadSuccess, with the books, on success', () => {
-      const action = new collection.Load();
-      const completion = new collection.LoadSuccess([book1, book2]);
+      const action = new CollectionActions.Load();
+      const completion = new CollectionActions.LoadSuccess([book1, book2]);
 
       actions$.stream = hot('-a', { a: action });
       const response = cold('-a-b|', { a: book1, b: book2 });
@@ -73,9 +73,9 @@ describe('CollectionEffects', () => {
     });
 
     it('should return a collection.LoadFail, if the query throws', () => {
-      const action = new collection.Load();
+      const action = new CollectionActions.Load();
       const error = 'Error!';
-      const completion = new collection.LoadFail(error);
+      const completion = new CollectionActions.LoadFail(error);
 
       actions$.stream = hot('-a', { a: action });
       const response = cold('-#', {}, error);
@@ -88,8 +88,8 @@ describe('CollectionEffects', () => {
 
   describe('addBookToCollection$', () => {
     it('should return a collection.AddBookSuccess, with the book, on success', () => {
-      const action = new collection.AddBook(book1);
-      const completion = new collection.AddBookSuccess(book1);
+      const action = new CollectionActions.AddBook(book1);
+      const completion = new CollectionActions.AddBookSuccess(book1);
 
       actions$.stream = hot('-a', { a: action });
       const response = cold('-b', { b: true });
@@ -101,8 +101,8 @@ describe('CollectionEffects', () => {
     });
 
     it('should return a collection.AddBookFail, with the book, when the db insert throws', () => {
-      const action = new collection.AddBook(book1);
-      const completion = new collection.AddBookFail(book1);
+      const action = new CollectionActions.AddBook(book1);
+      const completion = new CollectionActions.AddBookFail(book1);
       const error = 'Error!';
 
       actions$.stream = hot('-a', { a: action });
@@ -115,8 +115,8 @@ describe('CollectionEffects', () => {
 
     describe('removeBookFromCollection$', () => {
       it('should return a collection.RemoveBookSuccess, with the book, on success', () => {
-        const action = new collection.RemoveBook(book1);
-        const completion = new collection.RemoveBookSuccess(book1);
+        const action = new CollectionActions.RemoveBook(book1);
+        const completion = new CollectionActions.RemoveBookSuccess(book1);
 
         actions$.stream = hot('-a', { a: action });
         const response = cold('-b', { b: true });
@@ -130,8 +130,8 @@ describe('CollectionEffects', () => {
       });
 
       it('should return a collection.RemoveBookFail, with the book, when the db insert throws', () => {
-        const action = new collection.RemoveBook(book1);
-        const completion = new collection.RemoveBookFail(book1);
+        const action = new CollectionActions.RemoveBook(book1);
+        const completion = new CollectionActions.RemoveBookFail(book1);
         const error = 'Error!';
 
         actions$.stream = hot('-a', { a: action });

--- a/example-app/app/books/effects/collection.ts
+++ b/example-app/app/books/effects/collection.ts
@@ -8,7 +8,6 @@ import { of } from 'rxjs/observable/of';
 import { Load } from './../actions/book';
 
 import {
-  CollectionActions,
   LoadFail,
   LoadSuccess,
   AddBookSuccess,

--- a/example-app/app/books/guards/book-exists.ts
+++ b/example-app/app/books/guards/book-exists.ts
@@ -7,7 +7,7 @@ import { of } from 'rxjs/observable/of';
 
 import { GoogleBooksService } from '../../core/services/google-books';
 import * as fromBooks from '../reducers';
-import * as book from '../actions/book';
+import * as BookActions from '../actions/book';
 
 /**
  * Guards are hooks into the route resolution process, providing an opportunity
@@ -53,8 +53,8 @@ export class BookExistsGuard implements CanActivate {
    */
   hasBookInApi(id: string): Observable<boolean> {
     return this.googleBooks.retrieveBook(id).pipe(
-      map(bookEntity => new book.Load(bookEntity)),
-      tap((action: book.Load) => this.store.dispatch(action)),
+      map(bookEntity => new BookActions.Load(bookEntity)),
+      tap((action: BookActions.Load) => this.store.dispatch(action)),
       map(book => !!book),
       catchError(() => {
         this.router.navigate(['/404']);

--- a/example-app/app/books/reducers/books.ts
+++ b/example-app/app/books/reducers/books.ts
@@ -1,9 +1,9 @@
 import { createSelector } from '@ngrx/store';
 import { createEntityAdapter, EntityAdapter, EntityState } from '@ngrx/entity';
 import { Book } from '../models/book';
-import { BookActions, BookActionTypes } from '../actions/book';
+import { BookActionsUnion, BookActionTypes } from '../actions/book';
 import {
-  CollectionActions,
+  CollectionActionsUnion,
   CollectionActionTypes,
 } from '../actions/collection';
 
@@ -42,7 +42,7 @@ export const initialState: State = adapter.getInitialState({
 
 export function reducer(
   state = initialState,
-  action: BookActions | CollectionActions
+  action: BookActionsUnion | CollectionActionsUnion
 ): State {
   switch (action.type) {
     case BookActionTypes.SearchComplete:

--- a/example-app/app/books/reducers/collection.ts
+++ b/example-app/app/books/reducers/collection.ts
@@ -1,6 +1,6 @@
 import {
   CollectionActionTypes,
-  CollectionActions,
+  CollectionActionsUnion,
 } from './../actions/collection';
 
 export interface State {
@@ -17,7 +17,7 @@ const initialState: State = {
 
 export function reducer(
   state = initialState,
-  action: CollectionActions
+  action: CollectionActionsUnion
 ): State {
   switch (action.type) {
     case CollectionActionTypes.Load: {

--- a/example-app/app/books/reducers/search.ts
+++ b/example-app/app/books/reducers/search.ts
@@ -1,4 +1,4 @@
-import { BookActionTypes, BookActions } from '../actions/book';
+import { BookActionTypes, BookActionsUnion } from '../actions/book';
 
 export interface State {
   ids: string[];
@@ -14,7 +14,7 @@ const initialState: State = {
   query: '',
 };
 
-export function reducer(state = initialState, action: BookActions): State {
+export function reducer(state = initialState, action: BookActionsUnion): State {
   switch (action.type) {
     case BookActionTypes.Search: {
       const query = action.payload;

--- a/example-app/app/core/actions/layout.ts
+++ b/example-app/app/core/actions/layout.ts
@@ -13,4 +13,4 @@ export class CloseSidenav implements Action {
   readonly type = LayoutActionTypes.CloseSidenav;
 }
 
-export type LayoutActions = OpenSidenav | CloseSidenav;
+export type LayoutActionsUnion = OpenSidenav | CloseSidenav;

--- a/example-app/app/core/containers/app.ts
+++ b/example-app/app/core/containers/app.ts
@@ -4,8 +4,8 @@ import { Store, select } from '@ngrx/store';
 
 import * as fromRoot from '../../reducers';
 import * as fromAuth from '../../auth/reducers';
-import * as layout from '../actions/layout';
-import * as Auth from '../../auth/actions/auth';
+import * as LayoutActions from '../actions/layout';
+import * as AuthActions from '../../auth/actions/auth';
 
 @Component({
   selector: 'bc-app',
@@ -54,16 +54,16 @@ export class AppComponent {
      * updates and user interaction through the life of our
      * application.
      */
-    this.store.dispatch(new layout.CloseSidenav());
+    this.store.dispatch(new LayoutActions.CloseSidenav());
   }
 
   openSidenav() {
-    this.store.dispatch(new layout.OpenSidenav());
+    this.store.dispatch(new LayoutActions.OpenSidenav());
   }
 
   logout() {
     this.closeSidenav();
 
-    this.store.dispatch(new Auth.Logout());
+    this.store.dispatch(new AuthActions.Logout());
   }
 }

--- a/example-app/app/core/reducers/layout.ts
+++ b/example-app/app/core/reducers/layout.ts
@@ -1,4 +1,4 @@
-import { LayoutActionTypes, LayoutActions } from '../actions/layout';
+import { LayoutActionTypes, LayoutActionsUnion } from '../actions/layout';
 
 export interface State {
   showSidenav: boolean;
@@ -10,7 +10,7 @@ const initialState: State = {
 
 export function reducer(
   state: State = initialState,
-  action: LayoutActions
+  action: LayoutActionsUnion
 ): State {
   switch (action.type) {
     case LayoutActionTypes.CloseSidenav:


### PR DESCRIPTION
Hi @brandonroberts 
In the example app, there are two forms for the actions import name, one is pascal and another one is lowercase, as show below:

```ts
// app.ts
import * as layout from '../actions/layout';
import * as Auth from '../../auth/actions/auth';
```
If I was a beginner of ngrx, I couldn't figure out which one was the best practices. It was a little confusing for me.

I suggest to unify the form of the import name, meanwhile I don't know which one is better.

In the [Typed Actions](https://github.com/ngrx/platform/blob/master/docs/store/actions.md#typed-actions) section of the store document, It used the pascal, as show below:

```ts
import { Store, select } from '@ngrx/store';
import { Observable } from 'rxjs/Observable';
import * as Counter from './counter.actions';

interface AppState {
  counter: number;
}

@Component({
  selector: 'my-app',
  template: `
    <button (click)="increment()">Increment</button>
    <button (click)="decrement()">Decrement</button>
    <button (click)="reset()">Reset Counter</button>
    
    <div>Current Count: {{ counter | async }}</div>
  `
})
export class MyAppComponent {
  counter: Observable<number>;

  constructor(private store: Store<AppState>) {
    this.counter = store.pipe(select('counter'));
  }

  increment(){
    this.store.dispatch(new Counter.Increment());
  }

  decrement(){
    this.store.dispatch(new Counter.Decrement());
  }

  reset(){
    this.store.dispatch(new Counter.Reset(3));
  }
}
```

And if we import actions and model for the same entity both, we can just use the lowercase:

```ts
// find-book-page.ts
import * as book from '../actions/book';
import { Book } from '../models/book';
```

So, I need the answer from you guys and then complete this PR that in progress.