### PR TITLE
fix(StoreDevtools): Refresh devtools when extension is started

### DIFF
--- a/modules/store-devtools/spec/store.spec.ts
+++ b/modules/store-devtools/spec/store.spec.ts
@@ -177,6 +177,24 @@ describe('Store Devtools', () => {
       expect(getState()).toBe(2);
     });
 
+    it('should refresh to show current state as is', () => {
+      // actionId 0 = @@INIT
+      store.dispatch({ type: 'INCREMENT' });
+      store.dispatch({ type: 'INCREMENT' });
+      store.dispatch({ type: 'INCREMENT' });
+      store.dispatch({ type: 'INCREMENT' });
+
+      expect(getState()).toBe(4);
+      expect(getLiftedState().stagedActionIds).toEqual([0, 1, 2, 3, 4]);
+      expect(getLiftedState().skippedActionIds).toEqual([]);
+
+      devtools.refresh();
+
+      expect(getState()).toBe(4);
+      expect(getLiftedState().stagedActionIds).toEqual([0, 1, 2, 3, 4]);
+      expect(getLiftedState().skippedActionIds).toEqual([]);
+    });
+
     it('should reset to initial state', () => {
       store.dispatch({ type: 'INCREMENT' });
       expect(getState()).toBe(1);

--- a/modules/store-devtools/src/actions.ts
+++ b/modules/store-devtools/src/actions.ts
@@ -1,6 +1,7 @@
 import { Action } from '@ngrx/store';
 
 export const PERFORM_ACTION = 'PERFORM_ACTION';
+export const REFRESH = 'REFRESH';
 export const RESET = 'RESET';
 export const ROLLBACK = 'ROLLBACK';
 export const COMMIT = 'COMMIT';
@@ -22,6 +23,10 @@ export class PerformAction implements Action {
       );
     }
   }
+}
+
+export class Refresh implements Action {
+  readonly type = REFRESH;
 }
 
 export class Reset implements Action {
@@ -82,6 +87,7 @@ export class ImportState implements Action {
 
 export type All =
   | PerformAction
+  | Refresh
   | Reset
   | Rollback
   | Commit

--- a/modules/store-devtools/src/devtools.ts
+++ b/modules/store-devtools/src/devtools.ts
@@ -29,6 +29,7 @@ export class DevtoolsDispatcher extends ActionsSubject {}
 @Injectable()
 export class StoreDevtools implements Observer<any> {
   private stateSubscription: Subscription;
+  private extensionStartSubscription: Subscription;
   public dispatcher: ActionsSubject;
   public liftedState: Observable<LiftedState>;
   public state: Observable<any>;
@@ -95,11 +96,16 @@ export class StoreDevtools implements Observer<any> {
         }
       });
 
+    const extensionStartSubscription = extension.start$.subscribe(() => {
+      this.refresh();
+    });
+
     const liftedState$ = liftedStateSubject.asObservable() as Observable<
       LiftedState
     >;
     const state$ = liftedState$.pipe(map(unliftState));
 
+    this.extensionStartSubscription = extensionStartSubscription;
     this.stateSubscription = liftedStateSubscription;
     this.dispatcher = dispatcher;
     this.liftedState = liftedState$;
@@ -120,6 +126,10 @@ export class StoreDevtools implements Observer<any> {
 
   performAction(action: any) {
     this.dispatch(new Actions.PerformAction(action, +Date.now()));
+  }
+
+  refresh() {
+    this.dispatch(new Actions.Refresh());
   }
 
   reset() {

--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -60,6 +60,7 @@ export class DevtoolsExtension {
 
   liftedActions$: Observable<any>;
   actions$: Observable<any>;
+  start$: Observable<any>;
 
   constructor(
     @Inject(REDUX_DEVTOOLS_EXTENSION) devtoolsExtension: ReduxDevtoolsExtension,
@@ -169,10 +170,11 @@ export class DevtoolsExtension {
 
     const actionsUntilStop$ = actions$.pipe(takeUntil(stop$));
     const liftedUntilStop$ = liftedActions$.pipe(takeUntil(stop$));
+    this.start$ = start$.pipe(takeUntil(stop$));
 
     // Only take the action sources between the start/stop events
-    this.actions$ = start$.pipe(switchMap(() => actionsUntilStop$));
-    this.liftedActions$ = start$.pipe(switchMap(() => liftedUntilStop$));
+    this.actions$ = this.start$.pipe(switchMap(() => actionsUntilStop$));
+    this.liftedActions$ = this.start$.pipe(switchMap(() => liftedUntilStop$));
   }
 
   private unwrapAction(action: Action) {

--- a/modules/store-devtools/src/reducer.ts
+++ b/modules/store-devtools/src/reducer.ts
@@ -427,7 +427,6 @@ export function liftReducerWith(
 
         break;
       }
-      case Actions.REFRESH:
       default: {
         // If the action is not recognized, it's a monitor action.
         // Optimization: a monitor action can't change history.

--- a/modules/store-devtools/src/reducer.ts
+++ b/modules/store-devtools/src/reducer.ts
@@ -427,6 +427,7 @@ export function liftReducerWith(
 
         break;
       }
+      case Actions.REFRESH:
       default: {
         // If the action is not recognized, it's a monitor action.
         // Optimization: a monitor action can't change history.


### PR DESCRIPTION
## Description
hi!
this is a fix for https://github.com/ngrx/platform/issues/508 (https://github.com/ngrx/platform/issues/966)

solution:
basically i subscribe to the devtools-extension start action and i trigger an action `refresh` to rerender as is the state transformations