### PR TITLE
Fix 'oftype after'

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -74,12 +74,13 @@ import { Action } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Effect, Actions } from '@ngrx/effects';
+import { Login } from '../actions/auth';
 
 @Injectable()
 export class MyEffects {
   @Effect()
   someEffect$: Observable<Action> = this.actions$
-    .ofType(UserActions.LOGIN)
+    .ofType<Login>(UserActions.LOGIN)
     .pipe(map(action => action.payload), map(() => new AnotherAction()));
 
   constructor(private actions$: Actions) {}


### PR DESCRIPTION
There was a question on the gitter channel what the change was at the `oftType` before and after example.
Seems like there was none :sweat_smile: 