### PR TITLE
fix(RouterStore): change the default serializer to work around cycles in RouterStateSnapshot

### DIFF
--- a/modules/router-store/src/serializer.ts
+++ b/modules/router-store/src/serializer.ts
@@ -1,13 +1,47 @@
-import { InjectionToken } from '@angular/core';
-import { RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 
 export abstract class RouterStateSerializer<T> {
   abstract serialize(routerState: RouterStateSnapshot): T;
 }
 
+export interface SerializedRouterStateSnapshot {
+  root: ActivatedRouteSnapshot;
+  url: string;
+}
+
 export class DefaultRouterStateSerializer
-  implements RouterStateSerializer<RouterStateSnapshot> {
-  serialize(routerState: RouterStateSnapshot) {
-    return routerState;
+  implements RouterStateSerializer<SerializedRouterStateSnapshot> {
+  serialize(routerState: RouterStateSnapshot): SerializedRouterStateSnapshot {
+    return {
+      root: this.serializeRoute(routerState.root),
+      url: routerState.url,
+    };
+  }
+
+  private serializeRoute(
+    route: ActivatedRouteSnapshot
+  ): ActivatedRouteSnapshot {
+    const children = route.children.map(c => this.serializeRoute(c));
+    return {
+      params: route.params,
+      paramMap: route.paramMap,
+      data: route.data,
+      url: route.url,
+      outlet: route.outlet,
+      routeConfig: {
+        component: route.routeConfig ? route.routeConfig.component : undefined,
+      },
+      queryParams: route.queryParams,
+      queryParamMap: route.queryParamMap,
+      fragment: route.fragment,
+      component: (route.routeConfig
+        ? route.routeConfig.component
+        : undefined) as any,
+      root: undefined as any,
+      parent: undefined as any,
+      firstChild: children[0],
+      pathFromRoot: undefined as any,
+      children,
+    };
   }
 }

--- a/modules/store/src/reducer_manager.ts
+++ b/modules/store/src/reducer_manager.ts
@@ -72,7 +72,10 @@ export class ReducerManager extends BehaviorSubject<ActionReducer<any, any>>
 
   private updateReducers(key: string) {
     this.next(this.reducerFactory(this.reducers, this.initialState));
-    this.dispatcher.next(<Action & {feature: string}>{ type: UPDATE, feature: key });
+    this.dispatcher.next(<Action & { feature: string }>{
+      type: UPDATE,
+      feature: key,
+    });
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
RouterStateSnapshot contains cycles, which means that the default serializer doesn't work with the devtools.

This serializer implements a work around for the issue.