### PR TITLE
feat(Entity): Add 'selectId' and 'sortComparer' to state adapter

### DIFF
--- a/modules/entity/src/create_adapter.ts
+++ b/modules/entity/src/create_adapter.ts
@@ -29,6 +29,8 @@ export function createEntityAdapter<T>(
     : createUnsortedStateAdapter(selectId);
 
   return {
+    selectId,
+    sortComparer,
     ...stateFactory,
     ...selectorsFactory,
     ...stateAdapter,

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -76,6 +76,8 @@ export type EntitySelectors<T, V> = {
 };
 
 export interface EntityAdapter<T> extends EntityStateAdapter<T> {
+  selectId: IdSelector<T>;
+  sortComparer: false | Comparer<T>;
   getInitialState(): EntityState<T>;
   getInitialState<S extends object>(state: S): EntityState<T> & S;
   getSelectors(): EntitySelectors<T, EntityState<T>>;


### PR DESCRIPTION
When building tools on top of @ngrx/entity it can be helpful to have access to the resolved `selectId` and `sortComparer` functions.