### PR TITLE
feat(Schematics): implement "ng-add" schematic

### DIFF
--- a/modules/schematics/collection.json
+++ b/modules/schematics/collection.json
@@ -1,97 +1,103 @@
 {
   "schematics": {
     "action": {
-      "aliases": [ "a" ],
+      "aliases": ["a"],
       "factory": "./src/action",
       "schema": "./src/action/schema.json",
       "description": "Add store actions"
     },
 
     "class": {
-      "aliases": [ "cl" ],
+      "aliases": ["cl"],
       "extends": "@schematics/angular:class"
     },
 
     "component": {
-      "aliases": [ "c" ],
+      "aliases": ["c"],
       "extends": "@schematics/angular:component"
     },
 
     "container": {
-      "aliases": [ "co" ],
+      "aliases": ["co"],
       "factory": "./src/container",
       "schema": "./src/container/schema.json",
       "description": "Add store container component"
     },
 
     "directive": {
-      "aliases": [ "d" ],
+      "aliases": ["d"],
       "extends": "@schematics/angular:directive"
     },
 
     "effect": {
-      "aliases": [ "ef" ],
+      "aliases": ["ef"],
       "factory": "./src/effect",
       "schema": "./src/effect/schema.json",
       "description": "Add side effect class"
     },
 
     "entity": {
-      "aliases": [ "en" ],
+      "aliases": ["en"],
       "factory": "./src/entity",
       "schema": "./src/entity/schema.json",
       "description": "Add entity state"
     },
 
     "enum": {
-      "aliases": [ "e" ],
+      "aliases": ["e"],
       "extends": "@schematics/angular:enum"
     },
 
     "feature": {
-      "aliases": [ "f" ],
+      "aliases": ["f"],
       "factory": "./src/feature",
       "schema": "./src/feature/schema.json",
       "description": "Add feature state"
     },
 
     "guard": {
-      "aliases": [ "g" ],
+      "aliases": ["g"],
       "extends": "@schematics/angular:guard"
     },
 
     "interface": {
-      "aliases": [ "i" ],
+      "aliases": ["i"],
       "extends": "@schematics/angular:interface"
     },
 
     "module": {
-      "aliases": [ "m" ],
+      "aliases": ["m"],
       "extends": "@schematics/angular:module"
     },
 
     "pipe": {
-      "aliases": [ "p" ],
+      "aliases": ["p"],
       "extends": "@schematics/angular:pipe"
     },
 
     "reducer": {
-      "aliases": [ "r" ],
+      "aliases": ["r"],
       "factory": "./src/reducer",
       "schema": "./src/reducer/schema.json",
       "description": "Add state reducer"
     },
 
     "service": {
-      "aliases": [ "s" ],
+      "aliases": ["s"],
       "extends": "@schematics/angular:service"
     },
 
     "store": {
-      "aliases": [ "st" ],
+      "aliases": ["st"],
       "factory": "./src/store",
       "schema": "./src/store/schema.json",
       "description": "Adds initial setup for state managment"
+    },
+
+    "ng-add": {
+      "factory": "./src/ng-add",
+      "schema": "./src/ng-add/schema.json",
+      "description": "Adds initial root setup for state managment"
     }
   }
 }

