### PR TITLE
docs(schematics): add alternative setup command

### DIFF
--- a/docs/schematics/README.md
+++ b/docs/schematics/README.md
@@ -43,6 +43,11 @@ add the following to the `defaults` section in your `.angular-cli.json`.
     }
 ```
 
+Alternatively, you can run:
+```sh
+ng set defaults.schematics.collection=@ngrx/schematics
+```
+
 The [collection schema](../../modules/schematics/collection.json) also has aliases to the most common blueprints used to generate files.
 
 ## Initial State Setup

--- a/docs/schematics/README.md
+++ b/docs/schematics/README.md
@@ -35,15 +35,8 @@ After installing `@ngrx/schematics`, install the NgRx dependencies.
 ## Default Schematics Collection
 
 To use `@ngrx/schematics` as the default collection in your Angular CLI project,
-add the following to the `defaults` section in your `.angular-cli.json`.
+add it to your `.angular-cli.json`:
 
-```json
-    "schematics": {
-      "collection": "@ngrx/schematics"
-    }
-```
-
-Alternatively, you can run:
 ```sh
 ng set defaults.schematics.collection=@ngrx/schematics
 ```


### PR DESCRIPTION
Instead of editing the `.angular-cli.json` manually, you can run `ng set`. This is also used when setting up the `@angular/service-worker`.