### PR TITLE
cleanup metadata and add types

### DIFF
--- a/modules/effects/src/on_run_effects.ts
+++ b/modules/effects/src/on_run_effects.ts
@@ -3,17 +3,19 @@ import { Observable } from 'rxjs';
 import { EffectNotification } from './effect_notification';
 import { getSourceForInstance } from './effects_metadata';
 
+export type onRunEffectsFn = (
+  resolvedEffects$: Observable<EffectNotification>
+) => Observable<EffectNotification>;
+
 export interface OnRunEffects {
-  ngrxOnRunEffects(
-    resolvedEffects$: Observable<EffectNotification>
-  ): Observable<EffectNotification>;
+  ngrxOnRunEffects: onRunEffectsFn;
 }
 
-const onRunEffectsKey: keyof OnRunEffects = 'ngrxOnRunEffects';
+export const onRunEffectsKey: keyof OnRunEffects = 'ngrxOnRunEffects';
 
-export function isOnRunEffects(
-  sourceInstance: Object
-): sourceInstance is OnRunEffects {
+export function isOnRunEffects(sourceInstance: {
+  [onRunEffectsKey]?: onRunEffectsFn;
+}): sourceInstance is OnRunEffects {
   const source = getSourceForInstance(sourceInstance);
 
   return (


### PR DESCRIPTION
Remove leftover of `Reflect`
remove a bunch of `any` types
general cleanup

for https://github.com/ngrx/platform/issues/623

@robwormald @brandonroberts @MikeRyanDev  Any reason in particular why `METADATA_KEY` is added to `sourceProto.constructor` ( aka `instance.constructor`) instead of simply to the `instance`?
This prevents me from removing the remaining `constructor as any` pieces because `constructor` has type of `Function`.

I've experimented with putting it just on `instance` at Firebase and it appears to work just fine, but maybe there is some background that I'm not aware of.