### PR TITLE
No need to use | after #

### DIFF
--- a/example-app/app/auth/effects/auth.effects.spec.ts
+++ b/example-app/app/auth/effects/auth.effects.spec.ts
@@ -84,7 +84,7 @@ describe('AuthEffects', () => {
       const error = 'Invalid username or password';
 
       actions$.stream = hot('-a---', { a: action });
-      const response = cold('-#|', {}, error);
+      const response = cold('-#', {}, error);
       const expected = cold('--b', { b: completion });
       authService.login = jest.fn(() => response);
 


### PR DESCRIPTION
`#` is already an error terminating the observable.
Using `|` is redundant because an Observable cannot complete twice.