### PR TITLE
generate named umd bundles

### DIFF
--- a/build/tasks.ts
+++ b/build/tasks.ts
@@ -116,7 +116,11 @@ export async function createUmdBundles(config: Config) {
 
     const destinationName = util.getDestinationName(pkg);
 
-    const rollupArgs = [`-c ./modules/${pkg}/rollup.config.js`, `--sourcemap`];
+    const rollupArgs = [
+      `-c ./modules/${pkg}/rollup.config.js`,
+      `--sourcemap`,
+      `--amd.id ${config.scope}/${pkg}`,
+    ];
 
     await util.exec('rollup', rollupArgs);
     await util.mapSources(


### PR DESCRIPTION
Submitting a PR to generate named umd bundles for ngrx.

The motivation is to make ngrx bundles compatible with the Bazel dev server used in the sample here: https://github.com/alexeagle/angular-bazel-example

cc: @alexeagle 