### PR TITLE
Allow custom serializer

### DIFF
--- a/modules/store-devtools/spec/extension.spec.ts
+++ b/modules/store-devtools/spec/extension.spec.ts
@@ -15,7 +15,7 @@ import { unliftState } from '../src/utils';
 function createOptions(
   name: string = 'NgRx Store DevTools',
   features: any = false,
-  serialize: boolean | undefined = undefined,
+  serialize: boolean | undefined = false,
   maxAge: false | number = false
 ) {
   const options: ReduxDevtoolsExtensionConfig = {

--- a/modules/store-devtools/spec/extension.spec.ts
+++ b/modules/store-devtools/spec/extension.spec.ts
@@ -15,7 +15,7 @@ import { unliftState } from '../src/utils';
 function createOptions(
   name: string = 'NgRx Store DevTools',
   features: any = false,
-  serialize: boolean = false,
+  serialize: boolean | undefined = undefined,
   maxAge: false | number = false
 ) {
   const options: ReduxDevtoolsExtensionConfig = {
@@ -114,6 +114,25 @@ describe('DevtoolsExtension', () => {
       10
     );
     expect(reduxDevtoolsExtension.connect).toHaveBeenCalledWith(options);
+  });
+
+  it('should connect with custom serializer', () => {
+    const customSerializer = {
+      replacer: (key: {}, value: any) => value,
+    };
+
+    devtoolsExtension = new DevtoolsExtension(
+      reduxDevtoolsExtension,
+      createConfig({
+        name: 'ngrx-store-devtool-todolist',
+        serialize: customSerializer,
+      })
+    );
+    // Subscription needed or else extension connection will not be established.
+    devtoolsExtension.actions$.subscribe(() => null);
+    expect(reduxDevtoolsExtension.connect).toHaveBeenCalledWith(
+      jasmine.objectContaining({ serialize: customSerializer })
+    );
   });
 
   describe('notify', () => {

--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -3,7 +3,7 @@ import { InjectionToken, Type } from '@angular/core';
 
 export type ActionSanitizer = (action: Action, id: number) => Action;
 export type StateSanitizer = (state: any, index: number) => any;
-export type SerializeOptions = {
+export type SerializationOptions = {
   options?: boolean | any;
   replacer?: (key: any, value: any) => {};
   reviver?: (key: any, value: any) => {};
@@ -17,7 +17,7 @@ export class StoreDevtoolsConfig {
   actionSanitizer?: ActionSanitizer;
   stateSanitizer?: StateSanitizer;
   name?: string;
-  serialize?: boolean | SerializeOptions;
+  serialize?: boolean | SerializationOptions;
   logOnly?: boolean;
   features?: any;
 }

--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -3,6 +3,13 @@ import { InjectionToken, Type } from '@angular/core';
 
 export type ActionSanitizer = (action: Action, id: number) => Action;
 export type StateSanitizer = (state: any, index: number) => any;
+export type SerializeOptions = {
+  options?: boolean | any;
+  replacer?: (key: any, value: any) => {};
+  reviver?: (key: any, value: any) => {};
+  immutable?: any;
+  refs?: Array<any>;
+};
 
 export class StoreDevtoolsConfig {
   maxAge: number | false;
@@ -10,7 +17,7 @@ export class StoreDevtoolsConfig {
   actionSanitizer?: ActionSanitizer;
   stateSanitizer?: StateSanitizer;
   name?: string;
-  serialize?: boolean;
+  serialize?: boolean | SerializeOptions;
   logOnly?: boolean;
   features?: any;
 }

--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -5,7 +5,7 @@ import { filter, map, share, switchMap, takeUntil } from 'rxjs/operators';
 
 import { PERFORM_ACTION } from './actions';
 import {
-  SerializeOptions,
+  SerializationOptions,
   STORE_DEVTOOLS_CONFIG,
   StoreDevtoolsConfig,
 } from './config';
@@ -41,7 +41,7 @@ export interface ReduxDevtoolsExtensionConfig {
   name: string | undefined;
   instanceId: string;
   maxAge?: number;
-  serialize?: boolean | SerializeOptions;
+  serialize?: boolean | SerializationOptions;
 }
 
 export interface ReduxDevtoolsExtension {

--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -4,7 +4,11 @@ import { empty, Observable } from 'rxjs';
 import { filter, map, share, switchMap, takeUntil } from 'rxjs/operators';
 
 import { PERFORM_ACTION } from './actions';
-import { STORE_DEVTOOLS_CONFIG, StoreDevtoolsConfig } from './config';
+import {
+  SerializeOptions,
+  STORE_DEVTOOLS_CONFIG,
+  StoreDevtoolsConfig,
+} from './config';
 import { LiftedAction, LiftedState } from './reducer';
 import {
   sanitizeAction,
@@ -37,7 +41,7 @@ export interface ReduxDevtoolsExtensionConfig {
   name: string | undefined;
   instanceId: string;
   maxAge?: number;
-  serialize?: boolean;
+  serialize?: boolean | SerializeOptions;
 }
 
 export interface ReduxDevtoolsExtension {

--- a/modules/store-devtools/src/instrument.ts
+++ b/modules/store-devtools/src/instrument.ts
@@ -60,7 +60,7 @@ export function createConfig(
     actionSanitizer: undefined,
     stateSanitizer: undefined,
     name: DEFAULT_NAME,
-    serialize: false,
+    serialize: undefined,
     logOnly: false,
     features: false,
   };

--- a/modules/store-devtools/src/instrument.ts
+++ b/modules/store-devtools/src/instrument.ts
@@ -60,7 +60,7 @@ export function createConfig(
     actionSanitizer: undefined,
     stateSanitizer: undefined,
     name: DEFAULT_NAME,
-    serialize: undefined,
+    serialize: false,
     logOnly: false,
     features: false,
   };


### PR DESCRIPTION
`serialize` can be boolean or object. One of the teams needs to provide custom replacer.

Adjusting the `serialize` according to the docs for extension:

https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize