### PR TITLE
fix(Store): Handling of @ngrx/store/update-reducers Action on Startup leads to strange behaviour for initialStates

### DIFF
--- a/modules/store/spec/store.spec.ts
+++ b/modules/store/spec/store.spec.ts
@@ -296,7 +296,7 @@ describe('ngRx Store', () => {
       store.removeReducer(key);
       store.dispatch({ type: INCREMENT });
       store.take(1).subscribe(val => {
-        expect(val.counter4).toBeUndefined();
+        expect(val.counter4).toBe(0);
       });
     });
   });

--- a/modules/store/spec/utils.spec.ts
+++ b/modules/store/spec/utils.spec.ts
@@ -41,7 +41,7 @@ describe(`Store utils`, () => {
     it(`should return full initial state of the root when action '@ngrx/store/update-reducers' is running with no initial state`, () => {
       const initialStateForReducer2Only = { reducer2: { y: 'bar' } };
       const combinationForReducer1 = combineReducers(
-        { reducer1 } as any,
+        { reducer1 },
         initialStateForReducer2Only as any
       );
       const updateAction1 = { type: 'state1', payload: 'foo' };

--- a/modules/store/spec/utils.spec.ts
+++ b/modules/store/spec/utils.spec.ts
@@ -45,10 +45,9 @@ describe(`Store utils`, () => {
         initialStateForReducer2Only as any
       );
       const updateAction1 = { type: 'state1', payload: 'foo' };
-      expect(combinationForReducer1(undefined, updateAction1)).toEqual({
-        ...initialState,
-        ...{ reducer2: { y: 'bar' } },
-      });
+      expect(combinationForReducer1(undefined, updateAction1)).toEqual(
+        initialState
+      );
     });
   });
 

--- a/modules/store/spec/utils.spec.ts
+++ b/modules/store/spec/utils.spec.ts
@@ -37,6 +37,19 @@ describe(`Store utils`, () => {
     it(`should return original state if nothing changed`, () => {
       expect(combination(initialState, { type: '' })).toBe(initialState);
     });
+
+    it(`should return full initial state of the root when action '@ngrx/store/update-reducers' is running with no initial state`, () => {
+      const initialStateForReducer2Only = { reducer2: { y: 'bar' } };
+      const combinationForReducer1 = combineReducers(
+        { reducer1 } as any,
+        initialStateForReducer2Only as any
+      );
+      const updateAction1 = { type: 'state1', payload: 'foo' };
+      expect(combinationForReducer1(undefined, updateAction1)).toEqual({
+        ...initialState,
+        ...{ reducer2: { y: 'bar' } },
+      });
+    });
   });
 
   describe(`omit()`, () => {

--- a/modules/store/src/reducer_manager.ts
+++ b/modules/store/src/reducer_manager.ts
@@ -72,7 +72,10 @@ export class ReducerManager extends BehaviorSubject<ActionReducer<any, any>>
 
   private updateReducers(key: string) {
     this.next(this.reducerFactory(this.reducers, this.initialState));
-    this.dispatcher.next(<Action & {feature: string}>{ type: UPDATE, feature: key });
+    this.dispatcher.next(<Action & { feature: string }>{
+      type: UPDATE,
+      feature: key,
+    });
   }
 
   ngOnDestroy() {

--- a/modules/store/src/utils.ts
+++ b/modules/store/src/utils.ts
@@ -39,7 +39,7 @@ export function combineReducers(
       nextState[key] = nextStateForKey;
       hasChanged = hasChanged || nextStateForKey !== previousStateForKey;
     }
-    return hasChanged ? nextState : state;
+    return hasChanged ? { ...state, ...nextState } : state;
   };
 }
 


### PR DESCRIPTION
 - assign the new state to the overall initial state instead of returning the new state only
 - Add test to simulate the following situation:
 	Module MA and MB with initial state IA and IB in module.	
 	Overall initial state RootIAB { IB } with only state of MB being
	initiated.
	When action '@ngrx/store/update-reducers' is fired for MA the RootIAB should be merged with IA so we don't lose the IB initialization in RootIAB.
- Fixed failing test to expect 0 instead of undefined.

Closes #906 