### PR TITLE
improve documentation for Non-dispatching Effects

### DIFF
--- a/docs/effects/api.md
+++ b/docs/effects/api.md
@@ -75,7 +75,7 @@ export class SomeEffectsClass {
 
 Pass `{ dispatch: false }` to the decorator to prevent dispatching. 
 
-When an effect not dispatch an another action, the browser will crash because the effect is both 'subscribing' and 'dispatching'. This will causing an infinite loop. Common use case for `{ dispatch: false }` is logging and router navigation.
+Sometimes you don't want effects to dispatch an action, for example when you only want to log or navigate. But when an effect does not dispatch another action, the browser will crash because the effect is both 'subscribing' to and 'dispatching' the exact same action, causing an infinite loop. To prevent this, add { dispatch: false } to the decorator.
 
 Usage:
 

--- a/docs/effects/api.md
+++ b/docs/effects/api.md
@@ -73,7 +73,9 @@ export class SomeEffectsClass {
 
 ### Non-dispatching Effects
 
-Pass `{ dispatch: false }` to the decorator to prevent dispatching.
+Pass `{ dispatch: false }` to the decorator to prevent dispatching. 
+
+When an effect not dispatch an another action, the browser will crash because the effect is both 'subscribing' and 'dispatching'. This will causing an infinite loop. Common use case for `{ dispatch: false }` is logging and router navigation.
 
 Usage:
 


### PR DESCRIPTION
There was no an example description for why we have to use `{dispatch: false}` .  The main source idea is from here https://medium.com/@tanya/understanding-ngrx-effects-and-the-action-stream-1a74996a0c1c . Here for the documentation I wrote it in my own words.