### PR TITLE
feat(Effects): stringify action on invalid action

### DIFF
--- a/modules/effects/src/effect_notification.ts
+++ b/modules/effects/src/effect_notification.ts
@@ -37,7 +37,7 @@ function reportInvalidActions(
         new Error(
           `Effect ${getEffectName(
             output
-          )} dispatched an invalid action: ${action}`
+          )} dispatched an invalid action: ${stringify(action)}`
         )
       );
     }
@@ -56,4 +56,12 @@ function getEffectName({
   const isMethod = typeof sourceInstance[propertyName] === 'function';
 
   return `"${sourceName}.${propertyName}${isMethod ? '()' : ''}"`;
+}
+
+function stringify(action: Action | null | undefined) {
+  try {
+    return JSON.stringify(action);
+  } catch {
+    return action;
+  }
 }


### PR DESCRIPTION
To have a more meaningful error when the effects retrieve an invalid action we could stringify the action. That way the dev would immediately know which action is wrong, this could be helpful for newcomers.

Message before: 
```
ERROR Error: Effect "AuthEffects.login$" dispatched an invalid action: [object Object]
```

Message after: 
```
ERROR Error: Effect "AuthEffects.login$" dispatched an invalid action: [{"payload":{"user":{"name":"User"}},"type":"[Auth] Login Success"}]
```