### PR TITLE
feat(Schematics): Implement ng-add for store module

### DIFF
--- a/build/builder.ts
+++ b/build/builder.ts
@@ -4,6 +4,7 @@ import { createBuilder } from './util';
 export default createBuilder([
   ['Removing "./dist" Folder', tasks.removeDistFolder],
   ['Compiling packages with NGC', tasks.compilePackagesWithNgc],
+  ['Compiling schematics with TSC', tasks.compileModuleSchematicsWithTsc],
   ['Bundling FESMs', tasks.bundleFesms],
   ['Down-leveling FESMs to ES5', tasks.downLevelFesmsToES5],
   ['Creating UMD Bundles', tasks.createUmdBundles],

--- a/build/config.ts
+++ b/build/config.ts
@@ -2,6 +2,7 @@ export interface PackageDescription {
   name: string;
   hasTestingModule: boolean;
   bundle: boolean;
+  hasSchematics: boolean;
 }
 
 export interface Config {
@@ -14,30 +15,36 @@ export const packages: PackageDescription[] = [
     name: 'store',
     hasTestingModule: false,
     bundle: true,
+    hasSchematics: true,
   },
   {
     name: 'effects',
     hasTestingModule: true,
     bundle: true,
+    hasSchematics: false,
   },
   {
     name: 'router-store',
     hasTestingModule: false,
     bundle: true,
+    hasSchematics: false,
   },
   {
     name: 'store-devtools',
     hasTestingModule: false,
     bundle: true,
+    hasSchematics: false,
   },
   {
     name: 'entity',
     hasTestingModule: false,
     bundle: true,
+    hasSchematics: false,
   },
   {
     name: 'schematics',
     hasTestingModule: false,
     bundle: false,
+    hasSchematics: false,
   },
 ];

--- a/build/util.ts
+++ b/build/util.ts
@@ -182,8 +182,14 @@ export function baseDir(...dirs: string[]): string {
   return `"${path.resolve(__dirname, '../', ...dirs)}"`;
 }
 
-export function shouldBundle(config: Config, packageName: string) {
+export function shouldBundle(config: Config, packageName: string): boolean {
   const pkg = config.packages.find(pkg => pkg.name === packageName);
 
   return pkg ? pkg.bundle : false;
+}
+
+export function hasSchematics(config: Config, packageName: string): boolean {
+  const pkg = config.packages.find(pkg => pkg.name === packageName);
+
+  return pkg ? pkg.hasSchematics : false;
 }

--- a/modules/store/package.json
+++ b/modules/store/package.json
@@ -9,7 +9,10 @@
   "keywords": [
     "RxJS",
     "Angular",
-    "Redux"
+    "Redux",
+    "Schematics",
+    "Angular CLI",
+    "ng-add"
   ],
   "author": "NgRx",
   "license": "MIT",
@@ -19,8 +22,11 @@
   "homepage": "https://github.com/ngrx/platform#readme",
   "peerDependencies": {
     "@angular/core": "NG_VERSION",
+    "@angular-devkit/core": "^0.5.0",
+    "@angular-devkit/schematics": "^0.5.0",
     "rxjs": "RXJS_VERSION"
   },
+  "schematics": "./schematics/collection.json",
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },

--- a/modules/store/schematics/collection.json
+++ b/modules/store/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "schematics": {
+    "ng-add": {
+      "aliases": ["init"],
+      "factory": "./ng-add",
+      "schema": "./ng-add/schema.json",
+      "description": "Adds initial setup for state managment"
+    }
+  }
+}

--- a/modules/store/schematics/ng-add/index.ts
+++ b/modules/store/schematics/ng-add/index.ts
@@ -1,0 +1,19 @@
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  chain,
+  externalSchematic,
+} from '@angular-devkit/schematics';
+import { Schema as NgAddOptions } from './schema';
+
+export default function(options: NgAddOptions): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    return chain([
+      externalSchematic('@ngrx/schematics', 'store', {
+        ...options,
+        root: true,
+      }),
+    ])(host, context);
+  };
+}

--- a/modules/store/schematics/ng-add/schema.d.ts
+++ b/modules/store/schematics/ng-add/schema.d.ts
@@ -1,0 +1,9 @@
+export interface Schema {
+  name: string;
+  path?: string;
+  flat?: boolean;
+  spec?: boolean;
+  module?: string;
+  statePath?: string;
+  stateInterface?: string;
+}

--- a/modules/store/schematics/ng-add/schema.json
+++ b/modules/store/schematics/ng-add/schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsNgRxStoreNgAdd",
+  "title": "NgRx Root State Management Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the state.",
+      "type": "string"
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path to create the component.",
+      "visible": false
+    },
+    "flat": {
+      "type": "boolean",
+      "default": true,
+      "description": "Flag to indicate if a dir is created."
+    },
+    "spec": {
+      "type": "boolean",
+      "default": true,
+      "description": "Specifies if a spec file is generated."
+    },
+    "module": {
+      "type": "string",
+      "default": "",
+      "description": "Allows specification of the declaring module.",
+      "alias": "m",
+      "subtype": "filepath"
+    },
+    "statePath": {
+      "type": "string",
+      "default": "reducers"
+    },
+    "stateInterface": {
+      "type": "string",
+      "default": "State",
+      "description": "Specifies the interface for the state.",
+      "alias": "si"
+    }
+  },
+  "required": ["name"]
+}

--- a/modules/store/schematics/tsconfig-schematic.json
+++ b/modules/store/schematics/tsconfig-schematic.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": true,
+    "stripInternal": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "../../../dist/packages/store/schematics",
+    "paths": {},
+    "rootDir": ".",
+    "sourceMap": true,
+    "inlineSources": true,
+    "target": "es5",
+    "lib": ["es2017", "dom"],
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "files": ["ng-add/index.ts"],
+  "exclude": ["./*/files/**/*"],
+  "angularCompilerOptions": {
+    "skipMetadataEmit": true,
+    "enableSummariesForJit": false
+  }
+}


### PR DESCRIPTION
Add build steps to compile module schematics factory and copy schematic related files.
Added `ng-add` schematic to store module for an automatic scaffold with `ng add` command.

See https://github.com/ngrx/platform/issues/920