### PR TITLE
chore(Example): remove tslint configuration conflicting with prettier

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,35 +1,11 @@
 {
   "rules": {
     "class-name": true,
-    "comment-format": [true, "check-space"],
-    "indent": [true, "spaces"],
     "no-duplicate-variable": true,
     "no-eval": false,
     "no-internal-module": true,
-    "no-trailing-whitespace": true,
     "no-var-keyword": true,
-    "one-line": [true, "check-open-brace", "check-whitespace"],
-    "quotemark": [true, "single", "avoid-escape"],
-    "semicolon": true,
     "triple-equals": [false, "allow-null-check"],
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
-      }
-    ],
-    "variable-name": [true, "ban-keywords", "allow-leading-underscore"],
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ]
+    "variable-name": [true, "ban-keywords", "allow-leading-underscore"]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,7 @@
     "no-trailing-whitespace": true,
     "no-var-keyword": true,
     "one-line": [true, "check-open-brace", "check-whitespace"],
-    "quotemark": [true, "single"],
+    "quotemark": [true, "single", "avoid-escape"],
     "semicolon": true,
     "triple-equals": [false, "allow-null-check"],
     "typedef-whitespace": [


### PR DESCRIPTION
Now, tslint fails as described below.

```
$ ng lint

ERROR: /platform/example-app/app/shared/pipes/ellipsis.pipe.spec.ts[42, 6]: " should be '
```

We should use single quotes with escaping.

*ellipsis.pipe.spec.ts#L42
```
// current code
it("should return the string if it's length is less than 250", () => {
// expected
it('should return the string if it\'s length is less than 250', () => {
```

But this file is formatted by prettier as described below.

```
$ yarn run pritter

- it('should return the string if it\'s length is less than 250', () => {
+  it("should return the string if it's length is less than 250", () => {
```

So  I add tslint the "avoid-escape" option.
And ng lint command passes as expected.

```
$ ng lint

All files pass linting.
```

Also, we can use back-quotes instead double quotes.
In this way, we need not update tslint.json.

```
it(`should return the string if it's length is less than 250`, () => {
```

Please consider my change, thank you!