### PR TITLE
Fix command for generate an `Admin` feature state

### DIFF
--- a/docs/schematics/store.md
+++ b/docs/schematics/store.md
@@ -56,7 +56,7 @@ Generate an `Admin` feature state within the `admin` folder and register it with
 
 ```sh
 ng generate module admin --flat false
-ng generate store admin/Admin -m admin/admin.module.ts
+ng generate store admin/Admin -m admin.module.ts
 ```
 
 Generate the initial state management files within a `store` folder and register it within the `app.module.ts`.


### PR DESCRIPTION
https://github.com/ngrx/platform/issues/674
> @crimsonskyfalling this path is implicit. The path you provide for the feature will be the same path provided by the module.