### PR TITLE
feat(Entity): add updateMany by predicate

### DIFF
--- a/modules/entity/spec/sorted_state_adapter.spec.ts
+++ b/modules/entity/spec/sorted_state_adapter.spec.ts
@@ -316,7 +316,7 @@ describe('Sorted State Adapter', () => {
     );
 
     const withUpdates = adapter.updateMany(
-      { predicate: p => p.id.startsWith('a'), changes: change },
+      book => (book.id.startsWith('a') ? change : {}),
       withMany
     );
 

--- a/modules/entity/spec/sorted_state_adapter.spec.ts
+++ b/modules/entity/spec/sorted_state_adapter.spec.ts
@@ -280,7 +280,7 @@ describe('Sorted State Adapter', () => {
     });
   });
 
-  it('should let you update many entities in the state', () => {
+  it('should let you update many entities by id in the state', () => {
     const firstChange = { title: 'Zack' };
     const secondChange = { title: 'Aaron' };
     const withMany = adapter.addAll([TheGreatGatsby, AClockworkOrange], state);
@@ -304,6 +304,34 @@ describe('Sorted State Adapter', () => {
           ...AClockworkOrange,
           ...secondChange,
         },
+      },
+    });
+  });
+
+  it('should let you update many entities by predicate in the state', () => {
+    const change = { title: 'Changed titled' };
+    const withMany = adapter.addAll(
+      [TheGreatGatsby, AClockworkOrange, AnimalFarm],
+      state
+    );
+
+    const withUpdates = adapter.updateMany(
+      { predicate: p => p.id.startsWith('a'), changes: change },
+      withMany
+    );
+
+    expect(withUpdates).toEqual({
+      ids: [AClockworkOrange.id, AnimalFarm.id, TheGreatGatsby.id],
+      entities: {
+        [AClockworkOrange.id]: {
+          ...AClockworkOrange,
+          ...change,
+        },
+        [AnimalFarm.id]: {
+          ...AnimalFarm,
+          ...change,
+        },
+        [TheGreatGatsby.id]: TheGreatGatsby,
       },
     });
   });

--- a/modules/entity/spec/sorted_state_adapter.spec.ts
+++ b/modules/entity/spec/sorted_state_adapter.spec.ts
@@ -308,20 +308,22 @@ describe('Sorted State Adapter', () => {
     });
   });
 
