### PR TITLE
add ng-add for #920

### DIFF
--- a/modules/schematics/collection.json
+++ b/modules/schematics/collection.json
@@ -1,50 +1,54 @@
 {
   "extends": ["@schematics/angular"],
   "schematics": {
+    "ng-add": {
+      "description": "Required for CLI",
+      "factory": "./src/ng-add#ngAdd"
+    },
     "action": {
-      "aliases": [ "a" ],
+      "aliases": ["a"],
       "factory": "./src/action",
       "schema": "./src/action/schema.json",
       "description": "Add store actions"
     },
 
     "container": {
-      "aliases": [ "co" ],
+      "aliases": ["co"],
       "factory": "./src/container",
       "schema": "./src/container/schema.json",
       "description": "Add store container component"
     },
 
     "effect": {
-      "aliases": [ "ef" ],
+      "aliases": ["ef"],
       "factory": "./src/effect",
       "schema": "./src/effect/schema.json",
       "description": "Add side effect class"
     },
 
     "entity": {
-      "aliases": [ "en" ],
+      "aliases": ["en"],
       "factory": "./src/entity",
       "schema": "./src/entity/schema.json",
       "description": "Add entity state"
     },
 
     "feature": {
-      "aliases": [ "f" ],
+      "aliases": ["f"],
       "factory": "./src/feature",
       "schema": "./src/feature/schema.json",
       "description": "Add feature state"
     },
 
     "reducer": {
-      "aliases": [ "r" ],
+      "aliases": ["r"],
       "factory": "./src/reducer",
       "schema": "./src/reducer/schema.json",
       "description": "Add state reducer"
     },
 
     "store": {
-      "aliases": [ "st" ],
+      "aliases": ["st"],
       "factory": "./src/store",
       "schema": "./src/store/schema.json",
       "description": "Adds initial setup for state managment"

--- a/modules/schematics/src/ng-add.ts
+++ b/modules/schematics/src/ng-add.ts
@@ -1,0 +1,7 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+
+export default function(options: any): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    return host;
+  };
+}


### PR DESCRIPTION
Adds `ng-add` to `@ngrx/schematics`

I'm actually not sure how to test this... `ng add` doesn't appear to like relative paths... 

Related to #920 (not sure if it closes it)