### PR TITLE
[Example App]: Add support for loading images over https

### DIFF
--- a/example-app/app/books/components/book-detail.component.ts
+++ b/example-app/app/books/components/book-detail.component.ts
@@ -95,7 +95,8 @@ export class BookDetailComponent {
   get thumbnail() {
     return (
       this.book.volumeInfo.imageLinks &&
-      this.book.volumeInfo.imageLinks.smallThumbnail
+      this.book.volumeInfo.imageLinks.smallThumbnail && 
+      this.book.volumeInfo.imageLinks.smallThumbnail.replace('http:', '') 
     );
   }
 }

--- a/example-app/app/books/components/book-preview.component.ts
+++ b/example-app/app/books/components/book-preview.component.ts
@@ -96,7 +96,7 @@ export class BookPreviewComponent {
 
   get thumbnail(): string | boolean {
     if (this.book.volumeInfo.imageLinks) {
-      return this.book.volumeInfo.imageLinks.smallThumbnail;
+      return this.book.volumeInfo.imageLinks.smallThumbnail.replace('http:', '');
     }
 
     return false;


### PR DESCRIPTION
closes #1106 
add support for showing images in https (i.e, when loaded in stackblitz): 
<img width="1440" alt="screen shot 2018-05-31 at 8 56 51 am" src="https://user-images.githubusercontent.com/878660/40764210-e4cfe89a-64b0-11e8-8ad6-e64c8564ea0d.png">
