### PR TITLE
docs(Schematics): edit README to match ng cli docs

### DIFF
--- a/docs/schematics/README.md
+++ b/docs/schematics/README.md
@@ -2,7 +2,7 @@
 
 Scaffolding library for Angular applications using NgRx libraries.
 
-@ngrx/schematics provides blueprints for generating files when building out feature areas using NgRx. Built on top of `Schematics`, it integrates with the `Angular CLI` to make setting up and expanding NgRx in Angular applications easier.
+@ngrx/schematics provides CLI commands for generating files when building new NgRx feature areas and expanding existing ones. Built on top of [`Schematics`](https://blog.angular.io/schematics-an-introduction-dc1dfbc2a2b2), this tool integrates with the [`Angular CLI`](https://cli.angular.io/).
 
 ### Installation
 
@@ -41,7 +41,7 @@ add it to your `angular.json`:
 ng config cli.defaultCollection @ngrx/schematics
 ```
 
-The [collection schema](../../modules/schematics/collection.json) also has aliases to the most common blueprints used to generate files.
+The [collection schema](../../modules/schematics/collection.json) also has aliases to the most common schematics used to generate files.
 
 The `@ngrx/schematics` extend the default `@schematics/angular` collection. If you want to set defaults for schematics such as generating components with scss file, you must change the schematics package name from `@schematics/angular` to `@ngrx/schematics` in `angular.json`:
 
@@ -69,7 +69,7 @@ Generate the root effects and register it within the `app.module.ts`
 ng generate effect App --root --module app.module.ts --collection @ngrx/schematics
 ```
 
-## Blueprints
+## Schematics
 
 * [Action](action.md)
 * [Container](container.md)


### PR DESCRIPTION
Addresses issue #1060 
1) Edited the introduction and added some links.
2) Changed instances of "blueprints" to "schematics".