### PR TITLE
build: check schematics-core files in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             - ~/.cache/yarn
             - node_modules
 
-  schematics-core-copy:
+  check-schematics-core-copied:
     <<: *run_in_node_latest_browsers
     steps:
       - checkout
@@ -88,11 +88,6 @@ jobs:
       - run: yarn
       - run: yarn copy:schematics
       - run: git diff --name-only --exit-code ./modules
-      - save_cache:
-          key: *cache_key
-          paths:
-            - ~/.cache/yarn
-            - node_modules
 
   deploy:
     <<: *run_in_ngcontainer
@@ -113,11 +108,11 @@ workflows:
     jobs:
       - lint
       - bazel
-      - schematics-core-copy
+      - check-schematics-core-copied
       - test
       - deploy:
           requires:
-            - schematics-core-copy
+            - check-schematics-core-copied
             - test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,6 @@ var_2: &run_in_ngcontainer
 var_3: &set_bazel_options
   run:
     command: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc
-var_4: &run_in_node_latest_browsers
-  docker:
-  - image: circleci/node:latest-browsers
 
 jobs:
 
@@ -64,12 +61,15 @@ jobs:
       - run: bazel query --output=label //... | xargs bazel test
 
   test:
-    <<: *run_in_node_latest_browsers
+    docker:
+      - image: circleci/node:latest-browsers
     steps:
       - checkout
       - restore_cache:
           key: *cache_key
       - run: yarn
+      - run: yarn copy:schematics
+      - run: git diff --name-only --exit-code ./modules
       - run: yarn run ci
       - run: yarn run example:build:prod
       - run: yarn run example:test --watch=false
@@ -78,17 +78,6 @@ jobs:
           paths:
             - ~/.cache/yarn
             - node_modules
-
-  check-schematics-core-copied:
-    <<: *run_in_node_latest_browsers
-    steps:
-      - checkout
-      - restore_cache:
-          key: *cache_key
-      - run: yarn
-      - run: yarn copy:schematics
-      - run: git diff --name-only --exit-code ./modules
-
   deploy:
     <<: *run_in_ngcontainer
     steps:
@@ -108,11 +97,9 @@ workflows:
     jobs:
       - lint
       - bazel
-      - check-schematics-core-copied
       - test
       - deploy:
           requires:
-            - check-schematics-core-copied
             - test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ var_2: &run_in_ngcontainer
 var_3: &set_bazel_options
   run:
     command: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc
+var_4: &run_in_node_latest_browsers
+  docker:
+  - image: circleci/node:latest-browsers
 
 jobs:
 
@@ -61,8 +64,7 @@ jobs:
       - run: bazel query --output=label //... | xargs bazel test
 
   test:
-    docker:
-      - image: circleci/node:latest-browsers
+    <<: *run_in_node_latest_browsers
     steps:
       - checkout
       - restore_cache:
@@ -76,6 +78,22 @@ jobs:
           paths:
             - ~/.cache/yarn
             - node_modules
+
+  schematics-core-copy:
+    <<: *run_in_node_latest_browsers
+    steps:
+      - checkout
+      - restore_cache:
+          key: *cache_key
+      - run: yarn
+      - run: yarn copy:schematics
+      - run: git diff --name-only --exit-code ./modules
+      - save_cache:
+          key: *cache_key
+          paths:
+            - ~/.cache/yarn
+            - node_modules
+
   deploy:
     <<: *run_in_ngcontainer
     steps:
@@ -95,9 +113,11 @@ workflows:
     jobs:
       - lint
       - bazel
+      - schematics-core-copy
       - test
       - deploy:
           requires:
+            - schematics-core-copy
             - test
           filters:
             branches:

--- a/modules/schematics-core/utility/ast-utils.ts
+++ b/modules/schematics-core/utility/ast-utils.ts
@@ -10,6 +10,8 @@ import * as ts from 'typescript';
 import { Change, InsertChange } from './change';
 import { insertImport } from './route-utils';
 
+// This is change to fail ci.
+
 /**
  * Find all nodes from the AST in the subtree of node of SyntaxKind kind.
  * @param node

--- a/modules/schematics-core/utility/ast-utils.ts
+++ b/modules/schematics-core/utility/ast-utils.ts
@@ -10,8 +10,6 @@ import * as ts from 'typescript';
 import { Change, InsertChange } from './change';
 import { insertImport } from './route-utils';
 
-// This is change to fail ci.
-
 /**
  * Find all nodes from the AST in the subtree of node of SyntaxKind kind.
  * @param node


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## Why is this change necessarily?
Now, we must run `yarn copy:schematics` after modifying files in the schematics-core folder but we can merge pull request without it.
To prevent it, I add CI a new job.

## Changes I added
I newly added ci the `schematics-core-copy` job.
this job checks whether we executed `yarn copy:schematics` script and its changes are committed surely.
I configure this job to run before test job.

## How does this job work
CI runs `git diff --name-only --exit-code ./modules` command after `yarn copy:schematics` script.
It fails if our commits lacks changes of `yarn copy:schematics` script.

Closes #1214