### PR TITLE
Fix(Devtools): Test bugfix

### DIFF
--- a/modules/store-devtools/spec/extension.spec.ts
+++ b/modules/store-devtools/spec/extension.spec.ts
@@ -170,7 +170,7 @@ describe('DevtoolsExtension', () => {
       const SANITIZED_COUNTER = 42;
 
       function createPerformAction() {
-        return new PerformAction({ type: UNSANITIZED_TOKEN }, +Date.now());
+        return new PerformAction({ type: UNSANITIZED_TOKEN }, 1234567);
       }
 
       function testActionSanitizer(action: Action, id: number) {


### PR DESCRIPTION
A test helper function in devtools uses a Date.now() to create a date time, but since some tests use it multiple times in their test, it may happen that the system clock moves one ore more miliseconds foreward and the test fails.

May for example happen in this test:

````
it('for normal action', () => {
  const action = createPerformAction(); // <<<--- invocation 1
  const state = createState();

  devtoolsExtension.notify(action, state);
  expect(state).toEqual(createState());
  expect(action).toEqual(createPerformAction()); // <<<--- invocation 2
});
````

This PR replaces the Date.now() with a hardcoded time value.