### PR TITLE
feat(Store): feature name should be a key of the state

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -268,7 +268,7 @@ export function createSelectorFactory(
 }
 
 export function createFeatureSelector<T>(
-  featureName: string
+  featureName: keyof T
 ): MemoizedSelector<object, T> {
   return createSelector(
     (state: any) => state[featureName],


### PR DESCRIPTION
Right now you can type everything you want when calling the `createFeatureSelector` method.
This may result in vague errors because the state is undefined at runtime.
This PR should prevent these mistakes.


Result:
![snippet](https://user-images.githubusercontent.com/28659384/41559926-d5132b3a-7345-11e8-9988-b8c429109d5e.png)
