### PR TITLE
Fix for Schematics Documentation for Creating Stores

### DIFF
--- a/docs/schematics/store.md
+++ b/docs/schematics/store.md
@@ -56,7 +56,7 @@ Generate an `Admin` feature state within the `admin` folder and register it with
 
 ```sh
 ng generate module admin --flat false
-ng generate store Admin -m admin/admin.module.ts
+ng generate store admin/Admin -m admin/admin.module.ts
 ```
 
 Generate the initial state management files within a `store` folder and register it within the `app.module.ts`.


### PR DESCRIPTION
As the title says, this should update the docs to the correct command for creating a new store in a module other than the root app module.