### PR TITLE
docs(Schematics): add information about schematics settings (#1036)

### DIFF
--- a/docs/schematics/README.md
+++ b/docs/schematics/README.md
@@ -43,7 +43,7 @@ ng config cli.defaultCollection @ngrx/schematics
 
 The [collection schema](../../modules/schematics/collection.json) also has aliases to the most common blueprints used to generate files.
 
-The `@ngrx/schematics` extends default `@schematics/angular` collection. If you use additional settings for schematics such as generating components with scss file, you must change the schematics package name from `@schematics/angular` to `@ngrx/schematics` in `angular.json`:
+The `@ngrx/schematics` extend the default `@schematics/angular` collection. If you want to set defaults for schematics such as generating components with scss file, you must change the schematics package name from `@schematics/angular` to `@ngrx/schematics` in `angular.json`:
 
 ```json
 "schematics": {

--- a/docs/schematics/README.md
+++ b/docs/schematics/README.md
@@ -43,6 +43,16 @@ ng config cli.defaultCollection @ngrx/schematics
 
 The [collection schema](../../modules/schematics/collection.json) also has aliases to the most common blueprints used to generate files.
 
+The `@ngrx/schematics` extends default `@schematics/angular` collection. If you use additional settings for schematics such as generating components with scss file, you must change the schematics package name from `@schematics/angular` to `@ngrx/schematics` in `angular.json`:
+
+```json
+"schematics": {
+  "@ngrx/schematics:component": {
+    "styleext": "scss"
+  }
+}
+```
+
 ## Initial State Setup
 
 Generate the initial state management and register it within the `app.module.ts`


### PR DESCRIPTION
PR for #1036 
I added information of additional configuration when default collection for schematics changed to `@ngrx/schematics` and example of that.