### PR TITLE
Updated README for a simple Typo

### DIFF
--- a/docs/schematics/README.md
+++ b/docs/schematics/README.md
@@ -19,7 +19,7 @@ Install @ngrx/schematics from npm:
 
 ##### OR
 
-`yarn add github:ngrx/entity-builds --dev`
+`yarn add github:ngrx/schematics-builds --dev`
 
 ## Dependencies
 


### PR DESCRIPTION
Line no 22 => Replaced entity with schematics.
This is a simple typo by the previous person. I think he copied the README from the @ngrx/entity README. :-).