### PR TITLE
refactor(schematics-core): rename typo function and variable names

### DIFF
--- a/modules/effects/schematics-core/index.ts
+++ b/modules/effects/schematics-core/index.ts
@@ -42,7 +42,7 @@ export {
 
 export {
   addReducerToState,
-  addReducerToStateInferface,
+  addReducerToStateInterface,
   addReducerImportToNgModule,
   addReducerToActionReducerMap,
   omit,

--- a/modules/effects/schematics-core/utility/ngrx-utils.ts
+++ b/modules/effects/schematics-core/utility/ngrx-utils.ts
@@ -49,7 +49,7 @@ export function addReducerToState(options: any): Rule {
       true
     );
 
-    const stateInferfaceInsert = addReducerToStateInferface(
+    const stateInterfaceInsert = addReducerToStateInterface(
       source,
       reducersPath,
       options
@@ -60,7 +60,7 @@ export function addReducerToState(options: any): Rule {
       options
     );
 
-    const changes = [reducerImport, stateInferfaceInsert, reducerMapInsert];
+    const changes = [reducerImport, stateInterfaceInsert, reducerMapInsert];
     const recorder = host.beginUpdate(reducersPath);
     for (const change of changes) {
       if (change instanceof InsertChange) {
@@ -76,7 +76,7 @@ export function addReducerToState(options: any): Rule {
 /**
  * Insert the reducer into the first defined top level interface
  */
-export function addReducerToStateInferface(
+export function addReducerToStateInterface(
   source: ts.SourceFile,
   reducersPath: string,
   options: { name: string }

--- a/modules/entity/schematics-core/index.ts
+++ b/modules/entity/schematics-core/index.ts
@@ -42,7 +42,7 @@ export {
 
 export {
   addReducerToState,
-  addReducerToStateInferface,
+  addReducerToStateInterface,
   addReducerImportToNgModule,
   addReducerToActionReducerMap,
   omit,

--- a/modules/entity/schematics-core/utility/ngrx-utils.ts
+++ b/modules/entity/schematics-core/utility/ngrx-utils.ts
@@ -49,7 +49,7 @@ export function addReducerToState(options: any): Rule {
       true
     );
 
-    const stateInferfaceInsert = addReducerToStateInferface(
+    const stateInterfaceInsert = addReducerToStateInterface(
       source,
       reducersPath,
       options
@@ -60,7 +60,7 @@ export function addReducerToState(options: any): Rule {
       options
     );
 
-    const changes = [reducerImport, stateInferfaceInsert, reducerMapInsert];
+    const changes = [reducerImport, stateInterfaceInsert, reducerMapInsert];
     const recorder = host.beginUpdate(reducersPath);
     for (const change of changes) {
       if (change instanceof InsertChange) {
@@ -76,7 +76,7 @@ export function addReducerToState(options: any): Rule {
 /**
  * Insert the reducer into the first defined top level interface
  */
-export function addReducerToStateInferface(
+export function addReducerToStateInterface(
   source: ts.SourceFile,
   reducersPath: string,
   options: { name: string }

--- a/modules/router-store/schematics-core/index.ts
+++ b/modules/router-store/schematics-core/index.ts
@@ -42,7 +42,7 @@ export {
 
 export {
   addReducerToState,
-  addReducerToStateInferface,
+  addReducerToStateInterface,
   addReducerImportToNgModule,
   addReducerToActionReducerMap,
   omit,

--- a/modules/router-store/schematics-core/utility/ngrx-utils.ts
+++ b/modules/router-store/schematics-core/utility/ngrx-utils.ts
@@ -49,7 +49,7 @@ export function addReducerToState(options: any): Rule {
       true
     );
 
-    const stateInferfaceInsert = addReducerToStateInferface(
+    const stateInterfaceInsert = addReducerToStateInterface(
       source,
       reducersPath,
       options
@@ -60,7 +60,7 @@ export function addReducerToState(options: any): Rule {
       options
     );
 
-    const changes = [reducerImport, stateInferfaceInsert, reducerMapInsert];
+    const changes = [reducerImport, stateInterfaceInsert, reducerMapInsert];
     const recorder = host.beginUpdate(reducersPath);
     for (const change of changes) {
       if (change instanceof InsertChange) {
@@ -76,7 +76,7 @@ export function addReducerToState(options: any): Rule {
 /**
  * Insert the reducer into the first defined top level interface
  */
-export function addReducerToStateInferface(
+export function addReducerToStateInterface(
   source: ts.SourceFile,
   reducersPath: string,
   options: { name: string }

--- a/modules/schematics-core/index.ts
+++ b/modules/schematics-core/index.ts
@@ -42,7 +42,7 @@ export {
 
 export {
   addReducerToState,
-  addReducerToStateInferface,
+  addReducerToStateInterface,
   addReducerImportToNgModule,
   addReducerToActionReducerMap,
   omit,

--- a/modules/schematics-core/utility/ngrx-utils.ts
+++ b/modules/schematics-core/utility/ngrx-utils.ts
@@ -49,7 +49,7 @@ export function addReducerToState(options: any): Rule {
       true
     );
 
-    const stateInferfaceInsert = addReducerToStateInferface(
+    const stateInterfaceInsert = addReducerToStateInterface(
       source,
       reducersPath,
       options
@@ -60,7 +60,7 @@ export function addReducerToState(options: any): Rule {
       options
     );
 
-    const changes = [reducerImport, stateInferfaceInsert, reducerMapInsert];
+    const changes = [reducerImport, stateInterfaceInsert, reducerMapInsert];
     const recorder = host.beginUpdate(reducersPath);
     for (const change of changes) {
       if (change instanceof InsertChange) {
@@ -76,7 +76,7 @@ export function addReducerToState(options: any): Rule {
 /**
  * Insert the reducer into the first defined top level interface
  */
-export function addReducerToStateInferface(
+export function addReducerToStateInterface(
   source: ts.SourceFile,
   reducersPath: string,
   options: { name: string }

--- a/modules/schematics/schematics-core/index.ts
+++ b/modules/schematics/schematics-core/index.ts
@@ -42,7 +42,7 @@ export {
 
 export {
   addReducerToState,
-  addReducerToStateInferface,
+  addReducerToStateInterface,
   addReducerImportToNgModule,
   addReducerToActionReducerMap,
   omit,

--- a/modules/schematics/schematics-core/utility/ngrx-utils.ts
+++ b/modules/schematics/schematics-core/utility/ngrx-utils.ts
@@ -49,7 +49,7 @@ export function addReducerToState(options: any): Rule {
       true
     );
 
-    const stateInferfaceInsert = addReducerToStateInferface(
+    const stateInterfaceInsert = addReducerToStateInterface(
       source,
       reducersPath,
       options
@@ -60,7 +60,7 @@ export function addReducerToState(options: any): Rule {
       options
     );
 
-    const changes = [reducerImport, stateInferfaceInsert, reducerMapInsert];
+    const changes = [reducerImport, stateInterfaceInsert, reducerMapInsert];
     const recorder = host.beginUpdate(reducersPath);
     for (const change of changes) {
       if (change instanceof InsertChange) {
@@ -76,7 +76,7 @@ export function addReducerToState(options: any): Rule {
 /**
  * Insert the reducer into the first defined top level interface
  */
-export function addReducerToStateInferface(
+export function addReducerToStateInterface(
   source: ts.SourceFile,
   reducersPath: string,
   options: { name: string }

--- a/modules/store-devtools/schematics-core/index.ts
+++ b/modules/store-devtools/schematics-core/index.ts
@@ -42,7 +42,7 @@ export {
 
 export {
   addReducerToState,
-  addReducerToStateInferface,
+  addReducerToStateInterface,
   addReducerImportToNgModule,
   addReducerToActionReducerMap,
   omit,

--- a/modules/store-devtools/schematics-core/utility/ngrx-utils.ts
+++ b/modules/store-devtools/schematics-core/utility/ngrx-utils.ts
@@ -49,7 +49,7 @@ export function addReducerToState(options: any): Rule {
       true
     );
 
-    const stateInferfaceInsert = addReducerToStateInferface(
+    const stateInterfaceInsert = addReducerToStateInterface(
       source,
       reducersPath,
       options
@@ -60,7 +60,7 @@ export function addReducerToState(options: any): Rule {
       options
     );
 
-    const changes = [reducerImport, stateInferfaceInsert, reducerMapInsert];
+    const changes = [reducerImport, stateInterfaceInsert, reducerMapInsert];
     const recorder = host.beginUpdate(reducersPath);
     for (const change of changes) {
       if (change instanceof InsertChange) {
@@ -76,7 +76,7 @@ export function addReducerToState(options: any): Rule {
 /**
  * Insert the reducer into the first defined top level interface
  */
-export function addReducerToStateInferface(
+export function addReducerToStateInterface(
   source: ts.SourceFile,
   reducersPath: string,
   options: { name: string }

--- a/modules/store/schematics-core/index.ts
+++ b/modules/store/schematics-core/index.ts
@@ -42,7 +42,7 @@ export {
 
 export {
   addReducerToState,
-  addReducerToStateInferface,
+  addReducerToStateInterface,
   addReducerImportToNgModule,
   addReducerToActionReducerMap,
   omit,

--- a/modules/store/schematics-core/utility/ngrx-utils.ts
+++ b/modules/store/schematics-core/utility/ngrx-utils.ts
@@ -49,7 +49,7 @@ export function addReducerToState(options: any): Rule {
       true
     );
 
-    const stateInferfaceInsert = addReducerToStateInferface(
+    const stateInterfaceInsert = addReducerToStateInterface(
       source,
       reducersPath,
       options
@@ -60,7 +60,7 @@ export function addReducerToState(options: any): Rule {
       options
     );
 
-    const changes = [reducerImport, stateInferfaceInsert, reducerMapInsert];
+    const changes = [reducerImport, stateInterfaceInsert, reducerMapInsert];
     const recorder = host.beginUpdate(reducersPath);
     for (const change of changes) {
       if (change instanceof InsertChange) {
@@ -76,7 +76,7 @@ export function addReducerToState(options: any): Rule {
 /**
  * Insert the reducer into the first defined top level interface
  */
-export function addReducerToStateInferface(
+export function addReducerToStateInterface(
   source: ts.SourceFile,
   reducersPath: string,
   options: { name: string }


### PR DESCRIPTION
- rename "addReducerToStateInferface" to "addReducerToStateInterface"
- rename "stateInferfaceInsert" to "stateInterfaceInsert"

I ran `yarn copy:schematics` after modifying code in schematics-core directory.


Closes #1209