### PR TITLE
feat(Effects): Add support for effects inheritance from parent classes.

### DIFF
--- a/modules/effects/spec/effects_metadata.spec.ts
+++ b/modules/effects/spec/effects_metadata.spec.ts
@@ -35,6 +35,46 @@ describe('Effect Metadata', () => {
 
       expect(getSourceMetadata(mock)).toEqual([]);
     });
+
+    it('should get the effects metadata for class instance including metadata from parent classes', () => {
+      class AbstractFixture {
+        @Effect() a: any;
+        @Effect() b: any;
+        @Effect({ dispatch: false })
+        c: any;
+      }
+      class Fixture extends AbstractFixture {
+        d: any;
+        e: any;
+      }
+      class SubFixture extends Fixture {
+        @Effect() f: any;
+        @Effect({ dispatch: false })
+        g: any;
+      }
+
+      const mock1 = new AbstractFixture();
+      const mock2 = new Fixture();
+      const mock3 = new SubFixture();
+
+      expect(getSourceMetadata(mock1)).toEqual([
+        { propertyName: 'a', dispatch: true },
+        { propertyName: 'b', dispatch: true },
+        { propertyName: 'c', dispatch: false },
+      ]);
+      expect(getSourceMetadata(mock2)).toEqual([
+        { propertyName: 'a', dispatch: true },
+        { propertyName: 'b', dispatch: true },
+        { propertyName: 'c', dispatch: false },
+      ]);
+      expect(getSourceMetadata(mock3)).toEqual([
+        { propertyName: 'a', dispatch: true },
+        { propertyName: 'b', dispatch: true },
+        { propertyName: 'c', dispatch: false },
+        { propertyName: 'f', dispatch: true },
+        { propertyName: 'g', dispatch: false },
+      ]);
+    });
   });
 
   describe('getSourceProto', () => {

--- a/modules/effects/src/effects_metadata.ts
+++ b/modules/effects/src/effects_metadata.ts
@@ -11,8 +11,22 @@ export interface EffectMetadata {
   dispatch: boolean;
 }
 
-function getEffectMetadataEntries(sourceProto: any): EffectMetadata[] {
-  return sourceProto.constructor[METADATA_KEY] || [];
+function getEffectMetadataEntries(
+  sourceProto: any,
+  entries: EffectMetadata[] = []
+): EffectMetadata[] {
+  if (!sourceProto) return entries;
+
+  const parent = Object.getPrototypeOf(sourceProto);
+
+  if (!sourceProto.constructor.hasOwnProperty(METADATA_KEY)) {
+    return getEffectMetadataEntries(parent, entries);
+  }
+
+  return getEffectMetadataEntries(
+    parent,
+    sourceProto.constructor[METADATA_KEY].concat(entries)
+  );
 }
 
 function setEffectMetadataEntries(sourceProto: any, entries: EffectMetadata[]) {


### PR DESCRIPTION
I was trying to implement some abstraction for effects components, but faced some confusing behaviour: inherited class could pick up parent's class `@Effect` decorators only in case of you do not have any in the child one. Also the `setEffectMetadataEntries` method is performing properly and assigns metadata to all the parent and child class properties. So, I think it's worth to add the same behaviour for `getEffectMetadataEntries`.

The solution is quite simple and straightforward and does not change existing API. 