### PR TITLE
feat: allow properties in selectors

### DIFF
--- a/modules/store/spec/integration.spec.ts
+++ b/modules/store/spec/integration.spec.ts
@@ -177,6 +177,38 @@ describe('ngRx Integration spec', () => {
     });
 
     it('should use props to get a todo', () => {
+      const getTodosById = createSelector(
+        (state: TodoAppSchema, id: number) => {
+          return state.todos.find(p => p.id === id);
+        }
+      );
+
+      let testCase = 1;
+      const todo$ = store.pipe(select(getTodosById, 2));
+      todo$.subscribe(todo => {
+        if (testCase === 1) {
+          expect(todo).toEqual(undefined);
+        } else if (testCase === 2) {
+          expect(todo).toEqual({
+            id: 2,
+            text: 'second todo',
+            completed: false,
+          });
+        } else if (testCase === 3) {
+          expect(todo).toEqual({ id: 2, text: 'second todo', completed: true });
+        }
+        testCase++;
+      });
+
+      store.dispatch({ type: ADD_TODO, payload: { text: 'first todo' } });
+      store.dispatch({ type: ADD_TODO, payload: { text: 'second todo' } });
+      store.dispatch({
+        type: COMPLETE_TODO,
+        payload: { id: 2 },
+      });
+    });
+
+    it('should use the selector and props to get a todo', () => {
       const getTodosState = createFeatureSelector<TodoAppSchema, Todo[]>(
         'todos'
       );

--- a/modules/store/spec/selector.spec.ts
+++ b/modules/store/spec/selector.spec.ts
@@ -224,6 +224,51 @@ describe('Selectors', () => {
     });
   });
 