-  it('should let you update many entities by predicate in the state', () => {
-    const firstChange = { title: 'First change' };
-    const secondChange = { title: 'Second change' };
+  it('should let you map over entities in the state', () => {
+    const firstChange = { ...TheGreatGatsby, title: 'First change' };
+    const secondChange = { ...AClockworkOrange, title: 'Second change' };
 
     const withMany = adapter.addAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
 
-    const withUpdates = adapter.updateMany(
+    const withUpdates = adapter.map(
       book =>
         book.title === TheGreatGatsby.title
           ? firstChange
-          : book.title === AClockworkOrange.title ? secondChange : false,
+          : book.title === AClockworkOrange.title
+            ? secondChange
+            : book,
       withMany
     );
 

--- a/modules/entity/spec/sorted_state_adapter.spec.ts
+++ b/modules/entity/spec/sorted_state_adapter.spec.ts
@@ -309,29 +309,34 @@ describe('Sorted State Adapter', () => {
   });
 
   it('should let you update many entities by predicate in the state', () => {
-    const change = { title: 'Changed titled' };
+    const firstChange = { title: 'First change' };
+    const secondChange = { title: 'Second change' };
+
     const withMany = adapter.addAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
 
     const withUpdates = adapter.updateMany(
-      book => (book.id.startsWith('a') ? change : {}),
+      book =>
+        book.title === TheGreatGatsby.title
+          ? firstChange
+          : book.title === AClockworkOrange.title ? secondChange : false,
       withMany
     );
 
     expect(withUpdates).toEqual({
-      ids: [AClockworkOrange.id, AnimalFarm.id, TheGreatGatsby.id],
+      ids: [AnimalFarm.id, TheGreatGatsby.id, AClockworkOrange.id],
       entities: {
+        [AnimalFarm.id]: AnimalFarm,
+        [TheGreatGatsby.id]: {
+          ...TheGreatGatsby,
+          ...firstChange,
+        },
         [AClockworkOrange.id]: {
           ...AClockworkOrange,
-          ...change,
+          ...secondChange,
         },
-        [AnimalFarm.id]: {
-          ...AnimalFarm,
-          ...change,
-        },
-        [TheGreatGatsby.id]: TheGreatGatsby,
       },
     });
   });

--- a/modules/entity/spec/unsorted_state_adapter.spec.ts
+++ b/modules/entity/spec/unsorted_state_adapter.spec.ts
@@ -248,20 +248,22 @@ describe('Unsorted State Adapter', () => {
     });
   });
 
-  it('should let you update many entities by predicate in the state', () => {
-    const firstChange = { title: 'First change' };
-    const secondChange = { title: 'Second change' };
+  it('should let you map over entities in the state', () => {
+    const firstChange = { ...TheGreatGatsby, title: 'First change' };
+    const secondChange = { ...AClockworkOrange, title: 'Second change' };
 
     const withMany = adapter.addAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
 
-    const withUpdates = adapter.updateMany(
+    const withUpdates = adapter.map(
       book =>
         book.title === TheGreatGatsby.title
           ? firstChange
-          : book.title === AClockworkOrange.title ? secondChange : false,
+          : book.title === AClockworkOrange.title
+            ? secondChange
+            : book,
       withMany
     );
 

--- a/modules/entity/spec/unsorted_state_adapter.spec.ts
+++ b/modules/entity/spec/unsorted_state_adapter.spec.ts
@@ -258,7 +258,10 @@ describe('Unsorted State Adapter', () => {
     );
 
     const withUpdates = adapter.updateMany(
-      book => (book.id.startsWith('a') ? firstChange : secondChange),
+      book =>
+        book.title === TheGreatGatsby.title
+          ? firstChange
+          : book.title === AClockworkOrange.title ? secondChange : false,
       withMany
     );
 
@@ -267,16 +270,13 @@ describe('Unsorted State Adapter', () => {
       entities: {
         [TheGreatGatsby.id]: {
           ...TheGreatGatsby,
-          ...secondChange,
+          ...firstChange,
         },
         [AClockworkOrange.id]: {
           ...AClockworkOrange,
-          ...firstChange,
+          ...secondChange,
         },
-        [AnimalFarm.id]: {
-          ...AnimalFarm,
-          ...firstChange,
-        },
+        [AnimalFarm.id]: AnimalFarm,
       },
     });
   });

--- a/modules/entity/spec/unsorted_state_adapter.spec.ts
+++ b/modules/entity/spec/unsorted_state_adapter.spec.ts
@@ -220,7 +220,7 @@ describe('Unsorted State Adapter', () => {
     });
   });
 
-  it('should let you update many entities in the state', () => {
+  it('should let you update many entities by id in the state', () => {
     const firstChange = { title: 'First Change' };
     const secondChange = { title: 'Second Change' };
     const withMany = adapter.addAll([TheGreatGatsby, AClockworkOrange], state);
@@ -243,6 +243,34 @@ describe('Unsorted State Adapter', () => {
         [AClockworkOrange.id]: {
           ...AClockworkOrange,
           ...secondChange,
+        },
+      },
+    });
+  });
+
+  it('should let you update many entities by predicate in the state', () => {
+    const change = { title: 'Changed titled' };
+    const withMany = adapter.addAll(
+      [TheGreatGatsby, AClockworkOrange, AnimalFarm],
+      state
+    );
+
+    const withUpdates = adapter.updateMany(
+      { predicate: p => p.id.startsWith('a'), changes: change },
+      withMany
+    );
+
+    expect(withUpdates).toEqual({
+      ids: [TheGreatGatsby.id, AClockworkOrange.id, AnimalFarm.id],
+      entities: {
+        [TheGreatGatsby.id]: TheGreatGatsby,
+        [AClockworkOrange.id]: {
+          ...AClockworkOrange,
+          ...change,
+        },
+        [AnimalFarm.id]: {
+          ...AnimalFarm,
+          ...change,
         },
       },
     });

--- a/modules/entity/spec/unsorted_state_adapter.spec.ts
+++ b/modules/entity/spec/unsorted_state_adapter.spec.ts
@@ -249,28 +249,33 @@ describe('Unsorted State Adapter', () => {
   });
 
   it('should let you update many entities by predicate in the state', () => {
-    const change = { title: 'Changed titled' };
+    const firstChange = { title: 'First change' };
+    const secondChange = { title: 'Second change' };
+
     const withMany = adapter.addAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
 
     const withUpdates = adapter.updateMany(
-      { predicate: p => p.id.startsWith('a'), changes: change },
+      book => (book.id.startsWith('a') ? firstChange : secondChange),
       withMany
     );
 
     expect(withUpdates).toEqual({
       ids: [TheGreatGatsby.id, AClockworkOrange.id, AnimalFarm.id],
       entities: {
-        [TheGreatGatsby.id]: TheGreatGatsby,
+        [TheGreatGatsby.id]: {
+          ...TheGreatGatsby,
+          ...secondChange,
+        },
         [AClockworkOrange.id]: {
           ...AClockworkOrange,
-          ...change,
+          ...firstChange,
         },
         [AnimalFarm.id]: {
           ...AnimalFarm,
-          ...change,
+          ...firstChange,
         },
       },
     });

--- a/modules/entity/src/index.ts
+++ b/modules/entity/src/index.ts
@@ -1,2 +1,9 @@
 export { createEntityAdapter } from './create_adapter';
-export { Dictionary, EntityState, EntityAdapter, Update } from './models';
+export {
+  Dictionary,
+  EntityState,
+  EntityAdapter,
+  Update,
+  EntityMap,
+  Predicate,
+} from './models';

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -30,11 +30,7 @@ export type Update<T> = UpdateStr<T> | UpdateNum<T>;
 
 export type Predicate<T> = (entity: T) => boolean;
 
-export type UpdateMap<T> = {
-  (entity: T): Partial<T> | false;
-};
-
-export type Map<T> = (entity: T) => T;
+export type EntityMap<T> = (entity: T) => T;
 
 export interface EntityState<T> {
   ids: string[] | number[];
@@ -62,10 +58,11 @@ export interface EntityStateAdapter<T> {
 
   updateOne<S extends EntityState<T>>(update: Update<T>, state: S): S;
   updateMany<S extends EntityState<T>>(updates: Update<T>[], state: S): S;
-  updateMany<S extends EntityState<T>>(map: UpdateMap<T>, state: S): S;
 
   upsertOne<S extends EntityState<T>>(entity: T, state: S): S;
   upsertMany<S extends EntityState<T>>(entities: T[], state: S): S;
+
+  map<S extends EntityState<T>>(map: EntityMap<T>, state: S): S;
 }
 
 export interface EntitySelectors<T, V> {

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -35,9 +35,7 @@ export type UpdatePredicate<T> = {
   changes: Partial<T>;
 };
 
-export type Change<T> = {
-  (entity: T): Partial<T>;
-};
+export type Map<T> = (entity: T) => T;
 
 export interface EntityState<T> {
   ids: string[] | number[];
@@ -65,7 +63,7 @@ export interface EntityStateAdapter<T> {
 
   updateOne<S extends EntityState<T>>(update: Update<T>, state: S): S;
   updateMany<S extends EntityState<T>>(updates: Update<T>[], state: S): S;
-  updateMany<S extends EntityState<T>>(change: Change<T>, state: S): S;
+  updateMany<S extends EntityState<T>>(map: Map<T>, state: S): S;
 
   upsertOne<S extends EntityState<T>>(entity: T, state: S): S;
   upsertMany<S extends EntityState<T>>(entities: T[], state: S): S;

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -30,6 +30,11 @@ export type Update<T> = UpdateStr<T> | UpdateNum<T>;
 
 export type Predicate<T> = (entity: T) => boolean;
 
+export type UpdatePredicate<T> = {
+  predicate: Predicate<T>;
+  changes: Partial<T>;
+};
+
 export interface EntityState<T> {
   ids: string[] | number[];
   entities: Dictionary<T>;
@@ -56,6 +61,7 @@ export interface EntityStateAdapter<T> {
 
   updateOne<S extends EntityState<T>>(update: Update<T>, state: S): S;
   updateMany<S extends EntityState<T>>(updates: Update<T>[], state: S): S;
+  updateMany<S extends EntityState<T>>(update: UpdatePredicate<T>, state: S): S;
 
   upsertOne<S extends EntityState<T>>(entity: T, state: S): S;
   upsertMany<S extends EntityState<T>>(entities: T[], state: S): S;

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -65,7 +65,7 @@ export interface EntityStateAdapter<T> {
 
   updateOne<S extends EntityState<T>>(update: Update<T>, state: S): S;
   updateMany<S extends EntityState<T>>(updates: Update<T>[], state: S): S;
-  updateMany<S extends EntityState<T>>(update: Change<T>, state: S): S;
+  updateMany<S extends EntityState<T>>(change: Change<T>, state: S): S;
 
   upsertOne<S extends EntityState<T>>(entity: T, state: S): S;
   upsertMany<S extends EntityState<T>>(entities: T[], state: S): S;

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -35,6 +35,10 @@ export type UpdatePredicate<T> = {
   changes: Partial<T>;
 };
 
+export type Change<T> = {
+  (entity: T): Partial<T>;
+};
+
 export interface EntityState<T> {
   ids: string[] | number[];
   entities: Dictionary<T>;
@@ -61,7 +65,7 @@ export interface EntityStateAdapter<T> {
 
   updateOne<S extends EntityState<T>>(update: Update<T>, state: S): S;
   updateMany<S extends EntityState<T>>(updates: Update<T>[], state: S): S;
-  updateMany<S extends EntityState<T>>(update: UpdatePredicate<T>, state: S): S;
+  updateMany<S extends EntityState<T>>(update: Change<T>, state: S): S;
 
   upsertOne<S extends EntityState<T>>(entity: T, state: S): S;
   upsertMany<S extends EntityState<T>>(entities: T[], state: S): S;

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -30,9 +30,8 @@ export type Update<T> = UpdateStr<T> | UpdateNum<T>;
 
 export type Predicate<T> = (entity: T) => boolean;
 
-export type UpdatePredicate<T> = {
-  predicate: Predicate<T>;
-  changes: Partial<T>;
+export type UpdateMap<T> = {
+  (entity: T): Partial<T> | false;
 };
 
 export type Map<T> = (entity: T) => T;
@@ -63,7 +62,7 @@ export interface EntityStateAdapter<T> {
 
   updateOne<S extends EntityState<T>>(update: Update<T>, state: S): S;
   updateMany<S extends EntityState<T>>(updates: Update<T>[], state: S): S;
-  updateMany<S extends EntityState<T>>(map: Map<T>, state: S): S;
+  updateMany<S extends EntityState<T>>(map: UpdateMap<T>, state: S): S;
 
   upsertOne<S extends EntityState<T>>(entity: T, state: S): S;
   upsertMany<S extends EntityState<T>>(entities: T[], state: S): S;

--- a/modules/entity/src/sorted_state_adapter.ts
+++ b/modules/entity/src/sorted_state_adapter.ts
@@ -5,7 +5,7 @@ import {
   Dictionary,
   EntityStateAdapter,
   Update,
-  Change,
+  Map,
 } from './models';
 import { createStateOperator, DidMutate } from './state_adapter';
 import { createUnsortedStateAdapter } from './unsorted_state_adapter';
@@ -74,18 +74,15 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
   }
 
   function updateManyMutably(updates: Update<T>[], state: R): DidMutate;
-  function updateManyMutably(change: Change<T>, state: R): DidMutate;
-  function updateManyMutably(
-    updatesOrChange: any[] | any,
-    state: any
-  ): DidMutate {
+  function updateManyMutably(map: Map<T>, state: R): DidMutate;
+  function updateManyMutably(updatesOrMap: any[] | any, state: any): DidMutate {
     const models: T[] = [];
     const updates: Update<T>[] =
-      updatesOrChange instanceof Array
-        ? updatesOrChange
+      updatesOrMap instanceof Array
+        ? updatesOrMap
         : state.ids.map((id: string | number) => ({
             id,
-            changes: updatesOrChange(state.entities[id]),
+            changes: updatesOrMap(state.entities[id]),
           }));
 
     const didMutateIds =

--- a/modules/entity/src/sorted_state_adapter.ts
+++ b/modules/entity/src/sorted_state_adapter.ts
@@ -86,10 +86,10 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
       return updatesOrPredicate;
     } else {
       const { predicate, changes } = updatesOrPredicate;
-      const idsdToChange = state.ids.filter((key: string | number) =>
-        predicate(state.entities[key])
+      const idsToChange = state.ids.filter((id: string | number) =>
+        predicate(state.entities[id])
       );
-      return idsdToChange.map((id: string | number) => ({ id, changes }));
+      return idsToChange.map((id: string | number) => ({ id, changes }));
     }
   }
 

--- a/modules/entity/src/sorted_state_adapter.ts
+++ b/modules/entity/src/sorted_state_adapter.ts
@@ -80,16 +80,10 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
     const updates: Update<T>[] =
       updatesOrMap instanceof Array
         ? updatesOrMap
-        : state.ids.reduce((changes: Update<T>[], id: string | number) => {
+        : state.ids.reduce((changes: any[], id: string | number) => {
             const change = updatesOrMap(state.entities[id]);
             if (change && Object.keys(change).length > 0) {
-              return [
-                ...changes,
-                {
-                  id,
-                  changes: change,
-                },
-              ];
+              changes.push({ id, changes: change });
             }
             return changes;
           }, []);

--- a/modules/entity/src/sorted_state_adapter.ts
+++ b/modules/entity/src/sorted_state_adapter.ts
@@ -73,20 +73,6 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
     return newKey !== update.id;
   }
 
-  function decideIdsToUpdate(updates: Update<T>[], state: R): Update<T>[];
-  function decideIdsToUpdate(change: Change<T>, state: R): Update<T>[];
-  function decideIdsToUpdate(updatesOrChange: any[] | any, state: any): any[] {
-    if (updatesOrChange instanceof Array) {
-      return updatesOrChange;
-    } else {
-      const changes = state.ids.map((id: string | number) => ({
-        id,
-        changes: updatesOrChange(state.entities[id]),
-      }));
-      return changes;
-    }
-  }
-
   function updateManyMutably(updates: Update<T>[], state: R): DidMutate;
   function updateManyMutably(change: Change<T>, state: R): DidMutate;
   function updateManyMutably(
@@ -94,7 +80,13 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
     state: any
   ): DidMutate {
     const models: T[] = [];
-    const updates = decideIdsToUpdate(updatesOrChange, state);
+    const updates: Update<T>[] =
+      updatesOrChange instanceof Array
+        ? updatesOrChange
+        : state.ids.map((id: string | number) => ({
+            id,
+            changes: updatesOrChange(state.entities[id]),
+          }));
 
     const didMutateIds =
       updates.filter(update => takeUpdatedModel(models, update, state)).length >

--- a/modules/entity/src/sorted_state_adapter.ts
+++ b/modules/entity/src/sorted_state_adapter.ts
@@ -82,7 +82,7 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
         ? updatesOrMap
         : state.ids.reduce((changes: Update<T>[], id: string | number) => {
             const change = updatesOrMap(state.entities[id]);
-            if (change) {
+            if (change && Object.keys(change).length > 0) {
               return [
                 ...changes,
                 {

--- a/modules/entity/src/state_adapter.ts
+++ b/modules/entity/src/state_adapter.ts
@@ -1,4 +1,4 @@
-import { EntityState, EntityStateAdapter } from './models';
+import { EntityState } from './models';
 
 export enum DidMutate {
   EntitiesOnly,

--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -125,7 +125,7 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
         ? updatesOrMap
         : state.ids.reduce((changes: Update<T>[], id: string | number) => {
             const change = updatesOrMap(state.entities[id]);
-            if (change) {
+            if (change && Object.keys(change).length > 0) {
               return [
                 ...changes,
                 {

--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -112,20 +112,6 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
     return hasNewKey;
   }
 
-  function decideIdsToUpdate(updates: Update<T>[], state: R): Update<T>[];
-  function decideIdsToUpdate(change: Change<T>, state: R): Update<T>[];
-  function decideIdsToUpdate(updatesOrChange: any[] | any, state: any): any[] {
-    if (updatesOrChange instanceof Array) {
-      return updatesOrChange;
-    } else {
-      const changes = state.ids.map((id: string | number) => ({
-        id,
-        changes: updatesOrChange(state.entities[id]),
-      }));
-      return changes;
-    }
-  }
-
   function updateOneMutably(update: Update<T>, state: R): DidMutate;
   function updateOneMutably(update: any, state: any): DidMutate {
     return updateManyMutably([update], state);
@@ -138,9 +124,15 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
     state: any
   ): DidMutate {
     const newKeys: { [id: string]: string } = {};
-    const updates = decideIdsToUpdate(updatesOrChange, state).filter(
-      ({ id }: { id: number | string }) => id in state.entities
-    );
+    const changes: Update<T>[] =
+      updatesOrChange instanceof Array
+        ? updatesOrChange
+        : state.ids.map((id: string | number) => ({
+            id,
+            changes: updatesOrChange(state.entities[id]),
+          }));
+
+    const updates = changes.filter(({ id }) => id in state.entities);
 
     const didMutateEntities = updates.length > 0;
 

--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -124,10 +124,10 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
       return updatesOrPredicate;
     } else {
       const { predicate, changes } = updatesOrPredicate;
-      const idsdToChange = state.ids.filter((key: string | number) =>
-        predicate(state.entities[key])
+      const idsToChange = state.ids.filter((id: string | number) =>
+        predicate(state.entities[id])
       );
-      return idsdToChange.map((id: string | number) => ({ id, changes }));
+      return idsToChange.map((id: string | number) => ({ id, changes }));
     }
   }
 

--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -5,7 +5,6 @@ import {
   Update,
   Predicate,
   UpdatePredicate,
-  Change,
 } from './models';
 import { createStateOperator, DidMutate } from './state_adapter';
 import { selectIdValue } from './utils';
@@ -118,18 +117,15 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
   }
 
   function updateManyMutably(updates: Update<T>[], state: R): DidMutate;
-  function updateManyMutably(change: Change<T>, state: R): DidMutate;
-  function updateManyMutably(
-    updatesOrChange: any[] | any,
-    state: any
-  ): DidMutate {
+  function updateManyMutably(map: Map<T>, state: R): DidMutate;
+  function updateManyMutably(updatesOrMap: any[] | any, state: any): DidMutate {
     const newKeys: { [id: string]: string } = {};
     const changes: Update<T>[] =
-      updatesOrChange instanceof Array
-        ? updatesOrChange
+      updatesOrMap instanceof Array
+        ? updatesOrMap
         : state.ids.map((id: string | number) => ({
             id,
-            changes: updatesOrChange(state.entities[id]),
+            changes: updatesOrMap(state.entities[id]),
           }));
 
     const updates = changes.filter(({ id }) => id in state.entities);

--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -123,16 +123,10 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
     const changes: Update<T>[] =
       updatesOrMap instanceof Array
         ? updatesOrMap
-        : state.ids.reduce((changes: Update<T>[], id: string | number) => {
+        : state.ids.reduce((changes: any[], id: string | number) => {
             const change = updatesOrMap(state.entities[id]);
             if (change && Object.keys(change).length > 0) {
-              return [
-                ...changes,
-                {
-                  id,
-                  changes: change,
-                },
-              ];
+              changes.push({ id, changes: change });
             }
             return changes;
           }, []);


### PR DESCRIPTION
This PR allows to edit entities based on a predicate.
See #672, in the issue it was mentioned to update the entities via multiple predicates - see my comment as why I don't think thats a good idea. If needed I can implement it that way tho.

I do got one question about the implementation of the sorted state adapter. 
Why does this have an own implementation? 
In my head the sorted adapter should call the unsorted adapter and do the sorting afterwards, but I must be missing someting :sweat_smile: 