### PR TITLE
style(Schematics): revise Effects class name in description of spec file

### DIFF
--- a/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects__dot__spec.ts
+++ b/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects__dot__spec.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 
 import { <%= classify(name) %>Effects } from './<%= dasherize(name) %>.effects';
 
-describe('<%= classify(name) %>Service', () => {
+describe('<%= classify(name) %>Effects', () => {
   let actions$: Observable<any>;
   let effects: <%= classify(name) %>Effects;
 


### PR DESCRIPTION
I think "FooEffects" is more suitable than "FooService" for description of effects spec file.
please review this change, thank you!
