### PR TITLE
feat(effects): Improve performance of ofType

### DIFF
--- a/modules/effects/spec/of_type.spec.ts
+++ b/modules/effects/spec/of_type.spec.ts
@@ -1,0 +1,111 @@
+import { ofType, getOfTypeMetadata } from '../';
+import { forceBasicMode } from '../src/of_type';
+import { hot, cold } from 'jasmine-marbles';
+
+describe('ofType', function() {
+  const ADD = 'ADD';
+  const SUBTRACT = 'SUBTRACT';
+  const DIVIDE = 'DIVIDE';
+  const MULTIPLY = 'MULTIPLY';
+
+  it('should only emit values that are filtered out', () => {
+    const input = cold('-a-b-c-d', {
+      a: { type: ADD },
+      b: { type: SUBTRACT },
+      c: { type: DIVIDE },
+      d: { type: MULTIPLY },
+    });
+    const expected = cold('-a-b', {
+      a: { type: ADD },
+      b: { type: SUBTRACT },
+    });
+
+    const additionAndSubtraction$ = input.pipe(ofType(ADD, SUBTRACT));
+    expect(additionAndSubtraction$).toBeObservable(expected);
+  });
+
+  it('should only subscribe once to each action specified', () => {
+    const input = cold('-a-b-c-d', {
+      a: { type: ADD },
+      b: { type: SUBTRACT },
+      c: { type: DIVIDE },
+      d: { type: MULTIPLY },
+    });
+    const expected = cold('-a-b', {
+      a: { type: ADD },
+      b: { type: SUBTRACT },
+    });
+    const expected2 = cold('----c-d', {
+      c: { type: DIVIDE },
+      d: { type: MULTIPLY },
+    });
+
+    const subscriptions = [
+      input.pipe(ofType(ADD, SUBTRACT)).subscribe(),
+      input.pipe(ofType(DIVIDE, MULTIPLY)).subscribe(),
+    ];
+
+    expect(getOfTypeMetadata(input).watchedActions.includes(ADD)).toBe(true);
+    expect(getOfTypeMetadata(input).watchedActions.includes(SUBTRACT)).toBe(
+      true
+    );
+    expect(getOfTypeMetadata(input).watchedActions.includes(MULTIPLY)).toBe(
+      true
+    );
+    expect(getOfTypeMetadata(input).watchedActions.includes(DIVIDE)).toBe(true);
+    expect(getOfTypeMetadata(input).subscriptionCount).toBe(2);
+
+    subscriptions[0].unsubscribe();
+
+    expect(getOfTypeMetadata(input).watchedActions.includes(ADD)).toBe(false);
+    expect(getOfTypeMetadata(input).watchedActions.includes(SUBTRACT)).toBe(
+      false
+    );
+    expect(getOfTypeMetadata(input).watchedActions.includes(MULTIPLY)).toBe(
+      true
+    );
+    expect(getOfTypeMetadata(input).watchedActions.includes(DIVIDE)).toBe(true);
+    expect(getOfTypeMetadata(input).subscriptionCount).toBe(1);
+
+    subscriptions[1].unsubscribe();
+
+    expect(getOfTypeMetadata(input).watchedActions.includes(ADD)).toBe(false);
+    expect(getOfTypeMetadata(input).watchedActions.includes(SUBTRACT)).toBe(
+      false
+    );
+    expect(getOfTypeMetadata(input).watchedActions.includes(MULTIPLY)).toBe(
+      false
+    );
+    expect(getOfTypeMetadata(input).watchedActions.includes(DIVIDE)).toBe(
+      false
+    );
+    expect(getOfTypeMetadata(input).subscriptionCount).toBe(0);
+  });
+
+  it('should propogate errors', () => {
+    const input = cold('-#', {});
+    const expected = cold('-#', {});
+
+    const additionAndSubtraction$ = input.pipe(ofType(ADD, SUBTRACT));
+    expect(additionAndSubtraction$).toBeObservable(expected);
+  });
+
+  it('should allow basic mode to be forced, and still work', () => {
+    forceBasicMode(true);
+    const input = cold('-a-b-c-d', {
+      a: { type: ADD },
+      b: { type: SUBTRACT },
+      c: { type: DIVIDE },
+      d: { type: MULTIPLY },
+    });
+    const expected = cold('-a-b', {
+      a: { type: ADD },
+      b: { type: SUBTRACT },
+    });
+
+    const additionAndSubtraction$ = input.pipe(ofType(ADD, SUBTRACT));
+    expect(additionAndSubtraction$).toBeObservable(expected);
+
+    forceBasicMode(false);
+  });
+});

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Action, ScannedActionsSubject } from '@ngrx/store';
 import { Observable, Operator, OperatorFunction } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { ofType } from './of_type';
 
 @Injectable()
 export class Actions<V = Action> extends Observable<V> {
@@ -23,12 +24,4 @@ export class Actions<V = Action> extends Observable<V> {
   ofType<V2 extends V = V>(...allowedTypes: string[]): Actions<V2> {
     return ofType<any>(...allowedTypes)(this as Actions<any>) as Actions<V2>;
   }
-}
-
-export function ofType<T extends Action>(
-  ...allowedTypes: string[]
-): OperatorFunction<Action, T> {
-  return filter((action: Action): action is T =>
-    allowedTypes.some(type => type === action.type)
-  );
 }

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -4,9 +4,10 @@ export {
   getEffectsMetadata,
 } from './effects_metadata';
 export { mergeEffects } from './effects_resolver';
-export { Actions, ofType } from './actions';
+export { Actions } from './actions';
 export { EffectsModule } from './effects_module';
 export { EffectSources } from './effect_sources';
+export { ofType, getOfTypeMetadata } from './of_type';
 export { OnRunEffects } from './on_run_effects';
 export { EffectNotification } from './effect_notification';
 export { ROOT_EFFECTS_INIT } from './effects_root_module';

--- a/modules/effects/src/of_type.ts
+++ b/modules/effects/src/of_type.ts
@@ -9,7 +9,7 @@ import {
   Subscription,
 } from 'rxjs';
 import { filter, share } from 'rxjs/operators';
-import { merge } from 'rxjs/observable/merge';
+import { merge } from 'rxjs';
 
 let supportsMapAndSet = false;
 

--- a/modules/effects/src/of_type.ts
+++ b/modules/effects/src/of_type.ts
@@ -220,7 +220,7 @@ export function ofType<T extends Action>(
   }
 }
 