--- a/modules/schematics/src/ng-add/index.spec.ts
+++ b/modules/schematics/src/ng-add/index.spec.ts
@@ -1,0 +1,80 @@
+import { Tree, VirtualTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { createAppModule, getFileContent } from '../utility/test';
+import { Schema as NgAddOptions } from './schema';
+
+describe('NgAdd Schematic', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@ngrx/schematics',
+    path.join(__dirname, '../../collection.json')
+  );
+  const defaultOptions: NgAddOptions = {
+    path: 'app',
+    sourceDir: 'src',
+    name: 'foo',
+    effectName: 'bar',
+    effect: true,
+    module: undefined,
+    flat: false,
+    spec: true,
+    group: false,
+  };
+
+  let appTree: Tree;
+
+  beforeEach(() => {
+    appTree = new VirtualTree();
+    appTree = createAppModule(appTree);
+  });
+
+  it('should setup root store and effect', () => {
+    const options = { ...defaultOptions, module: 'app.module.ts' };
+
+    const tree = schematicRunner.runSchematic('ng-add', options, appTree);
+    const content = getFileContent(tree, '/src/app/app.module.ts');
+
+    expect(content).toMatch(/import { StoreModule } from '@ngrx\/store';/);
+    expect(content).toMatch(/import { EffectsModule } from '@ngrx\/effects';/);
+    expect(content).toMatch(
+      /import { StoreDevtoolsModule } from '@ngrx\/store-devtools';/
+    );
+    expect(content).toMatch(
+      /import { reducers, metaReducers } from '\.\/reducers';/
+    );
+    expect(content).toMatch(
+      /StoreModule\.forRoot\(reducers, { metaReducers }\)/
+    );
+    expect(content).toMatch(/EffectsModule\.forRoot\(\[BarEffects\]\)/);
+    expect(content).toMatch(
+      /!environment\.production \? StoreDevtoolsModule\.instrument\(\) : \[\]/
+    );
+  });
+
+  it('should create state and feature files', () => {
+    const options = { ...defaultOptions };
+
+    const tree = schematicRunner.runSchematic('ng-add', options, appTree);
+    const files = tree.files;
+
+    expect(files.indexOf('/src/app/reducers/index.ts')).toBeGreaterThanOrEqual(
+      0
+    );
+    expect(
+      files.indexOf('/src/app/bar/bar.effects.spec.ts')
+    ).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('/src/app/bar/bar.effects.ts')).toBeGreaterThanOrEqual(
+      0
+    );
+  });
+
+  it('should not create feature files', () => {
+    const options = { ...defaultOptions, effect: false };
+
+    const tree = schematicRunner.runSchematic('ng-add', options, appTree);
+    const files = tree.files;
+
+    expect(files.indexOf('/src/app/bar/bar.effects.spec.ts')).toEqual(-1);
+    expect(files.indexOf('/src/app/bar/bar.effects.ts')).toEqual(-1);
+  });
+});

--- a/modules/schematics/src/ng-add/index.ts
+++ b/modules/schematics/src/ng-add/index.ts
@@ -1,0 +1,42 @@
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  chain,
+  schematic,
+} from '@angular-devkit/schematics';
+import { Schema as NgAddOptions } from './schema';
+
+export default function(options: NgAddOptions): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    const schematicsToRun = [
+      schematic('store', {
+        flat: options.flat,
+        module: options.module,
+        name: options.name,
+        path: options.path,
+        sourceDir: options.sourceDir,
+        spec: options.spec,
+        statePath: options.statePath,
+        root: true,
+      }),
+    ];
+
+    if (options.effect) {
+      schematicsToRun.push(
+        schematic('effect', {
+          flat: options.flat,
+          group: options.group,
+          module: options.module,
+          name: options.effectName,
+          path: options.path,
+          sourceDir: options.sourceDir,
+          spec: options.spec,
+          root: true,
+        })
+      );
+    }
+
+    return chain(schematicsToRun)(host, context);
+  };
+}

--- a/modules/schematics/src/ng-add/schema.d.ts
+++ b/modules/schematics/src/ng-add/schema.d.ts
@@ -1,0 +1,12 @@
+export interface Schema {
+  path?: string;
+  sourceDir?: string;
+  name: string;
+  effectName?: string;
+  effect?: boolean;
+  module?: string;
+  flat?: boolean;
+  spec?: boolean;
+  statePath?: string;
+  group?: boolean;
+}

--- a/modules/schematics/src/ng-add/schema.json
+++ b/modules/schematics/src/ng-add/schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsNgRxNgAdd",
+  "title": "NgRx Root State Effect Options Schema",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "default": "app"
+    },
+    "sourceDir": {
+      "type": "string",
+      "default": "src",
+      "alias": "sd"
+    },
+    "name": {
+      "type": "string"
+    },
+    "effectName": {
+      "type": "string",
+      "default": "App",
+      "description": "Root effect name."
+    },
+    "effect": {
+      "type": "boolean",
+      "default": true,
+      "description": "Specifies if a root effect is generated."
+    },
+    "flat": {
+      "type": "boolean",
+      "default": true,
+      "description": "Flag to indicate if a dir is created."
+    },
+    "module": {
+      "type": "string",
+      "description": "Specifies the declaring module.",
+      "aliases": ["m"]
+    },
+    "spec": {
+      "type": "boolean",
+      "default": true,
+      "description": "Specifies if a spec file is generated."
+    },
+    "statePath": {
+      "type": "string",
+      "default": "reducers"
+    },
+    "group": {
+      "type": "boolean",
+      "default": false,
+      "description": "Group effects file within 'effects' folder",
+      "aliases": ["g"]
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
Add implementation for `ng-add` schematic that initializes root store and optionally root effect.

See https://github.com/ngrx/platform/issues/920