### PR TITLE
fix(StoreDevtools): report errors to ErrorHandler instead of console

### DIFF
--- a/modules/store-devtools/src/devtools.ts
+++ b/modules/store-devtools/src/devtools.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, OnDestroy } from '@angular/core';
+import { Injectable, Inject, OnDestroy, ErrorHandler } from '@angular/core';
 import {
   State,
   Action,
@@ -51,6 +51,7 @@ export class StoreDevtools implements Observer<any> {
     reducers$: ReducerObservable,
     extension: DevtoolsExtension,
     scannedActions: ScannedActionsSubject,
+    errorHandler: ErrorHandler,
     @Inject(INITIAL_STATE) initialState: any,
     @Inject(STORE_DEVTOOLS_CONFIG) config: StoreDevtoolsConfig
   ) {
@@ -58,6 +59,7 @@ export class StoreDevtools implements Observer<any> {
     const liftReducer = liftReducerWith(
       initialState,
       liftedInitialState,
+      errorHandler,
       config.monitor,
       config
     );


### PR DESCRIPTION
## What is the current behavior?
store-devtools catch errors happening in reducers and log them to console

## Expected behavior:
store-devtools catch errors happening in reducers and pass them to angular ErrorHandler

As stated in #643 store-devtools should  be usable in production, but the current behavior hide reducers errors in the console instead of reporting them to ErrorHandler as #667 do