### PR TITLE
fix: deprecate instance operators in Store and Effects

### DIFF
--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -20,6 +20,9 @@ export class Actions<V = Action> extends Observable<V> {
     return observable;
   }
 
+  /**
+   * @deprecated from 6.1.0. Use the pipeable `ofType` operator instead.
+   */
   ofType<V2 extends V = V>(...allowedTypes: string[]): Actions<V2> {
     return ofType<any>(...allowedTypes)(this as Actions<any>) as Actions<V2>;
   }

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -19,6 +19,9 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
     this.source = state$;
   }
 
+  /**
+   * @deprecated from 6.1.0. Use the pipeable `select` operator instead.
+   */
   select<K>(mapFn: (state: T) => K): Observable<K>;
   select<a extends keyof T>(key: a): Observable<T[a]>;
   select<a extends keyof T, b extends keyof T[a]>(


### PR DESCRIPTION
Adding deprecation notices since we'll be removing these at some point before the next major release.