### PR TITLE
feat(Schematics): use ofType operator function instead of Actions#ofType

### DIFF
--- a/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
+++ b/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
-import { Actions, Effect } from '@ngrx/effects';
-<% if(feature) { %>import { <%= classify(name) %>Actions, <%= classify(name) %>ActionTypes } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
+import { Actions, Effect<% if(feature) { %>, ofType<% } %> } from '@ngrx/effects';
+<% if (feature) { %>import { Load<%= classify(name) %>s, <%= classify(name) %>ActionTypes } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
 
 @Injectable()
 export class <%= classify(name) %>Effects {
-<% if(feature) { %>
+<% if (feature) { %>
   @Effect()
-  effect$ = this.actions$.ofType(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s);
+  effect$ = this.actions$.pipe(ofType<Load<%= classify(name) %>s>(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s));
 <% } %>
   constructor(private actions$: Actions) {}
 }

--- a/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
+++ b/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
@@ -6,7 +6,7 @@ import { Actions, Effect<% if (feature) { %>, ofType<% } %> } from '@ngrx/effect
 export class <%= classify(name) %>Effects {
 <% if (feature) { %>
   @Effect()
-  effect$ = this.actions$.pipe(ofType<Load<%= classify(name) %>s>(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s));
+  loadFoos$ = this.actions$.pipe(ofType<Load<%= classify(name) %>s>(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s));
 <% } %>
   constructor(private actions$: Actions) {}
 }

--- a/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
+++ b/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Actions, Effect<% if(feature) { %>, ofType<% } %> } from '@ngrx/effects';
+import { Actions, Effect<% if (feature) { %>, ofType<% } %> } from '@ngrx/effects';
 <% if (feature) { %>import { Load<%= classify(name) %>s, <%= classify(name) %>ActionTypes } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
 
 @Injectable()

--- a/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
+++ b/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect<% if (feature) { %>, ofType<% } %> } from '@ngrx/effects';
-<% if (feature) { %>import { Load<%= classify(name) %>s, <%= classify(name) %>ActionTypes } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
+<% if (feature) { %>import { <%= classify(name) %>ActionTypes } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
 
 @Injectable()
 export class <%= classify(name) %>Effects {
 <% if (feature) { %>
   @Effect()
-  loadFoos$ = this.actions$.pipe(ofType<Load<%= classify(name) %>s>(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s));
+  loadFoos$ = this.actions$.pipe(ofType(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s));
 <% } %>
   constructor(private actions$: Actions) {}
 }

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -50,7 +50,7 @@ describe('Effect Schematic', () => {
     ).toBeGreaterThanOrEqual(0);
   });
 
-  it('should create an effect class which has an "effect$" property if feature is set', () => {
+  it('should create an effect class which has a "loadFoos$" property if feature is set', () => {
     const options = { ...defaultOptions, feature: true };
 
     const tree = schematicRunner.runSchematic('effect', options, appTree);
@@ -65,11 +65,11 @@ describe('Effect Schematic', () => {
     );
     expect(content).toMatch(/export class FooEffects/);
     expect(content).toMatch(
-      /effect\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
+      /loadFoos\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
     );
   });
 
-  it('should create an effect class which does not has an "effect$" property if root is set', () => {
+  it('should create an effect class which does not has a "loadFoos$" property if root is set', () => {
     const options = { ...defaultOptions, root: true };
 
     const tree = schematicRunner.runSchematic('effect', options, appTree);
@@ -84,7 +84,7 @@ describe('Effect Schematic', () => {
     );
     expect(content).toMatch(/export class FooEffects/);
     expect(content).not.toMatch(
-      /effect\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
+      /loadFoos\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
     );
   });
 

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -37,7 +37,7 @@ describe('Effect Schematic', () => {
     appTree = createWorkspace(schematicRunner, appTree);
   });
 
-  it('should create an effect file and its spec file', () => {
+  it('should create an effect with a spec file', () => {
     const options = { ...defaultOptions };
 
     const tree = schematicRunner.runSchematic('effect', options, appTree);
@@ -48,44 +48,6 @@ describe('Effect Schematic', () => {
     expect(
       files.indexOf(`${projectPath}/src/app/foo/foo.effects.ts`)
     ).toBeGreaterThanOrEqual(0);
-  });
-
-  it('should create an effect class which has a "loadFoos$" property if feature is set', () => {
-    const options = { ...defaultOptions, feature: true };
-
-    const tree = schematicRunner.runSchematic('effect', options, appTree);
-    const content = tree.readContent(
-      `${projectPath}/src/app/foo/foo.effects.ts`
-    );
-    expect(content).toMatch(
-      /import { Actions, Effect, ofType } from '@ngrx\/effects';/
-    );
-    expect(content).toMatch(
-      /import { LoadFoos, FooActionTypes } from '\.\/foo.actions';/
-    );
-    expect(content).toMatch(/export class FooEffects/);
-    expect(content).toMatch(
-      /loadFoos\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
-    );
-  });
-
-  it('should create an effect class which does not have a "loadFoos$" property if root is set', () => {
-    const options = { ...defaultOptions, root: true };
-
-    const tree = schematicRunner.runSchematic('effect', options, appTree);
-    const content = tree.readContent(
-      `${projectPath}/src/app/foo/foo.effects.ts`
-    );
-    expect(content).toMatch(
-      /import { Actions, Effect } from '@ngrx\/effects';/
-    );
-    expect(content).not.toMatch(
-      /import { LoadFoos, FooActionTypes } from '\.\/foo.actions';/
-    );
-    expect(content).toMatch(/export class FooEffects/);
-    expect(content).not.toMatch(
-      /loadFoos\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
-    );
   });
 
   it('should not be provided by default', () => {
@@ -254,6 +216,44 @@ describe('Effect Schematic', () => {
 
     expect(content).toMatch(
       /import \{ LoadFoos, FooActionTypes } from \'\.\.\/\.\.\/actions\/foo\/foo\.actions';/
+    );
+  });
+
+  it('should create an effect that describes a source of actions within a feature', () => {
+    const options = { ...defaultOptions, feature: true };
+
+    const tree = schematicRunner.runSchematic('effect', options, appTree);
+    const content = tree.readContent(
+      `${projectPath}/src/app/foo/foo.effects.ts`
+    );
+    expect(content).toMatch(
+      /import { Actions, Effect, ofType } from '@ngrx\/effects';/
+    );
+    expect(content).toMatch(
+      /import { LoadFoos, FooActionTypes } from '\.\/foo.actions';/
+    );
+    expect(content).toMatch(/export class FooEffects/);
+    expect(content).toMatch(
+      /loadFoos\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
+    );
+  });
+
+  it('should create an effect that does not define a source of actions within the root', () => {
+    const options = { ...defaultOptions, root: true };
+
+    const tree = schematicRunner.runSchematic('effect', options, appTree);
+    const content = tree.readContent(
+      `${projectPath}/src/app/foo/foo.effects.ts`
+    );
+    expect(content).toMatch(
+      /import { Actions, Effect } from '@ngrx\/effects';/
+    );
+    expect(content).not.toMatch(
+      /import { LoadFoos, FooActionTypes } from '\.\/foo.actions';/
+    );
+    expect(content).toMatch(/export class FooEffects/);
+    expect(content).not.toMatch(
+      /loadFoos\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
     );
   });
 });

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -37,7 +37,7 @@ describe('Effect Schematic', () => {
     appTree = createWorkspace(schematicRunner, appTree);
   });
 
-  it('should create an effect', () => {
+  it('should create an effect file and its spec file', () => {
     const options = { ...defaultOptions };
 
     const tree = schematicRunner.runSchematic('effect', options, appTree);
@@ -48,6 +48,44 @@ describe('Effect Schematic', () => {
     expect(
       files.indexOf(`${projectPath}/src/app/foo/foo.effects.ts`)
     ).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should create an effect class which has an "effect$" property if feature is set', () => {
+    const options = { ...defaultOptions, feature: true };
+
+    const tree = schematicRunner.runSchematic('effect', options, appTree);
+    const content = tree.readContent(
+      `${projectPath}/src/app/foo/foo.effects.ts`
+    );
+    expect(content).toMatch(
+      /import { Actions, Effect, ofType } from '@ngrx\/effects';/
+    );
+    expect(content).toMatch(
+      /import { LoadFoos, FooActionTypes } from '\.\/foo.actions';/
+    );
+    expect(content).toMatch(/export class FooEffects/);
+    expect(content).toMatch(
+      /effect\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
+    );
+  });
+
+  it('should create an effect class which does not has an "effect$" property if root is set', () => {
+    const options = { ...defaultOptions, root: true };
+
+    const tree = schematicRunner.runSchematic('effect', options, appTree);
+    const content = tree.readContent(
+      `${projectPath}/src/app/foo/foo.effects.ts`
+    );
+    expect(content).toMatch(
+      /import { Actions, Effect } from '@ngrx\/effects';/
+    );
+    expect(content).not.toMatch(
+      /import { LoadFoos, FooActionTypes } from '\.\/foo.actions';/
+    );
+    expect(content).toMatch(/export class FooEffects/);
+    expect(content).not.toMatch(
+      /effect\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
+    );
   });
 
   it('should not be provided by default', () => {
@@ -215,7 +253,7 @@ describe('Effect Schematic', () => {
     );
 
     expect(content).toMatch(
-      /import\ \{\ FooActions,\ FooActionTypes\ }\ from\ \'\.\.\/\.\.\/actions\/foo\/foo\.actions';/
+      /import \{ LoadFoos, FooActionTypes } from \'\.\.\/\.\.\/actions\/foo\/foo\.actions';/
     );
   });
 });

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -215,7 +215,7 @@ describe('Effect Schematic', () => {
     );
 
     expect(content).toMatch(
-      /import \{ LoadFoos, FooActionTypes } from \'\.\.\/\.\.\/actions\/foo\/foo\.actions';/
+      /import \{ FooActionTypes } from \'\.\.\/\.\.\/actions\/foo\/foo\.actions';/
     );
   });
 
@@ -230,11 +230,11 @@ describe('Effect Schematic', () => {
       /import { Actions, Effect, ofType } from '@ngrx\/effects';/
     );
     expect(content).toMatch(
-      /import { LoadFoos, FooActionTypes } from '\.\/foo.actions';/
+      /import { FooActionTypes } from '\.\/foo.actions';/
     );
     expect(content).toMatch(/export class FooEffects/);
     expect(content).toMatch(
-      /loadFoos\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
+      /loadFoos\$ = this\.actions\$.pipe\(ofType\(FooActionTypes\.LoadFoos\)\);/
     );
   });
 
@@ -249,11 +249,11 @@ describe('Effect Schematic', () => {
       /import { Actions, Effect } from '@ngrx\/effects';/
     );
     expect(content).not.toMatch(
-      /import { LoadFoos, FooActionTypes } from '\.\/foo.actions';/
+      /import { FooActionTypes } from '\.\/foo.actions';/
     );
     expect(content).toMatch(/export class FooEffects/);
     expect(content).not.toMatch(
-      /loadFoos\$ = this\.actions\$.pipe\(ofType<LoadFoos>\(FooActionTypes\.LoadFoos\)\);/
+      /loadFoos\$ = this\.actions\$.pipe\(ofType\(FooActionTypes\.LoadFoos\)\);/
     );
   });
 });

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -69,7 +69,7 @@ describe('Effect Schematic', () => {
     );
   });
 
-  it('should create an effect class which does not has a "loadFoos$" property if root is set', () => {
+  it('should create an effect class which does not have a "loadFoos$" property if root is set', () => {
     const options = { ...defaultOptions, root: true };
 
     const tree = schematicRunner.runSchematic('effect', options, appTree);


### PR DESCRIPTION
I suppose that we should use ofType operator function instead of Actions#ofType in generated files by schematics.
Please consider this change, thank you!