### PR TITLE
refactor(Store): avoid createFeatureReducer being invoked per-action

### DIFF
--- a/modules/store/spec/utils.spec.ts
+++ b/modules/store/spec/utils.spec.ts
@@ -1,4 +1,4 @@
-import { omit, createFeatureReducer } from '../src/utils';
+import { omit, createFeatureReducerFactory } from '../src/utils';
 import { combineReducers, compose } from '@ngrx/store';
 
 describe(`Store utils`, () => {
@@ -74,17 +74,18 @@ describe(`Store utils`, () => {
     });
   });
 
-  describe('createFeatureReducer()', () => {
-    it('should compose a reducer from the provided meta reducers', () => {
+  describe('createFeatureReducerFactory()', () => {
+    it('should compose a reducer factory from the provided meta reducers', () => {
       const metaReducer = jasmine
         .createSpy('metaReducer')
         .and.callFake(red => (s: any, a: any) => red(s, a));
       const reducer = (state: any, action: any) => state;
 
-      const featureReducer = createFeatureReducer(reducer, [metaReducer]);
-
+      const featureReducerFactory = createFeatureReducerFactory([metaReducer]);
       const initialState = 1;
-      const state = featureReducer(initialState, undefined);
+      const featureReducer = featureReducerFactory(reducer, initialState);
+
+      const state = featureReducer(undefined, <any>undefined);
 
       expect(metaReducer).toHaveBeenCalled();
       expect(state).toBe(initialState);

--- a/modules/store/src/reducer_manager.ts
+++ b/modules/store/src/reducer_manager.ts
@@ -10,7 +10,11 @@ import {
   StoreFeature,
 } from './models';
 import { INITIAL_STATE, INITIAL_REDUCERS, REDUCER_FACTORY } from './tokens';
-import { omit, createReducerFactory, createFeatureReducer } from './utils';
+import {
+  omit,
+  createReducerFactory,
+  createFeatureReducerFactory,
+} from './utils';
 import { ActionsSubject } from './actions_subject';
 
 export abstract class ReducerObservable extends Observable<
@@ -41,11 +45,7 @@ export class ReducerManager extends BehaviorSubject<ActionReducer<any, any>>
   }: StoreFeature<any, any>) {
     const reducer =
       typeof reducers === 'function'
-        ? (state: any, action: any) =>
-            createFeatureReducer(reducers, metaReducers)(
-              state === undefined ? initialState : state,
-              action
-            )
+        ? createFeatureReducerFactory(metaReducers)(reducers, initialState)
         : createReducerFactory(reducerFactory, metaReducers)(
             reducers,
             initialState

--- a/modules/store/src/utils.ts
+++ b/modules/store/src/utils.ts
@@ -97,13 +97,20 @@ export function createReducerFactory<T, V extends Action = Action>(
   return reducerFactory;
 }
 
-export function createFeatureReducer<T, V extends Action = Action>(
-  reducer: ActionReducer<T, V>,
+export function createFeatureReducerFactory<T, V extends Action = Action>(
   metaReducers?: MetaReducer<T, V>[]
-): ActionReducer<T, V> {
-  if (Array.isArray(metaReducers) && metaReducers.length > 0) {
-    return compose<ActionReducer<T, V>>(...metaReducers)(reducer);
-  }
+): (reducer: ActionReducer<T, V>, initialState?: T) => ActionReducer<T, V> {
+  const reducerFactory =
+    Array.isArray(metaReducers) && metaReducers.length > 0
+      ? compose<ActionReducer<T, V>>(...metaReducers)
+      : (r: ActionReducer<T, V>) => r;
 
-  return reducer;
+  return (reducer: ActionReducer<T, V>, initialState?: T) => {
+    reducer = reducerFactory(reducer);
+
+    return (state: T | undefined, action: V) => {
+      state = state === undefined ? initialState : state;
+      return reducer(state, action);
+    };
+  };
 }


### PR DESCRIPTION
I noticed this while doing #886. `createFeatureReducer` was being invoked for each action. In some cases (when `metaReducers` exist) this would invoke `compose` and create a new composed method for each action.

This also changes `createFeatureReducer` to `createFeatureReducerFactory` more like `createReducerFactory`. This could potentially be undone to simplify this PR, but I thought the end result (the two methods being more alike) was better.

However... I think the better solution would be changing the `ActionReducerFactory` `reducerMap` argument from `ActionReducerMap<T, V>` to `ActionReducerMap<T, V> | ActionReducer<T, V>`. Then this `createFeatureReducer` method can be dropped and the reducer vs map of reducers code paths would be combined into one. Things like the `initialValue` logic would no longer be in two places ([a](https://github.com/ngrx/platform/commit/8deffc3dd8dc0932efb8626fc1926ebfd0fac95b#diff-46ac3744db99c69c50de39d2dc253e37R46), [b](https://github.com/ngrx/platform/commit/8deffc3dd8dc0932efb8626fc1926ebfd0fac95b#diff-b1befd0d816408efc33272e96ede4a4aR30)). But I think such a change to `ActionReducerFactory` would be a breaking API change...?