### PR TITLE
fix(Schematics): Remove aliases for state and stateInterface options

### DIFF
--- a/modules/schematics/src/container/schema.json
+++ b/modules/schematics/src/container/schema.json
@@ -91,14 +91,12 @@
     },
     "state": {
       "type": "string",
-      "description": "Specifies the path to the state exports.",
-      "alias": "s"
+      "description": "Specifies the path to the state exports."
     },
     "stateInterface": {
       "type": "string",
       "default": "State",
-      "description": "Specifies the interface for the state.",
-      "alias": "si"
+      "description": "Specifies the interface for the state."
     }
   },
   "required": []


### PR DESCRIPTION
Container aliases for state and stateInterface removed.

BREAKING CHANGE:

Aliases for `state` and `stateInterface` were removed due to conflicts with component aliases without reasonable alternatives.