### PR TITLE
fix(deps): Update minimum node version to 8.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "buildifier": "find . -type f \\( -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs $(bazel info bazel-bin)/external/com_github_bazelbuild_buildtools/buildifier/*/buildifier"
   },
   "engines": {
-    "node": ">=8.6.0",
+    "node": ">=8.9.0",
     "npm": ">=5.3.0",
     "yarn": ">=1.3.0 <2.0.0"
   },


### PR DESCRIPTION
`@angular/cli@6.0.0-rc.2` requires `node>=8.9.0`

Updated `package.json` to set minimum node version to `>=8.9.0`

Closes #988 