### PR TITLE
fix(Entity): Fix type annotations for getInitialState methods

### DIFF
--- a/modules/entity/spec/entity_state.spec.ts
+++ b/modules/entity/spec/entity_state.spec.ts
@@ -1,4 +1,4 @@
-import { createEntityAdapter, EntityAdapter } from '../src';
+import { createEntityAdapter, EntityAdapter, EntityState } from '../src';
 import { BookModel } from './fixtures/book';
 
 describe('Entity State', () => {
@@ -22,10 +22,30 @@ describe('Entity State', () => {
   it('should let you provide additional initial state properties', () => {
     const additionalProperties = { isHydrated: true };
 
+    // initialState is type EntityState<BookModel> & { isHydrated: boolean; }
     const initialState = adapter.getInitialState(additionalProperties);
 
     expect(initialState).toEqual({
       ...additionalProperties,
+      ids: [],
+      entities: {},
+    });
+  });
+
+  it('should provide intellisense for additional initial state properties', () => {
+    interface StateWithAdditionalProps extends EntityState<BookModel> {
+      isHydrated: boolean;
+    }
+
+    // initialState is type StateWithAdditionalProps
+    const initialState = adapter.getInitialState<StateWithAdditionalProps>({
+        // intellisense here for StateWithAdditionalProps
+        isHydrated: true,
+        // nonStateProp: 'not allowed', // red squigglies
+    });
+
+    expect(initialState).toEqual({
+      isHydrated: true,
       ids: [],
       entities: {},
     });

--- a/modules/entity/src/entity_state.ts
+++ b/modules/entity/src/entity_state.ts
@@ -9,11 +9,14 @@ export function getInitialEntityState<V>(): EntityState<V> {
 
 export function createInitialStateFactory<V>() {
   function getInitialState(): EntityState<V>;
+  function getInitialState<S extends EntityState<V>>(
+    additionalState: Partial<S>
+  ): S;
   function getInitialState<S extends object>(
     additionalState: S
   ): EntityState<V> & S;
   function getInitialState(additionalState: any = {}): any {
-    return Object.assign(getInitialEntityState(), additionalState);
+    return Object.assign(getInitialEntityState<V>(), additionalState);
   }
 
   return { getInitialState };

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -79,6 +79,7 @@ export interface EntityAdapter<T> extends EntityStateAdapter<T> {
   selectId: IdSelector<T>;
   sortComparer: false | Comparer<T>;
   getInitialState(): EntityState<T>;
+  getInitialState<S extends EntityState<T>>(state: Partial<S>): S;
   getInitialState<S extends object>(state: S): EntityState<T> & S;
   getSelectors(): EntitySelectors<T, EntityState<T>>;
   getSelectors<V>(


### PR DESCRIPTION
This adds intellisense support for extended state objects within the `getInitialState` method if the state type is passed as a generic parameter.
For example, here's an excerpt from the added test for this (given the constraints of type annotation testing):

```typescript
    interface StateWithAdditionalProps extends EntityState<BookModel> {
      isHydrated: boolean;
    }

    // initialState is type StateWithAdditionalProps
    const initialState = adapter.getInitialState<StateWithAdditionalProps>({
        // intellisense here for StateWithAdditionalProps
        isHydrated: true,
        // nonStateProp: 'not allowed', // red squigglies
    });
```

This commit also preserves the previous overload, which allows adding arbitrary objects without complaining (valid for some use cases, I suppose, so didn't want to break it):

```typescript
    const additionalProperties = { isHydrated: true };

    // initialState is type EntityState<BookModel> & { isHydrated: boolean; }
    const initialState = adapter.getInitialState(additionalProperties);
```
