### PR TITLE
docs(devtools): Specify that you need to inject the store for devtools to work

### DIFF
--- a/docs/store-devtools/README.md
+++ b/docs/store-devtools/README.md
@@ -34,7 +34,8 @@ import { environment } from '../environments/environment'; // Angular CLI enviro
 })
 export class AppModule { }
 ```
-3. Once some component injects the ngrx `Store`, devtools will be enabled!
+
+***NOTE:*** Once some component injects the `Store` service, Devtools will be enabled.
 
 ### Instrumentation options
 When you call the instrumentation, you can give an optional configuration object:

--- a/docs/store-devtools/README.md
+++ b/docs/store-devtools/README.md
@@ -34,6 +34,7 @@ import { environment } from '../environments/environment'; // Angular CLI enviro
 })
 export class AppModule { }
 ```
+3. Once some component injects the ngrx `Store`, devtools will be enabled!
 
 ### Instrumentation options
 When you call the instrumentation, you can give an optional configuration object:


### PR DESCRIPTION
I spent some time trying to debug things until I found https://github.com/ngrx/platform/issues/245 which mentions that the store needs to be injected before the devtools start working! Hopefully the next person that runs into this will be able to find the answer here.