### PR TITLE
refactor(RouterStore): change default state key to router

### DIFF
--- a/docs/router-store/README.md
+++ b/docs/router-store/README.md
@@ -34,11 +34,11 @@ export declare type RouterNavigationAction<T = RouterStateSnapshot> = {
 };
 ```
 
-* Reducers receive this action, throwing an error in the reducer cancels navigation.
-* Effects can listen for this action.
-* The `ROUTER_CANCEL` action represents a guard canceling navigation.
-* A `ROUTER_ERROR` action represents a navigation error .
-* `ROUTER_CANCEL` and `ROUTER_ERROR` contain the store state before the navigation. Use the previous state to restore the consistency of the store.
+- Reducers receive this action, throwing an error in the reducer cancels navigation.
+- Effects can listen for this action.
+- The `ROUTER_CANCEL` action represents a guard canceling navigation.
+- A `ROUTER_ERROR` action represents a navigation error .
+- `ROUTER_CANCEL` and `ROUTER_ERROR` contain the store state before the navigation. Use the previous state to restore the consistency of the store.
 
 ## Setup
 
@@ -56,9 +56,7 @@ import { AppComponent } from './app.component';
       // routes
     ]),
     // Connects RouterModule with StoreModule
-    StoreRouterConnectingModule.forRoot({
-      stateKey: 'router', // name of reducer key
-    }),
+    StoreRouterConnectingModule.forRoot(),
   ],
   bootstrap: [AppComponent],
 })
@@ -67,6 +65,7 @@ export class AppModule {}
 
 ## API Documentation
 
-* [Navigation actions](./api.md#navigation-actions)
-* [Effects](./api.md#effects)
-* [Custom Router State Serializer](./api.md#custom-router-state-serializer)
+- [Configuration Options](./api.md#configuration-options)
+- [Navigation actions](./api.md#navigation-actions)
+- [Effects](./api.md#effects)
+- [Custom Router State Serializer](./api.md#custom-router-state-serializer)

--- a/docs/router-store/api.md
+++ b/docs/router-store/api.md
@@ -1,5 +1,18 @@
 # API
 
+## Configuration Options
+
+To connect the Angular router module with the NgRx store module, import the store module via
+`StoreRouterConnectingModule.forRoot()`.
+
+```ts
+interface StoreRouterConfig {
+  stateKey?: string;
+}
+```
+
+- `stateKey`: The name of reducer key, defaults to `router`
+
 ## Navigation actions
 
 Navigation actions are not provided as part of the router package. You provide your own
@@ -150,9 +163,7 @@ export const reducers: ActionReducerMap<State> = {
     RouterModule.forRoot([
       // routes
     ]),
-    StoreRouterConnectingModule.forRoot({
-      stateKey: 'router',
-    }),
+    StoreRouterConnectingModule.forRoot(),
   ],
   providers: [{ provide: RouterStateSerializer, useClass: CustomSerializer }],
 })

--- a/modules/router-store/spec/integration.spec.ts
+++ b/modules/router-store/spec/integration.spec.ts
@@ -244,7 +244,7 @@ describe('integration spec', () => {
         : null;
     };
 
-    createTestModule({ reducers: { routerReducer, reducer } });
+    createTestModule({ reducers: { router: routerReducer, reducer } });
 
     const router = TestBed.get(Router);
     const store = TestBed.get(Store);
@@ -252,8 +252,8 @@ describe('integration spec', () => {
 
     const routerReducerStates: any[] = [];
     store.subscribe((state: any) => {
-      if (state.routerReducer) {
-        routerReducerStates.push(state.routerReducer);
+      if (state.router) {
+        routerReducerStates.push(state.router);
       }
     });
 

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -126,7 +126,7 @@ export const _ROUTER_CONFIG = new InjectionToken(
 export const ROUTER_CONFIG = new InjectionToken(
   '@ngrx/router-store Configuration'
 );
-export const DEFAULT_ROUTER_FEATURENAME = 'routerReducer';
+export const DEFAULT_ROUTER_FEATURENAME = 'router';
 
 export function _createDefaultRouterConfig(
   config: StoreRouterConfig | StoreRouterConfigFunction

--- a/projects/example-app/src/app/app.module.ts
+++ b/projects/example-app/src/app/app.module.ts
@@ -7,10 +7,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 import { DBModule } from '@ngrx/db';
-import {
-  StoreRouterConnectingModule,
-  RouterStateSerializer,
-} from '@ngrx/router-store';
+import { StoreRouterConnectingModule } from '@ngrx/router-store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 
 import { CoreModule } from './core/core.module';
@@ -44,13 +41,7 @@ import { AppRoutingModule } from './app-routing.module';
     /**
      * @ngrx/router-store keeps router state up-to-date in the store.
      */
-    StoreRouterConnectingModule.forRoot({
-      /*
-        They stateKey defines the name of the state used by the router-store reducer.
-        This matches the key defined in the map of reducers
-      */
-      stateKey: 'router',
-    }),
+    StoreRouterConnectingModule.forRoot(),
 
     /**
      * Store devtools instrument the store retaining past versions of state


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1241 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Closes #1241 

BREAKING CHANGE:

The default state key is changed from routerReducer to router