+  describe('createSelector with only a props selector', () => {
+    it('should deliver the state and the props to the projection function', () => {
+      const projectFn = jasmine.createSpy('projectionFn');
+      const state = { counter: {} };
+      const props = { value: 47 };
+      const selector = createSelector(projectFn)(state, props);
+      expect(projectFn).toHaveBeenCalledWith(state, props);
+    });
+
+    it('should be possible to use a projector fn', () => {
+      const projectFn = jasmine.createSpy('projectionFn');
+      const selector = createSelector(projectFn);
+      selector.projector('foo', 'bar');
+      expect(projectFn).toHaveBeenCalledWith('foo', 'bar');
+    });
+
+    it('should call the projector function when the state changes', () => {
+      const projectFn = jasmine.createSpy('projectionFn');
+      const selector = createSelector(projectFn);
+
+      const firstState = { first: 'state' };
+      const secondState = { second: 'state' };
+      const props = { foo: 'props' };
+      selector(firstState, props);
+      selector(firstState, props);
+      selector(secondState, props);
+      expect(projectFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should allow you to release memoized arguments', () => {
+      const state = { first: 'state' };
+      const props = { first: 'props' };
+      const projectFn = jasmine.createSpy('projectionFn');
+      const selector = createSelector(projectFn);
+
+      selector(state, props);
+      selector(state, props);
+      selector.release();
+      selector(state, props);
+      selector(state, props);
+
+      expect(projectFn).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('createSelector with arrays', () => {
     it('should deliver the value of selectors to the projection function', () => {
       const projectFn = jasmine.createSpy('projectionFn');

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -33,6 +33,9 @@ export interface StoreFeature<T, V extends Action = Action> {
   metaReducers?: MetaReducer<T, V>[];
 }
 
-export interface Selector<T, V> {
-  (state: T): V;
-}
+export type Selector<T, V> = (state: T) => V;
+
+export type SelectorWithProps<State, Props, Result> = (
+  state: State,
+  props: Props
+) => Result;

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -1,4 +1,4 @@
-import { Selector } from './models';
+import { Selector, SelectorWithProps } from './models';
 
 export type AnyFn = (...args: any[]) => any;
 
@@ -10,6 +10,12 @@ export type ComparatorFn = (a: any, b: any) => boolean;
 
 export interface MemoizedSelector<State, Result>
   extends Selector<State, Result> {
+  release(): void;
+  projector: AnyFn;
+}
+
+export interface MemoizedSelectorWithProps<State, Props, Result>
+  extends SelectorWithProps<State, Props, Result> {
   release(): void;
   projector: AnyFn;
 }
@@ -80,31 +86,68 @@ export function defaultMemoize(
 
 export function createSelector<State, S1, Result>(
   s1: Selector<State, S1>,
-  projector: (S1: S1) => Result
+  projector: (s1: S1) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, Result>(
+  s1: SelectorWithProps<State, Props, S1>,
+  projector: (s1: S1) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
 export function createSelector<State, S1, Result>(
   selectors: [Selector<State, S1>],
   projector: (s1: S1) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, Result>(
+  selectors: [SelectorWithProps<State, Props, S1>],
+  projector: (s1: S1) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
+
 export function createSelector<State, S1, S2, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
   projector: (s1: S1, s2: S2) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, Result>(
+  s1: SelectorWithProps<State, Props, S1>,
+  s2: SelectorWithProps<State, Props, S2>,
+  projector: (s1: S1, s2: S2) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
 export function createSelector<State, S1, S2, Result>(
   selectors: [Selector<State, S1>, Selector<State, S2>],
   projector: (s1: S1, s2: S2) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, Result>(
+  selectors: [
+    SelectorWithProps<State, Props, S1>,
+    SelectorWithProps<State, Props, S2>
+  ],
+  projector: (s1: S1, s2: S2) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
+
 export function createSelector<State, S1, S2, S3, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
   s3: Selector<State, S3>,
   projector: (s1: S1, s2: S2, s3: S3) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, S3, Result>(
+  s1: SelectorWithProps<State, Props, S1>,
+  s2: SelectorWithProps<State, Props, S2>,
+  s3: SelectorWithProps<State, Props, S3>,
+  projector: (s1: S1, s2: S2, s3: S3) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
 export function createSelector<State, S1, S2, S3, Result>(
   selectors: [Selector<State, S1>, Selector<State, S2>, Selector<State, S3>],
   projector: (s1: S1, s2: S2, s3: S3) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, S3, Result>(
+  selectors: [
+    SelectorWithProps<State, Props, S1>,
+    SelectorWithProps<State, Props, S2>,
+    SelectorWithProps<State, Props, S3>
+  ],
+  projector: (s1: S1, s2: S2, s3: S3) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
+
 export function createSelector<State, S1, S2, S3, S4, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -112,6 +155,13 @@ export function createSelector<State, S1, S2, S3, S4, Result>(
   s4: Selector<State, S4>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, S3, S4, Result>(
+  s1: SelectorWithProps<State, Props, S1>,
+  s2: SelectorWithProps<State, Props, S2>,
+  s3: SelectorWithProps<State, Props, S3>,
+  s4: SelectorWithProps<State, Props, S4>,
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
 export function createSelector<State, S1, S2, S3, S4, Result>(
   selectors: [
     Selector<State, S1>,
@@ -121,6 +171,16 @@ export function createSelector<State, S1, S2, S3, S4, Result>(
   ],
   projector: (s1: S1, s2: S2, s3: S3, s4: S4) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, S3, S4, Result>(
+  selectors: [
+    SelectorWithProps<State, Props, S1>,
+    SelectorWithProps<State, Props, S2>,
+    SelectorWithProps<State, Props, S3>,
+    SelectorWithProps<State, Props, S4>
+  ],
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
+
 export function createSelector<State, S1, S2, S3, S4, S5, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -129,6 +189,14 @@ export function createSelector<State, S1, S2, S3, S4, S5, Result>(
   s5: Selector<State, S5>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, S3, S4, S5, Result>(
+  s1: SelectorWithProps<State, Props, S1>,
+  s2: SelectorWithProps<State, Props, S2>,
+  s3: SelectorWithProps<State, Props, S3>,
+  s4: SelectorWithProps<State, Props, S4>,
+  s5: SelectorWithProps<State, Props, S5>,
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
 export function createSelector<State, S1, S2, S3, S4, S5, Result>(
   selectors: [
     Selector<State, S1>,
@@ -139,6 +207,17 @@ export function createSelector<State, S1, S2, S3, S4, S5, Result>(
   ],
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, S3, S4, S5, Result>(
+  selectors: [
+    SelectorWithProps<State, Props, S1>,
+    SelectorWithProps<State, Props, S2>,
+    SelectorWithProps<State, Props, S3>,
+    SelectorWithProps<State, Props, S4>,
+    SelectorWithProps<State, Props, S5>
+  ],
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
+
 export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -148,6 +227,15 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
   s6: Selector<State, S6>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, S3, S4, S5, S6, Result>(
+  s1: SelectorWithProps<State, Props, S1>,
+  s2: SelectorWithProps<State, Props, S2>,
+  s3: SelectorWithProps<State, Props, S3>,
+  s4: SelectorWithProps<State, Props, S4>,
+  s5: SelectorWithProps<State, Props, S5>,
+  s6: SelectorWithProps<State, Props, S6>,
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
 export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
   selectors: [
     Selector<State, S1>,
@@ -159,6 +247,18 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
   ],
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<State, Props, S1, S2, S3, S4, S5, S6, Result>(
+  selectors: [
+    SelectorWithProps<State, Props, S1>,
+    SelectorWithProps<State, Props, S2>,
+    SelectorWithProps<State, Props, S3>,
+    SelectorWithProps<State, Props, S4>,
+    SelectorWithProps<State, Props, S5>,
+    SelectorWithProps<State, Props, S6>
+  ],
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
+
 export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -169,6 +269,27 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
   s7: Selector<State, S7>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<
+  State,
+  Props,
+  S1,
+  S2,
+  S3,
+  S4,
+  S5,
+  S6,
+  S7,
+  Result
+>(
+  s1: SelectorWithProps<State, Props, S1>,
+  s2: SelectorWithProps<State, Props, S2>,
+  s3: SelectorWithProps<State, Props, S3>,
+  s4: SelectorWithProps<State, Props, S4>,
+  s5: SelectorWithProps<State, Props, S5>,
+  s6: SelectorWithProps<State, Props, S6>,
+  s7: SelectorWithProps<State, Props, S7>,
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
 export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
   selectors: [
     Selector<State, S1>,
@@ -181,6 +302,30 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
   ],
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<
+  State,
+  Props,
+  S1,
+  S2,
+  S3,
+  S4,
+  S5,
+  S6,
+  S7,
+  Result
+>(
+  selectors: [
+    SelectorWithProps<State, Props, S1>,
+    SelectorWithProps<State, Props, S2>,
+    SelectorWithProps<State, Props, S3>,
+    SelectorWithProps<State, Props, S4>,
+    SelectorWithProps<State, Props, S5>,
+    SelectorWithProps<State, Props, S6>,
+    SelectorWithProps<State, Props, S7>
+  ],
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
+
 export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -201,6 +346,38 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
     s8: S8
   ) => Result
 ): MemoizedSelector<State, Result>;
+export function createSelector<
+  State,
+  Props,
+  S1,
+  S2,
+  S3,
+  S4,
+  S5,
+  S6,
+  S7,
+  S8,
+  Result
+>(
+  s1: SelectorWithProps<State, Props, S1>,
+  s2: SelectorWithProps<State, Props, S2>,
+  s3: SelectorWithProps<State, Props, S3>,
+  s4: SelectorWithProps<State, Props, S4>,
+  s5: SelectorWithProps<State, Props, S5>,
+  s6: SelectorWithProps<State, Props, S6>,
+  s7: SelectorWithProps<State, Props, S7>,
+  s8: SelectorWithProps<State, Props, S8>,
+  projector: (
+    s1: S1,
+    s2: S2,
+    s3: S3,
+    s4: S4,
+    s5: S5,
+    s6: S6,
+    s7: S7,
+    s8: S8
+  ) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
 export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
   selectors: [
     Selector<State, S1>,
@@ -223,23 +400,61 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
     s8: S8
   ) => Result
 ): MemoizedSelector<State, Result>;
-export function createSelector(...input: any[]) {
+export function createSelector<
+  State,
+  Props,
+  S1,
+  S2,
+  S3,
+  S4,
+  S5,
+  S6,
+  S7,
+  S8,
+  Result
+>(
+  selectors: [
+    SelectorWithProps<State, Props, S1>,
+    SelectorWithProps<State, Props, S2>,
+    SelectorWithProps<State, Props, S3>,
+    SelectorWithProps<State, Props, S4>,
+    SelectorWithProps<State, Props, S5>,
+    SelectorWithProps<State, Props, S6>,
+    SelectorWithProps<State, Props, S7>,
+    SelectorWithProps<State, Props, S8>
+  ],
+  projector: (
+    s1: S1,
+    s2: S2,
+    s3: S3,
+    s4: S4,
+    s5: S5,
+    s6: S6,
+    s7: S7,
+    s8: S8
+  ) => Result
+): MemoizedSelectorWithProps<State, Props, Result>;
+
+export function createSelector(
+  ...input: any[]
+): Selector<any, any> | SelectorWithProps<any, any, any> {
   return createSelectorFactory(defaultMemoize)(...input);
 }
 
 export function defaultStateFn(
   state: any,
-  selectors: Selector<any, any>[],
+  selectors: any[],
+  props: any,
   memoizedProjector: MemoizedProjection
 ): any {
-  const args = selectors.map(fn => fn(state));
-
+  const args = selectors.map(fn => fn(state, props));
   return memoizedProjector.memoized.apply(null, args);
 }
 
 export type SelectorFactoryConfig<T = any, V = any> = {
   stateFn: (
     state: T,
+    props: any,
     selectors: Selector<any, any>[],
     memoizedProjector: MemoizedProjection
   ) => V;
@@ -252,13 +467,22 @@ export function createSelectorFactory<T = any, V = any>(
   memoize: MemoizeFn,
   options: SelectorFactoryConfig<T, V>
 ): (...input: any[]) => Selector<T, V>;
+export function createSelectorFactory<T = any, Props = any, V = any>(
+  memoize: MemoizeFn
+): (...input: any[]) => SelectorWithProps<T, Props, V>;
+export function createSelectorFactory<T = any, Props = any, V = any>(
+  memoize: MemoizeFn,
+  options: SelectorFactoryConfig<T, V>
+): (...input: any[]) => SelectorWithProps<T, Props, V>;
 export function createSelectorFactory(
   memoize: MemoizeFn,
   options: SelectorFactoryConfig<any, any> = {
     stateFn: defaultStateFn,
   }
 ) {
-  return function(...input: any[]): Selector<any, any> {
+  return function(
+    ...input: any[]
+  ): Selector<any, any> | SelectorWithProps<any, any, any> {
     let args = input;
     if (Array.isArray(args[0])) {
       const [head, ...tail] = args;
@@ -276,8 +500,13 @@ export function createSelectorFactory(
       return projector.apply(null, selectors);
     });
 
-    const memoizedState = defaultMemoize(function(state: any) {
-      return options.stateFn.apply(null, [state, selectors, memoizedProjector]);
+    const memoizedState = defaultMemoize(function(state: any, props: any) {
+      return options.stateFn.apply(null, [
+        state,
+        selectors,
+        props,
+        memoizedProjector,
+      ]);
     });
 
     function release() {

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -435,6 +435,10 @@ export function createSelector<
   ) => Result
 ): MemoizedSelectorWithProps<State, Props, Result>;
 
+export function createSelector<State, Props, Result>(
+  projector: SelectorWithProps<State, Props, Result>
+): MemoizedSelectorWithProps<State, Props, Result>;
+
 export function createSelector(
   ...input: any[]
 ): Selector<any, any> | SelectorWithProps<any, any, any> {
@@ -501,6 +505,12 @@ export function createSelectorFactory(
     });
 
     const memoizedState = defaultMemoize(function(state: any, props: any) {
+      // createSelector works directly on state
+      // e.g. createSelector((state, props) => ...)
+      if (selectors.length === 0) {
+        return projector.apply(null, [state, props]);
+      }
+
       return options.stateFn.apply(null, [
         state,
         selectors,

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -109,11 +109,13 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
 
 export const STORE_PROVIDERS: Provider[] = [Store];
 
-export function select<T, K>(
-  mapFn: (state: T) => K
+export function select<T, Props, K>(
+  mapFn: (state: T, props: Props) => K,
+  props?: Props
 ): (source$: Observable<T>) => Observable<K>;
 export function select<T, a extends keyof T>(
-  key: a
+  key: a,
+  props: null
 ): (source$: Observable<T>) => Observable<T[a]>;
 export function select<T, a extends keyof T, b extends keyof T[a]>(
   key1: a,
@@ -175,20 +177,25 @@ export function select<
  * This overload is used to support spread operator with
  * fixed length tuples type in typescript 2.7
  */
-export function select<T, K = any>(
+export function select<T, Props = any, K = any>(
+  propsOrPath: Props,
   ...paths: string[]
 ): (source$: Observable<T>) => Observable<K>;
-export function select<T, K>(
-  pathOrMapFn: ((state: T) => any) | string,
+export function select<T, Props, K>(
+  pathOrMapFn: ((state: T, props?: Props) => any) | string,
+  propsOrPath: Props | string,
   ...paths: string[]
 ) {
   return function selectOperator(source$: Observable<T>): Observable<K> {
     let mapped$: Observable<any>;
 
     if (typeof pathOrMapFn === 'string') {
-      mapped$ = source$.pipe(pluck(pathOrMapFn, ...paths));
+      const pathSlices = [<string>propsOrPath, ...paths].filter(Boolean);
+      mapped$ = source$.pipe(pluck(pathOrMapFn, ...pathSlices));
     } else if (typeof pathOrMapFn === 'function') {
-      mapped$ = source$.pipe(map(pathOrMapFn));
+      mapped$ = source$.pipe(
+        map(source => pathOrMapFn(source, <Props>propsOrPath))
+      );
     } else {
       throw new TypeError(
         `Unexpected type '${typeof pathOrMapFn}' in select operator,` +


### PR DESCRIPTION
This allows to provide provide extra properties inside selectors.

```ts
const selector = createSelector(
  state => state.count * 10,
  (state, props) => state.count + props.value,
  (one, two) => one + two
);

const result = selector(
  {
    count: 10,
  },
  { value: 47 }
);

// Result = 157.
```

If we agree on this I can add a commit to enhance the docs.

Closes #1152.