-class OfTypeMetadata {
+export class OfTypeMetadata {
   constructor(private _source: Observable<any>) {}
 
   get watchedActions() {

--- a/modules/effects/src/of_type.ts
+++ b/modules/effects/src/of_type.ts
@@ -1,0 +1,254 @@
+import { Action } from '@ngrx/store';
+import {
+  Observable,
+  Operator,
+  OperatorFunction,
+  Subscriber,
+  TeardownLogic,
+  Subject,
+  Subscription,
+} from 'rxjs';
+import { filter, share } from 'rxjs/operators';
+import { merge } from 'rxjs/observable/merge';
+
+let supportsMapAndSet = false;
+
+forceBasicMode(false);
+
+function ofTypeBasic<T extends Action>(
+  ...allowedTypes: string[]
+): OperatorFunction<Action, T> {
+  return filter((action: Action): action is T =>
+    allowedTypes.some(type => type === action.type)
+  );
+}
+
+/**
+ * The Action to Stream Map, is a map of observables
+ *
+ * Explained in a marble diagram:
+ *
+ * Map<Sources to Filters>
+ * sourceA -> {
+ *            A: Subject<A Action>,
+ *            B: Subject<B Action>
+ *            }
+ *
+ * B into sourceA, emits, a value on the B Subject.
+ */
+let __actionToStreamMap: Map<Observable<Action>, Map<string, Subject<any>>>;
+let __actionToStreamSubscriptionsCount: Map<
+  Observable<Action>,
+  Map<string, number>
+>;
+let __sourceSubscriptionsCount: Map<Observable<Action>, number>;
+let __sourceSubscriptions: Map<Observable<Action>, Subscription>;
+
+if (supportsMapAndSet) {
+  __actionToStreamMap = new Map();
+  __actionToStreamSubscriptionsCount = new Map();
+  __sourceSubscriptionsCount = new Map();
+  __sourceSubscriptions = new Map();
+}
+
+function trackSourceSubscriptions(source: Observable<Action>) {
+  const count = (__sourceSubscriptionsCount.get(source) || 0) + 1;
+  __sourceSubscriptionsCount.set(source, count);
+}
+
+function untrackSourceSubscriptions(source: Observable<Action>) {
+  let count = (__sourceSubscriptionsCount.get(source) || 0) - 1;
+  __sourceSubscriptionsCount.set(source, count <= 0 ? 0 : count);
+  return count;
+}
+
+function subscribeToSource(source: Observable<Action>) {
+  if (!__sourceSubscriptions.has(source)) {
+    __sourceSubscriptionsCount.set(source, 0);
+    __sourceSubscriptions.set(
+      source,
+      source.subscribe(
+        next => {
+          const type = next ? next.type : null;
+          if (type !== null) {
+            const allActions = __actionToStreamMap.get(source);
+            if (allActions) {
+              const actionSubject = allActions.get(type);
+              if (actionSubject) {
+                actionSubject.next(next);
+              }
+            }
+          }
+        },
+        err => {
+          // Propogate the error and reset.
+          const allActions = __actionToStreamMap.get(source);
+          if (allActions) {
+            allActions.forEach(action => {
+              action.error(err);
+            });
+          }
+          __actionToStreamMap.set(source, new Map());
+        },
+        () => {
+          // Propogate the completion and reset.
+          const allActions = __actionToStreamMap.get(source);
+          if (allActions) {
+            allActions.forEach(action => {
+              action.complete();
+            });
+          }
+          __actionToStreamMap.set(source, new Map());
+        }
+      )
+    );
+  }
+  trackSourceSubscriptions(source);
+}
+
+function unsubscribeFromSource(source: Observable<Action>) {
+  const count = untrackSourceSubscriptions(source);
+  if (count === 0) {
+    const subscription = __sourceSubscriptions.get(source);
+    if (subscription) {
+      subscription.unsubscribe();
+      __sourceSubscriptions.delete(source);
+    }
+  }
+}
+
+function listenToActions<T extends Action>(
+  source: Observable<Action>,
+  actionTypes: string[]
+) {
+  let sourceToActionsMap: Map<string, Subject<Action>> =
+    __actionToStreamMap.get(source) || new Map();
+  if (!__actionToStreamMap.has(source)) {
+    __actionToStreamMap.set(source, sourceToActionsMap);
+  }
+  let actionSubscriptionsCount: Map<string, number> =
+    __actionToStreamSubscriptionsCount.get(source) || new Map();
+  if (!__actionToStreamSubscriptionsCount.has(source)) {
+    __actionToStreamSubscriptionsCount.set(source, actionSubscriptionsCount);
+  }
+  function listenToAction(actionType: string) {
+    if (!sourceToActionsMap.has(actionType)) {
+      sourceToActionsMap.set(actionType, new Subject<Action>());
+    }
+    actionSubscriptionsCount.set(
+      actionType,
+      (actionSubscriptionsCount.get(actionType) || 0) + 1
+    );
+  }
+  actionTypes.forEach(listenToAction);
+}
+function unlistenToActions<T extends Action>(
+  source: Observable<Action>,
+  actionTypes: string[]
+) {
+  let actionSubscriptionsCount: Map<
+    string,
+    number
+  > = __actionToStreamSubscriptionsCount.get(source) as any; // Will always exist.
+  function unlistenToAction(actionType: string) {
+    let count = (actionSubscriptionsCount.get(actionType) || 0) - 1;
+    actionSubscriptionsCount.set(actionType, count < 0 ? 0 : count);
+    if (count <= 0) {
+      const map = __actionToStreamMap.get(source);
+      if (map) {
+        map.delete(actionType);
+      }
+    }
+  }
+  actionTypes.forEach(unlistenToAction);
+}
+
+function filterForActions<T extends Action>(
+  source: Observable<Action>,
+  actionTypes: string[]
+): Observable<T> {
+  const allActions = __actionToStreamMap.get(source) as any; // This will always have a value
+
+  const actionSubjects: Subject<T>[] = [];
+  actionTypes.map(type => allActions.get(type)).forEach(element => {
+    if (element) {
+      actionSubjects.push(element);
+    }
+  });
+  return merge(...actionSubjects);
+}
+
+function observeSource<T extends Action>(
+  source: Observable<Action>,
+  actionTypes: string[]
+): Observable<T> {
+  listenToActions(source, actionTypes);
+
+  return new Observable<T>(subscriber => {
+    subscribeToSource(source);
+
+    const filterSubscription = filterForActions<T>(
+      source,
+      actionTypes
+    ).subscribe(subscriber);
+
+    return {
+      unsubscribe() {
+        unlistenToActions(source, actionTypes);
+        unsubscribeFromSource(source);
+        filterSubscription.unsubscribe();
+      },
+    };
+  });
+}
+
+function ofTypeMap<T extends Action>(
+  ...allowedTypes: string[]
+): OperatorFunction<Action, T> {
+  return function ofTypeOperatorFunction(source: Observable<Action>) {
+    return observeSource<T>(source, allowedTypes);
+  };
+}
+
+export function ofType<T extends Action>(
+  ...allowedTypes: string[]
+): OperatorFunction<Action, T> {
+  if (supportsMapAndSet) {
+    return ofTypeMap<T>(...allowedTypes);
+  } else {
+    return ofTypeBasic<T>(...allowedTypes);
+  }
+}
+
+class OfTypeMetadata {
+  constructor(private _source: Observable<any>) {}
+
+  get watchedActions() {
+    const map = __actionToStreamMap.get(this._source);
+    const keys: string[] = [];
+    if (map) {
+      map.forEach((item, key) => keys.push(key));
+    }
+    return keys;
+  }
+
+  get subscriptionCount() {
+    return __sourceSubscriptionsCount.get(this._source) || 0;
+  }
+}
+
+export function getOfTypeMetadata(source: Observable<any>) {
+  return new OfTypeMetadata(source);
+}
+
+export function forceBasicMode(force = true) {
+  if (force) {
+    supportsMapAndSet = false;
+  } else {
+    try {
+      if (Map !== undefined && Set !== undefined) {
+        supportsMapAndSet = true;
+      }
+    } catch {}
+  }
+}


### PR DESCRIPTION
Instead of naively applying `filter`, ofType now uses a Map to only send actions along to the exact places where they will be used.

Closes #978 