### PR TITLE
fix(test): remove mapCoverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
       "html",
       "json"
     ],
-    "mapCoverage": true,
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/modules/*.*/"


### PR DESCRIPTION
```
Deprecation Warning:
  Option "mapCoverage" has been removed, as it's no longer necessary.
  Please update your configuration.
```

facebook/jest#5177