### PR TITLE
Effects: Add support for effects of different instances of same class

### DIFF
--- a/modules/effects/spec/effect_sources.spec.ts
+++ b/modules/effects/spec/effect_sources.spec.ts
@@ -92,12 +92,23 @@ describe('EffectSources', () => {
     });
 
     it('should ignore duplicate sources', () => {
+      const sources$ = cold('--a--a--a--', {
+        a: new SourceA(),
+      });
+      const expected = cold('--a--------', { a });
+
+      const output = toActions(sources$);
+
+      expect(output).toBeObservable(expected);
+    });
+
+    it('should resolve effects from same class but different instances', () => {
       const sources$ = cold('--a--b--c--', {
         a: new SourceA(),
         b: new SourceA(),
         c: new SourceA(),
       });
-      const expected = cold('--a--------', { a });
+      const expected = cold('--a--a--a--', { a });
 
       const output = toActions(sources$);
 

--- a/modules/effects/src/effect_sources.ts
+++ b/modules/effects/src/effect_sources.ts
@@ -11,7 +11,6 @@ import {
 } from 'rxjs/operators';
 
 import { verifyOutput } from './effect_notification';
-import { getSourceForInstance } from './effects_metadata';
 import { resolveEffectSource } from './effects_resolver';
 
 @Injectable()
@@ -29,7 +28,7 @@ export class EffectSources extends Subject<any> {
    */
   toActions(): Observable<Action> {
     return this.pipe(
-      groupBy(getSourceForInstance),
+      groupBy(source => source),
       mergeMap(source$ =>
         source$.pipe(
           exhaustMap(resolveEffectSource),


### PR DESCRIPTION
Fixes #1246 

With this change, it is possible to add different instances of the same class to the effects and have them running:

```
class ConfigurableEffect {
  @Effect({ dispatch: false })
  doSth$ = timer(1000).pipe(
    tap(() => console.log(this.message))
  );

  constructor(private message: string) { }
}

@NgModule({
  imports: [BrowserModule, FormsModule, StoreModule.forRoot(() => true), EffectsModule.forRoot([])],
  declarations: [AppComponent, HelloComponent],
  bootstrap: [AppComponent]
})
export class AppModule {
  constructor(effectSources: EffectSources) {
    effectSources.addEffects(new ConfigurableEffect("configA"));
    effectSources.addEffects(new ConfigurableEffect("configB"));
    // -> this did not work before, second effects instance was never run
  }
}
```

`EffectSources` still filters out effects which are already running, so no danger of running the same effects instance multiple times.