### PR TITLE
feat(Schematics): Rename default action type for action blueprint

### DIFF
--- a/modules/schematics/src/action/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.actions.ts
+++ b/modules/schematics/src/action/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.actions.ts
@@ -1,11 +1,11 @@
 import { Action } from '@ngrx/store';
 
 export enum <%= classify(name) %>ActionTypes {
-  <%= classify(name) %>Action = '[<%= classify(name) %>] Action'
+  Load<%= classify(name) %>s = '[<%= classify(name) %>] Load <%= classify(name) %>s'
 }
 
 export class <%= classify(name) %> implements Action {
-  readonly type = <%= classify(name) %>ActionTypes.<%= classify(name) %>Action;
+  readonly type = <%= classify(name) %>ActionTypes.Load<%= classify(name) %>s;
 }
 
-export type <%= classify(name) %>Actions = <%= classify(name) %>;
+export type <%= classify(name) %>Actions = Load<%= classify(name) %>s;

--- a/modules/schematics/src/effect/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
+++ b/modules/schematics/src/effect/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
@@ -6,7 +6,7 @@ import { Actions, Effect } from '@ngrx/effects';
 export class <%= classify(name) %>Effects {
 <% if(feature) { %>
   @Effect()
-  effect$ = this.actions$.ofType(<%= classify(name) %>ActionTypes.<%= classify(name) %>Action);
+  effect$ = this.actions$.ofType(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s);
 <% } %>
   constructor(private actions$: Actions) {}
 }

--- a/modules/schematics/src/reducer/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.reducer.ts
+++ b/modules/schematics/src/reducer/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.reducer.ts
@@ -12,7 +12,7 @@ export const initialState: State = {
 export function reducer(state = initialState, action: <% if(feature) { %><%= classify(name) %>Actions<% } else { %>Action<% } %>): State {
   switch (action.type) {
 <% if(feature) { %>
-    case <%= classify(name) %>ActionTypes.<%= classify(name) %>Action:
+    case <%= classify(name) %>ActionTypes.Load<%= classify(name) %>s:
       return state;
 
 <% } %>


### PR DESCRIPTION
Closes #1040

BREAKING CHANGE:

The action blueprint has been updated to be less generic, with associated reducer and effects updated for the feature blueprint

BEFORE:

export enum UserActionTypes {
  UserAction = '[User] Action'
}

export class User implements Action {
  readonly type = UserActionTypes.UserAction;
}

export type UserActions = User;

AFTER:

export enum UserActionTypes {
  LoadUsers = '[User] Load Users'
}

export class LoadUsers implements Action {
  readonly type = UserActionTypes.LoadUsers;
}

export type UserActions = LoadUsers;