### PR TITLE
expose Dictionary as part of an API

### DIFF
--- a/modules/entity/src/index.ts
+++ b/modules/entity/src/index.ts
@@ -1,2 +1,2 @@
 export { createEntityAdapter } from './create_adapter';
-export { EntityState, EntityAdapter, Update } from './models';
+export { Dictionary, EntityState, EntityAdapter, Update } from './models';


### PR DESCRIPTION
When code exports a symbol whose type is inferred (or contains an inferred type), the type must be imported so that a correct name can be generated for it in the resulting .d.ts file.

For example, that means when we create any `selector` we have to import `MemoizedSelector` to the file, and, also not to have the **unused import** linter error, at least one of the selectors has to be fully typed.

Since `MemoizedSelector` is exported through `public_api.ts`, solving this problem is pretty straightforward, however one of the teams has started using `entities` now and has to import `Dictionary` for the exactly same reason, but `Dictionary` is not exported.

e.g. this is the code that they need to use:
```
export const fooEntities: MemoizedSelector<StateWithFoo, Dictionary<Foo>> =
    createSelector(fooFeature, adapter.getSelectors().selectEntities);
```

for more on exported variables with inferred type:
https://github.com/Microsoft/TypeScript/issues/5711#issuecomment-157793294
