### PR TITLE
style(ExampleApp): remove unused import

### DIFF
--- a/example-app/app/auth/components/login-form.component.spec.ts
+++ b/example-app/app/auth/components/login-form.component.spec.ts
@@ -2,8 +2,6 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { StoreModule, Store, combineReducers } from '@ngrx/store';
 import { LoginFormComponent } from './login-form.component';
-import * as Auth from '../actions/auth';
-import * as fromAuth from '../reducers';
 import { ReactiveFormsModule } from '@angular/forms';
 
 describe('Login Page', () => {


### PR DESCRIPTION
The `../actions/auth` import is throwing an error because the file does not exist.
Removed the imports because there aren't used.