### PR TITLE
fix: Added defaults for ng-add schematics

### DIFF
--- a/modules/effects/schematics/ng-add/index.spec.ts
+++ b/modules/effects/schematics/ng-add/index.spec.ts
@@ -22,7 +22,7 @@ describe('Effect ng-add Schematic', () => {
     skipPackageJson: false,
     project: 'bar',
     spec: true,
-    module: undefined,
+    module: 'app',
     flat: false,
     group: false,
   };
@@ -66,14 +66,12 @@ describe('Effect ng-add Schematic', () => {
     ).toBeGreaterThanOrEqual(0);
   });
 
-  it('should not be provided by default', () => {
+  it('should be provided by default', () => {
     const options = { ...defaultOptions };
 
     const tree = schematicRunner.runSchematic('ng-add', options, appTree);
     const content = tree.readContent(`${projectPath}/src/app/app.module.ts`);
-    expect(content).not.toMatch(
-      /import { FooEffects } from '.\/foo\/foo.effects'/
-    );
+    expect(content).toMatch(/import { FooEffects } from '.\/foo\/foo.effects'/);
   });
 
   it('should import into a specified module', () => {
@@ -112,7 +110,7 @@ describe('Effect ng-add Schematic', () => {
   });
 
   it('should register the root effect in the provided module', () => {
-    const options = { ...defaultOptions, module: 'app.module.ts' };
+    const options = { ...defaultOptions };
 
     const tree = schematicRunner.runSchematic('ng-add', options, appTree);
     const content = tree.readContent(`${projectPath}/src/app/app.module.ts`);

--- a/modules/effects/schematics/ng-add/index.ts
+++ b/modules/effects/schematics/ng-add/index.ts
@@ -136,9 +136,6 @@ export default function(options: RootEffectOptions): Rule {
     ]);
 
     return chain([
-      options && options.skipPackageJson
-        ? noop()
-        : addNgRxEffectsToPackageJson(),
       branchAndMerge(
         chain([
           filter(
@@ -150,6 +147,9 @@ export default function(options: RootEffectOptions): Rule {
           mergeWith(templateSource),
         ])
       ),
+      options && options.skipPackageJson
+        ? noop()
+        : addNgRxEffectsToPackageJson(),
     ])(host, context);
   };
 }

--- a/modules/effects/schematics/ng-add/schema.json
+++ b/modules/effects/schematics/ng-add/schema.json
@@ -7,10 +7,7 @@
     "name": {
       "description": "The name of the effect.",
       "type": "string",
-      "$default": {
-        "$source": "argv",
-        "index": 0
-      }
+      "default": "App"
     },
     "skipPackageJson": {
       "type": "boolean",
@@ -21,7 +18,7 @@
     "path": {
       "type": "string",
       "format": "path",
-      "description": "The path to create the component.",
+      "description": "The path to create the effect.",
       "visible": false
     },
     "flat": {
@@ -36,7 +33,7 @@
     },
     "module": {
       "type": "string",
-      "default": "",
+      "default": "app",
       "description": "Allows specification of the declaring module.",
       "alias": "m",
       "subtype": "filepath"

--- a/modules/store/schematics/ng-add/index.spec.ts
+++ b/modules/store/schematics/ng-add/index.spec.ts
@@ -16,10 +16,9 @@ describe('Store ng-add Schematic', () => {
     path.join(__dirname, '../collection.json')
   );
   const defaultOptions: RootStoreOptions = {
-    name: 'foo',
     skipPackageJson: false,
     project: 'bar',
-    module: undefined,
+    module: 'app',
   };
 
   const projectPath = getTestProjectPath();
@@ -58,18 +57,21 @@ describe('Store ng-add Schematic', () => {
     ).toBeGreaterThanOrEqual(0);
   });
 
-  it('should not be provided by default', () => {
+  it('should be provided by default', () => {
     const options = { ...defaultOptions };
 
     const tree = schematicRunner.runSchematic('ng-add', options, appTree);
     const content = tree.readContent(`${projectPath}/src/app/app.module.ts`);
-    expect(content).not.toMatch(
+    expect(content).toMatch(
       /import { reducers, metaReducers } from '\.\/reducers';/
+    );
+    expect(content).toMatch(
+      /StoreModule.forRoot\(reducers, { metaReducers }\)/
     );
   });
 
   it('should import into a specified module', () => {
-    const options = { ...defaultOptions, module: 'app.module.ts' };
+    const options = { ...defaultOptions };
 
     const tree = schematicRunner.runSchematic('ng-add', options, appTree);
     const content = tree.readContent(`${projectPath}/src/app/app.module.ts`);

--- a/modules/store/schematics/ng-add/schema.json
+++ b/modules/store/schematics/ng-add/schema.json
@@ -4,14 +4,6 @@
   "title": "NgRx Root State Management Options Schema",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the state.",
-      "type": "string",
-      "$default": {
-        "$source": "argv",
-        "index": 0
-      }
-    },
     "skipPackageJson": {
       "type": "boolean",
       "default": false,
@@ -21,12 +13,12 @@
     "path": {
       "type": "string",
       "format": "path",
-      "description": "The path to create the component.",
+      "description": "The path to create the state.",
       "visible": false
     },
     "module": {
       "type": "string",
-      "default": "",
+      "default": "app",
       "description": "Allows specification of the declaring module.",
       "alias": "m",
       "subtype": "filepath"

--- a/modules/store/schematics/ng-add/schema.ts
+++ b/modules/store/schematics/ng-add/schema.ts
@@ -1,5 +1,4 @@
 export interface Schema {
-  name: string;
   skipPackageJson?: boolean;
   path?: string;
   project?: string;


### PR DESCRIPTION
Allows the package to be added with sane defaults using `ng add @ngrx/store` and `@ngrx/effects`.

Do not squash these commits