### PR TITLE
Prepare for TS 2.9

### DIFF
--- a/modules/store-devtools/src/reducer.ts
+++ b/modules/store-devtools/src/reducer.ts
@@ -330,7 +330,7 @@ export function liftReducerWith(
           skippedActionIds,
           committedState,
           currentStateIndex,
-          computedStates,
+          computedStates
         } = liftedAction.nextLiftedState);
         break;
       }

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -100,8 +100,10 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
     this.reducerManager.addReducer(key, reducer);
   }
 
+  // Once TS is >= 2.8 replace with <Key extends Extract<keyof T, string>>
   removeReducer<Key extends keyof T>(key: Key) {
-    this.reducerManager.removeReducer(key);
+    // TS2.9: keyof T is string|number|symbol, explicitly cast to string to fix.
+    this.reducerManager.removeReducer(key as string);
   }
 }
 

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   singleQuote: true,
-  trailingComma: 'es5',
+  trailingComma: 'none',
 };


### PR DESCRIPTION
At Google we already switched to 2.9. This PR makes ngrx/platform compatible with 2.9 as well (while still running fine at 2.7.2)