### PR TITLE
Include Stackblitz in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Reactive libraries for Angular
 - [@ngrx/schematics](./docs/schematics/README.md) - Scaffolding library for Angular applications using NgRx.
 
 ## Examples
-- [example-app](./example-app/README.md) - Example application utilizing @ngrx libraries, showcasing common patterns and best practices.
+- [example-app](./example-app/README.md) - Example application utilizing @ngrx libraries, showcasing common patterns and best practices.  Try it on [StackBlitz](https://stackblitz.com/github/ngrx/platform/).
 
 ## Migration
 - [Migration guide](./MIGRATION.md) for users of ngrx packages prior to 4.x.

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -46,3 +46,7 @@ Navigate to [http://localhost:4200/](http://localhost:4200/) in your browser. To
 
 _NOTE:_ The above setup instructions assume you have added local npm bin folders to your path.
 If this is not the case you will need to install the Angular CLI globally.
+
+### Try it on StackBlitz
+
+Try the example-app on [StackBlitz](https://stackblitz.com/github/ngrx/platform/).


### PR DESCRIPTION
Fixes #827 

ngrx/platform was incompatible with StackBlitz due to issues building the @ngrx/schematics package.
Reached out to [@ericsimon](https://github.com/EricSimons) who put in a hotfix. ngrx/platform is now compatible: https://stackblitz.com/github/ngrx/platform/

Added links to the StackBlitz in the platform and example-app READMEs.