### PR TITLE
fix(schematics): correct a type of action class generated

### DIFF
--- a/modules/schematics/src/action/files/__name@dasherize@if-flat__/__name@dasherize__.actions.ts
+++ b/modules/schematics/src/action/files/__name@dasherize@if-flat__/__name@dasherize__.actions.ts
@@ -8,4 +8,4 @@ export class <%= classify(name) %> implements Action {
   readonly type = <%= classify(name) %>ActionTypes.Load<%= classify(name) %>s;
 }
 
-export type <%= classify(name) %>Actions = Load<%= classify(name) %>s;
+export type <%= classify(name) %>Actions = <%= classify(name) %>;

--- a/modules/schematics/src/action/files/__name@dasherize@if-flat__/__name@dasherize__.actions.ts
+++ b/modules/schematics/src/action/files/__name@dasherize@if-flat__/__name@dasherize__.actions.ts
@@ -4,8 +4,8 @@ export enum <%= classify(name) %>ActionTypes {
   Load<%= classify(name) %>s = '[<%= classify(name) %>] Load <%= classify(name) %>s'
 }
 
-export class <%= classify(name) %> implements Action {
+export class Load<%= classify(name) %>s implements Action {
   readonly type = <%= classify(name) %>ActionTypes.Load<%= classify(name) %>s;
 }
 
-export type <%= classify(name) %>Actions = <%= classify(name) %>;
+export type <%= classify(name) %>Actions = Load<%= classify(name) %>s;

--- a/modules/schematics/src/action/index.spec.ts
+++ b/modules/schematics/src/action/index.spec.ts
@@ -69,7 +69,7 @@ describe('Action Schematic', () => {
     expect(fileContent).toMatch(/export enum FooActionTypes/);
   });
 
-  it('should create a class named "LoadFoos"', () => {
+  it('should create a class based on the provided name', () => {
     const tree = schematicRunner.runSchematic(
       'action',
       defaultOptions,
@@ -82,7 +82,7 @@ describe('Action Schematic', () => {
     expect(fileContent).toMatch(/export class LoadFoos implements Action/);
   });
 
-  it('should create a type named "FooActions"', () => {
+  it('should create the union type based on the provided name', () => {
     const tree = schematicRunner.runSchematic(
       'action',
       defaultOptions,

--- a/modules/schematics/src/action/index.spec.ts
+++ b/modules/schematics/src/action/index.spec.ts
@@ -69,7 +69,7 @@ describe('Action Schematic', () => {
     expect(fileContent).toMatch(/export enum FooActionTypes/);
   });
 
-  it('should create an type named "FooActions"', () => {
+  it('should create a class named "LoadFoos"', () => {
     const tree = schematicRunner.runSchematic(
       'action',
       defaultOptions,
@@ -79,7 +79,20 @@ describe('Action Schematic', () => {
       `${projectPath}/src/app/foo.actions.ts`
     );
 
-    expect(fileContent).toMatch(/export type FooActions = Foo/);
+    expect(fileContent).toMatch(/export class LoadFoos implements Action/);
+  });
+
+  it('should create a type named "FooActions"', () => {
+    const tree = schematicRunner.runSchematic(
+      'action',
+      defaultOptions,
+      appTree
+    );
+    const fileContent = tree.readContent(
+      `${projectPath}/src/app/foo.actions.ts`
+    );
+
+    expect(fileContent).toMatch(/export type FooActions = LoadFoos/);
   });
 
   it('should group within an "actions" folder if group is set', () => {

--- a/modules/schematics/src/action/index.spec.ts
+++ b/modules/schematics/src/action/index.spec.ts
@@ -69,6 +69,19 @@ describe('Action Schematic', () => {
     expect(fileContent).toMatch(/export enum FooActionTypes/);
   });
 
+  it('should create an type named "FooActions"', () => {
+    const tree = schematicRunner.runSchematic(
+      'action',
+      defaultOptions,
+      appTree
+    );
+    const fileContent = tree.readContent(
+      `${projectPath}/src/app/foo.actions.ts`
+    );
+
+    expect(fileContent).toMatch(/export type FooActions = Foo/);
+  });
+
   it('should group within an "actions" folder if group is set', () => {
     const tree = schematicRunner.runSchematic(
       'action',


### PR DESCRIPTION
I used `ng generate action` command and found the generated file are invalid.
Please check the result I generated, thank you.

* Result I generated
```
import { Action } from '@ngrx/store';

export enum FooActionTypes {
  LoadFoos = '[Foo] Load Foos'
}

export class Foo implements Action {
  readonly type = FooActionTypes.LoadFoos;
}

export type FooActions = LoadFoos;
```

* Expected
```
import { Action } from '@ngrx/store';

export enum FooActionTypes {
  LoadFoos = '[Foo] Load Foos'
}

export class Foo implements Action {
  readonly type = FooActionTypes.LoadFoos;
}

export type FooActions = Foo; // <<< this should be Action class name!
```