### PR TITLE
Add docs in @ngrx/schematics for Ionic integration

### DIFF
--- a/docs/schematics/README.md
+++ b/docs/schematics/README.md
@@ -5,6 +5,7 @@ Scaffolding library for Angular applications using NgRx libraries.
 @ngrx/schematics provides blueprints for generating files when building out feature areas using NgRx. Built on top of `Schematics`, it integrates with the `Angular CLI` to make setting up and expanding NgRx in Angular applications easier.
 
 ### Installation
+
 Install @ngrx/schematics from npm:
 
 `npm install @ngrx/schematics --save-dev`
@@ -30,7 +31,6 @@ After installing `@ngrx/schematics`, install the NgRx dependencies.
 ##### OR
 
 `yarn add @ngrx/{store,effects,entity,store-devtools}`
-
 
 ## Default Schematics Collection
 
@@ -59,12 +59,103 @@ Generate the root effects and register it within the `app.module.ts`
 ng generate effect App --root --module app.module.ts --collection @ngrx/schematics
 ```
 
+## Ionic integration
+
+In an Ionic project, you normally use the Ionic CLI (`ionic`) instead of the Angular CLI (`ng`).
+
+But you can integrate Angular CLI and `@ngrx/schematics` with these simple steps:
+
+* Install Angular CLI in your `devDependencies`:
+
+```bash
+npm install --save-dev @angular/cli@latest
+```
+
+* Install `@ngrx/schematics` and its dependencies following the steps in the sections above.
+
+* Create a `.angular-cli.json` file in your root directory, besides your `ionic.config.json` file. Angular CLI (`ng`) will use it to know where to generate files. The only contents it needs to have are:
+
+```json
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "apps": [
+    {
+      "root": "src"
+    }
+  ]
+}
+```
+
+* Make `@ngrx/schematics` the default collection as described above, e.g.:
+
+```bash
+ng set defaults.schematics.collection=@ngrx/schematics
+```
+
+* Make SCSS the default style format (the default for Ionic):
+
+```bash
+ng set defaults.styleExt scss
+```
+
+**Note**: when you generate components (like containers) they are generated with a `styleUrls` pointing to the `.scss` file. But by default, Ionic doesn't include styles directly in each component, so, you will probably need to remove that line from the components you create with `ng`.
+
+that command will modify the file `.angular-cli.json` so that you don't have to type `--collection @ngrx/schematics` with every command.
+
+* After that, you can use `ng` with the same instructions as above, e.g.:
+
+```bash
+ng generate store State --root --module app.module.ts
+```
+
+---
+
+**Note**: as Ionic currently doesn't support Angular's `environment.ts` files, you will have to remove them from the imports and adjust the changed files manually, but apart from that, you can use the generated files normally. You will probably will have to remove from `app.module.ts` the line with:
+
+```TypeScript
+import { environment } from '../environments/environment';
+```
+
+And change the line with:
+
+```TypeScript
+    !environment.production ? StoreDevtoolsModule.instrument() : [],
+```
+
+to:
+
+```TypeScript
+    StoreDevtoolsModule.instrument(),
+```
+
+during development and probably remove that line in production.
+
+And in the file in `reducers/index.ts` remove the line:
+
+```TypeScript
+import { environment } from '../../environments/environment';
+```
+
+and change the line:
+
+```TypeScript
+export const metaReducers: MetaReducer<State>[] = !environment.production ? [] : [];
+```
+
+to:
+
+```TypeScript
+export const metaReducers: MetaReducer<State>[] = [];
+```
+
+during development and probably remove that line in production.
+
 ## Blueprints
 
-- [Action](action.md)
-- [Container](container.md)
-- [Effect](effect.md)
-- [Entity](entity.md)
-- [Feature](feature.md)
-- [Reducer](reducer.md)
-- [Store](store.md)
+* [Action](action.md)
+* [Container](container.md)
+* [Effect](effect.md)
+* [Entity](entity.md)
+* [Feature](feature.md)
+* [Reducer](reducer.md)
+* [Store](store.md)

--- a/docs/schematics/README.md
+++ b/docs/schematics/README.md
@@ -73,7 +73,7 @@ npm install --save-dev @angular/cli@latest
 
 * Install `@ngrx/schematics` and its dependencies following the steps in the sections above.
 
-* Create a `.angular-cli.json` file in your root directory, besides your `ionic.config.json` file. Angular CLI (`ng`) will use it to know where to generate files. The only contents it needs to have are:
+* Create a `.angular-cli.json` file in your root directory, beside your `ionic.config.json` file. Angular CLI (`ng`) will use it to know where to generate new files. The only contents it needs to have are:
 
 ```json
 {
@@ -92,15 +92,13 @@ npm install --save-dev @angular/cli@latest
 ng set defaults.schematics.collection=@ngrx/schematics
 ```
 
+that command will modify the file `.angular-cli.json` so that you don't have to type `--collection @ngrx/schematics` with every command.
+
 * Make SCSS the default style format (the default for Ionic):
 
 ```bash
 ng set defaults.styleExt scss
 ```
-
-**Note**: when you generate components (like containers) they are generated with a `styleUrls` pointing to the `.scss` file. But by default, Ionic doesn't include styles directly in each component, so, you will probably need to remove that line from the components you create with `ng`.
-
-that command will modify the file `.angular-cli.json` so that you don't have to type `--collection @ngrx/schematics` with every command.
 
 * After that, you can use `ng` with the same instructions as above, e.g.:
 
@@ -108,9 +106,15 @@ that command will modify the file `.angular-cli.json` so that you don't have to 
 ng generate store State --root --module app.module.ts
 ```
 
+**Note**: when you generate components (like containers) they are generated with a `styleUrls` pointing to the `.scss` file. But by default, Ionic doesn't include styles directly in each component, so, you will probably need to remove that line from the components you create with `ng`. You would remove a line similar to this:
+
+```TypeScript
+  styleUrls: ['./login.component.css']
+```
+
 ---
 
-**Note**: as Ionic currently doesn't support Angular's `environment.ts` files, you will have to remove them from the imports and adjust the changed files manually, but apart from that, you can use the generated files normally. You will probably will have to remove from `app.module.ts` the line with:
+**Note**: as Ionic currently doesn't support Angular's `environment.ts` files, you will have to remove them from the imports and adjust the changed files manually, but apart from that, you can use the generated files normally. You will probably have to remove from `app.module.ts` the line with:
 
 ```TypeScript
 import { environment } from '../environments/environment';
@@ -128,7 +132,7 @@ to:
     StoreDevtoolsModule.instrument(),
 ```
 
-during development and probably remove that line in production.
+during development, and probably remove that line in production.
 
 And in the file in `reducers/index.ts` remove the line:
 
@@ -148,7 +152,7 @@ to:
 export const metaReducers: MetaReducer<State>[] = [];
 ```
 
-during development and probably remove that line in production.
+during development, and probably remove that line in production.
 
 ## Blueprints
 

--- a/docs/schematics/README.md
+++ b/docs/schematics/README.md
@@ -59,101 +59,6 @@ Generate the root effects and register it within the `app.module.ts`
 ng generate effect App --root --module app.module.ts --collection @ngrx/schematics
 ```
 
-## Ionic integration
-
-In an Ionic project, you normally use the Ionic CLI (`ionic`) instead of the Angular CLI (`ng`).
-
-But you can integrate Angular CLI and `@ngrx/schematics` with these simple steps:
-
-* Install Angular CLI in your `devDependencies`:
-
-```bash
-npm install --save-dev @angular/cli@latest
-```
-
-* Install `@ngrx/schematics` and its dependencies following the steps in the sections above.
-
-* Create a `.angular-cli.json` file in your root directory, beside your `ionic.config.json` file. Angular CLI (`ng`) will use it to know where to generate new files. The only contents it needs to have are:
-
-```json
-{
-  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-  "apps": [
-    {
-      "root": "src"
-    }
-  ]
-}
-```
-
-* Make `@ngrx/schematics` the default collection as described above, e.g.:
-
-```bash
-ng set defaults.schematics.collection=@ngrx/schematics
-```
-
-that command will modify the file `.angular-cli.json` so that you don't have to type `--collection @ngrx/schematics` with every command.
-
-* Make SCSS the default style format (the default for Ionic):
-
-```bash
-ng set defaults.styleExt scss
-```
-
-* After that, you can use `ng` with the same instructions as above, e.g.:
-
-```bash
-ng generate store State --root --module app.module.ts
-```
-
-**Note**: when you generate components (like containers) they are generated with a `styleUrls` pointing to the `.scss` file. But by default, Ionic doesn't include styles directly in each component, so, you will probably need to remove that line from the components you create with `ng`. You would remove a line similar to this:
-
-```TypeScript
-  styleUrls: ['./login.component.css']
-```
-
----
-
-**Note**: as Ionic currently doesn't support Angular's `environment.ts` files, you will have to remove them from the imports and adjust the changed files manually, but apart from that, you can use the generated files normally. You will probably have to remove from `app.module.ts` the line with:
-
-```TypeScript
-import { environment } from '../environments/environment';
-```
-
-And change the line with:
-
-```TypeScript
-    !environment.production ? StoreDevtoolsModule.instrument() : [],
-```
-
-to:
-
-```TypeScript
-    StoreDevtoolsModule.instrument(),
-```
-
-during development, and probably remove that line in production.
-
-And in the file in `reducers/index.ts` remove the line:
-
-```TypeScript
-import { environment } from '../../environments/environment';
-```
-
-and change the line:
-
-```TypeScript
-export const metaReducers: MetaReducer<State>[] = !environment.production ? [] : [];
-```
-
-to:
-
-```TypeScript
-export const metaReducers: MetaReducer<State>[] = [];
-```
-
-during development, and probably remove that line in production.
-
 ## Blueprints
 
 * [Action](action.md)
@@ -163,3 +68,6 @@ during development, and probably remove that line in production.
 * [Feature](feature.md)
 * [Reducer](reducer.md)
 * [Store](store.md)
+
+## API Documentation
+ * [Integration with Ionic](ionic.md)

--- a/docs/schematics/ionic.md
+++ b/docs/schematics/ionic.md
@@ -1,0 +1,94 @@
+## Ionic integration
+
+In an Ionic project, you normally use the Ionic CLI (`ionic`) instead of the Angular CLI (`ng`).
+
+But you can integrate Angular CLI and `@ngrx/schematics` with these simple steps:
+
+* Install Angular CLI in your `devDependencies`:
+
+```bash
+npm install --save-dev @angular/cli@latest
+```
+
+* Install `@ngrx/schematics` and its dependencies following the steps in the sections above.
+
+* Create a `.angular-cli.json` file in your root directory, beside your `ionic.config.json` file. Angular CLI (`ng`) will use it to know where to generate new files. The only contents it needs to have are:
+
+```json
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "apps": [
+    {
+      "root": "src"
+    }
+  ]
+}
+```
+
+* Make `@ngrx/schematics` the default collection as described above, e.g.:
+
+```bash
+ng set defaults.schematics.collection=@ngrx/schematics
+```
+
+that command will modify the file `.angular-cli.json` so that you don't have to type `--collection @ngrx/schematics` with every command.
+
+* Make SCSS the default style format (the default for Ionic):
+
+```bash
+ng set defaults.styleExt scss
+```
+
+* After that, you can use `ng` with the same instructions as above, e.g.:
+
+```bash
+ng generate store State --root --module app.module.ts
+```
+
+**Note**: when you generate components (like containers) they are generated with a `styleUrls` pointing to the `.scss` file. But by default, Ionic doesn't include styles directly in each component, so, you will probably need to remove that line from the components you create with `ng`. You would remove a line similar to this:
+
+```TypeScript
+  styleUrls: ['./login.component.css']
+```
+
+---
+
+**Note**: as Ionic currently doesn't support Angular's `environment.ts` files, you will have to remove them from the imports and adjust the changed files manually, but apart from that, you can use the generated files normally. You will probably have to remove from `app.module.ts` the line with:
+
+```TypeScript
+import { environment } from '../environments/environment';
+```
+
+And change the line with:
+
+```TypeScript
+    !environment.production ? StoreDevtoolsModule.instrument() : [],
+```
+
+to:
+
+```TypeScript
+    StoreDevtoolsModule.instrument(),
+```
+
+during development, and probably remove that line in production.
+
+And in the file in `reducers/index.ts` remove the line:
+
+```TypeScript
+import { environment } from '../../environments/environment';
+```
+
+and change the line:
+
+```TypeScript
+export const metaReducers: MetaReducer<State>[] = !environment.production ? [] : [];
+```
+
+to:
+
+```TypeScript
+export const metaReducers: MetaReducer<State>[] = [];
+```
+
+during development, and probably remove that line in production.


### PR DESCRIPTION
Include a section in the `@ngrx/schematics` `README.md` on how to integrate it and use it with Ionic.

---

As Ionic projects normally use the `ionic` CLI instead of `ng`, and several files have a slightly different structure than a normal Angular CLI project, it's not obvious how to use `@ngrx/schematics` in an Ionic project.

The added docs are a simple guide with the steps needed to integrate and use `@ngrx/schematics` in an Ionic project.