### PR TITLE
#1160 - Update Entity Adapter documentation for clarity

### DIFF
--- a/docs/entity/adapter.md
+++ b/docs/entity/adapter.md
@@ -261,19 +261,17 @@ export function reducer(state = initialState, action: UserActionsUnion): State {
 
 export const getSelectedUserId = (state: State) => state.selectedUserId;
 
-export const {
-  // select the array of user ids
-  selectIds: selectUserIds,
+// select the array of user ids
+export const selectUserIds = adapter.getSelectors().selectIds;
 
-  // select the dictionary of user entities
-  selectEntities: selectUserEntities,
+// select the dictionary of user entities
+export const selectUserEntities = adapter.getSelectors().selectEntities;
 
-  // select the array of users
-  selectAll: selectAllUsers,
+// select the array of users
+export const selectAllUsers = adapter.getSelectors().selectAll;
 
-  // select the total user count
-  selectTotal: selectUserTotal,
-} = adapter.getSelectors();
+// select the total user count
+export const selectUserTotal = adapter.getSelectors().selectTotal;
 ```
 
 ### Entity Selectors

--- a/docs/entity/adapter.md
+++ b/docs/entity/adapter.md
@@ -261,17 +261,20 @@ export function reducer(state = initialState, action: UserActionsUnion): State {
 
 export const getSelectedUserId = (state: State) => state.selectedUserId;
 
+// get the selectors
+const { selectIds, selectEntities, selectAll, selectTotal } = adapter.getSelectors();
+
 // select the array of user ids
-export const selectUserIds = adapter.getSelectors().selectIds;
+export const selectUserIds = selectIds;
 
 // select the dictionary of user entities
-export const selectUserEntities = adapter.getSelectors().selectEntities;
+export const selectUserEntities = selectEntities;
 
 // select the array of users
-export const selectAllUsers = adapter.getSelectors().selectAll;
+export const selectAllUsers = selectAll;
 
 // select the total user count
-export const selectUserTotal = adapter.getSelectors().selectTotal;
+export const selectUserTotal = selectTotal;
 ```
 
 ### Entity Selectors


### PR DESCRIPTION
Destructuring syntax in this example adds a layer of complexity that may trip up developers who aren't used to using it. Declaring the Entity Adapter selector methods more explicitly should help to keep the example focused on its original intent.