### PR TITLE
fix(Store): only default to initialValue when store value is undefined

### DIFF
--- a/modules/store/src/reducer_manager.ts
+++ b/modules/store/src/reducer_manager.ts
@@ -43,7 +43,7 @@ export class ReducerManager extends BehaviorSubject<ActionReducer<any, any>>
       typeof reducers === 'function'
         ? (state: any, action: any) =>
             createFeatureReducer(reducers, metaReducers)(
-              state || initialState,
+              state === undefined ? initialState : state,
               action
             )
         : createReducerFactory(reducerFactory, metaReducers)(

--- a/modules/store/src/utils.ts
+++ b/modules/store/src/utils.ts
@@ -27,7 +27,7 @@ export function combineReducers(
   const finalReducerKeys = Object.keys(finalReducers);
 
   return function combination(state, action) {
-    state = state || initialState;
+    state = state === undefined ? initialState : state;
     let hasChanged = false;
     const nextState: any = {};
     for (let i = 0; i < finalReducerKeys.length; i++) {


### PR DESCRIPTION
This assumes the store will only have an `undefined` state on initialization and sets the `initialSate` at that time. If the store state ever becomes `undefined` again in the future it will be reset to the `initialState` again.  This basically means `initialState` is more of a "default state" then "initial", but this at least improves it to be an undefined-check instead of falsey-check.  If we wanted to change this to be more strictly an "initial" state then this change would grow quite a bit.

For example if you add the following diff to the tests weird things occur:
```
@@ -74,8 +74,8 @@ describe('ngRx Store', () => {
       store = TestBed.get(Store);
       dispatcher = TestBed.get(ActionsSubject);
 
-      const actionSequence = '--a--b--c--d--e--f--g';
+      const actionSequence = '--a--b--c--d--e--f--g--h';
       const actionValues = {
         a: { type: INCREMENT },
         b: { type: 'OTHER' },
@@ -84,6 +84,7 @@ describe('ngRx Store', () => {
         e: { type: INCREMENT },
         f: { type: INCREMENT },
+        g: { type: CLEAR },   //set state to undefined
+        h: { type: 'OTHER' }, //reproduces https://github.com/ngrx/platform/issues/880
       };
       const counterSteps = hot(actionSequence, actionValues);
       counterSteps.subscribe(action => store.dispatch(action));
```