### PR TITLE
fix(schematics): Remove peer dependencies on Angular DevKit

### DIFF
--- a/modules/schematics/package.json
+++ b/modules/schematics/package.json
@@ -24,9 +24,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP",
     "migrations": "NG_UPDATE_MIGRATIONS"
-  },
-  "peerDependencies": {
-    "@angular-devkit/core": "NG_DEVKIT_VERSION",
-    "@angular-devkit/schematics": "NG_DEVKIT_VERSION"
   }
 }

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -7,7 +7,6 @@ load("@build_bazel_rules_nodejs//:defs.bzl",
 DEFAULT_TSCONFIG = "//:tsconfig.json"
 NG_VERSION = "^6.0.0"
 RXJS_VERSION = "^5.6.0-forward-compat.0 || ^6.0.0"
-NG_DEVKIT_VERSION = "^0.6.0"
 NG_UPDATE_MIGRATIONS = "./migrations/migration.json"
 MODULE_SCHEMATICS_COLLECTION = "./schematics/collection.json"
 
@@ -30,7 +29,6 @@ PKG_GROUP_REPLACEMENTS = {
     "\"NG_UPDATE_PACKAGE_GROUP\"": """[
       %s
     ]""" % ",\n      ".join(["\"%s\"" % s for s in NGRX_SCOPED_PACKAGES]),
-    "NG_DEVKIT_VERSION": NG_DEVKIT_VERSION,
     "NG_UPDATE_MIGRATIONS": NG_UPDATE_MIGRATIONS,
     "MODULE_SCHEMATICS_COLLECTION": MODULE_SCHEMATICS_COLLECTION,
 }


### PR DESCRIPTION
The peer dependencies prevent you from using `ng update` since they are pinned to specific versions. We'll verify the schematics work across versions and rely on the dependencies provided implicitly with the CLI

Closes #1206