### PR TITLE
fix(build): Use default build for schematics

### DIFF
--- a/modules/effects/migrations/BUILD
+++ b/modules/effects/migrations/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "migrations",

--- a/modules/effects/schematics-core/BUILD
+++ b/modules/effects/schematics-core/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "schematics-core",

--- a/modules/entity/migrations/BUILD
+++ b/modules/entity/migrations/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "migrations",

--- a/modules/entity/schematics-core/BUILD
+++ b/modules/entity/schematics-core/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "schematics-core",

--- a/modules/router-store/migrations/BUILD
+++ b/modules/router-store/migrations/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "migrations",

--- a/modules/router-store/schematics-core/BUILD
+++ b/modules/router-store/schematics-core/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "schematics-core",

--- a/modules/schematics/BUILD
+++ b/modules/schematics/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
-load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "schematics",

--- a/modules/schematics/migrations/BUILD
+++ b/modules/schematics/migrations/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "migrations",

--- a/modules/schematics/schematics-core/BUILD
+++ b/modules/schematics/schematics-core/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "schematics-core",

--- a/modules/store-devtools/migrations/BUILD
+++ b/modules/store-devtools/migrations/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "migrations",

--- a/modules/store-devtools/schematics-core/BUILD
+++ b/modules/store-devtools/schematics-core/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "schematics-core",

--- a/modules/store/migrations/BUILD
+++ b/modules/store/migrations/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "migrations",

--- a/modules/store/schematics-core/BUILD
+++ b/modules/store/schematics-core/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "schematics-core",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -11,11 +11,11 @@ NG_DEVKIT_VERSION = "^0.6.0"
 NG_UPDATE_MIGRATIONS = "./migrations/migration.json"
 
 NGRX_SCOPED_PACKAGES = ["@ngrx/%s" % p for p in [
+    "store",
     "effects",
     "entity",
     "router-store",
     "schematics",
-    "store",
     "store-devtools",
 ]]
 


### PR DESCRIPTION
Fixes the replacements when building @ngrx/schematics
Moves `@ngrx/store` to first in the `packageGroup`, which enables use of `ng update @ngrx/store` to update all installed @ngrx packages