### PR TITLE
feat(Store): Implement ng-add schematic

### DIFF
--- a/modules/store/collection.json
+++ b/modules/store/collection.json
@@ -1,0 +1,9 @@
+{
+  "schematics": {
+    "ng-add": {
+      "factory": "./src/ng-add",
+      "schema": "./src/ng-add/schema.json",
+      "description": "Adds initial setup for state managment"
+    }
+  }
+}

--- a/modules/store/package.json
+++ b/modules/store/package.json
@@ -24,5 +24,6 @@
   "peerDependencies": {
     "@angular/core": "^5.0.0",
     "rxjs": "^5.5.0"
-  }
+  },
+  "schematics": "./collection.json"
 }

--- a/modules/store/src/ng-add/index.ts
+++ b/modules/store/src/ng-add/index.ts
@@ -1,0 +1,19 @@
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  chain,
+  externalSchematic,
+} from '@angular-devkit/schematics';
+import { Schema as NgAddOptions } from './schema';
+
+export default function(options: NgAddOptions): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    return chain([
+      externalSchematic('@ngrx/schematics', 'store', {
+        ...options,
+        root: true,
+      }),
+    ])(host, context);
+  };
+}

--- a/modules/store/src/ng-add/schema.d.ts
+++ b/modules/store/src/ng-add/schema.d.ts
@@ -1,0 +1,9 @@
+export interface Schema {
+  path?: string;
+  sourceDir?: string;
+  name: string;
+  module?: string;
+  flat?: boolean;
+  spec?: boolean;
+  statePath?: string;
+}

--- a/modules/store/src/ng-add/schema.json
+++ b/modules/store/src/ng-add/schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsNgRxStoreNgAdd",
+  "title": "NgRx Root State Options Schema",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "default": "app"
+    },
+    "sourceDir": {
+      "type": "string",
+      "default": "src",
+      "alias": "sd"
+    },
+    "name": {
+      "type": "string"
+    },
+    "flat": {
+      "type": "boolean",
+      "default": true,
+      "description": "Flag to indicate if a dir is created."
+    },
+    "module": {
+      "type": "string",
+      "description": "Specifies the declaring module.",
+      "aliases": ["m"]
+    },
+    "spec": {
+      "type": "boolean",
+      "default": true,
+      "description": "Specifies if a spec file is generated."
+    },
+    "statePath": {
+      "type": "string",
+      "default": "reducers"
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
Added `ng-add` schematic to package for an automatic scaffold with `ng add` command.

See https://github.com/ngrx/platform/issues/920