### PR TITLE
docs(router-store): Document new actions and config

### DIFF
--- a/docs/router-store/README.md
+++ b/docs/router-store/README.md
@@ -16,6 +16,25 @@ Install @ngrx/router-store from npm:
 
 @ngrx/router-store provides four navigation actions which are dispatched in a specific order. Effects can listen to these actions. The `routerReducer` provided by @ngrx/router-store updates its state with the latest router state given by the actions.
 
+#### Order of actions
+
+Success case:
+
+- `ROUTER_REQUEST`
+- `ROUTER_NAVIGATION`
+- `ROUTER_NAVIGATED`
+
+Error / Cancel case (with early [Navigation Action Timing](./api.md#navigation-action-timing)):
+
+- `ROUTER_REQUEST`
+- `ROUTER_NAVIGATION`
+- `ROUTER_CANCEL` / `ROUTER_ERROR`
+
+Error / Cancel case (with late [Navigation Action Timing](./api.md#navigation-action-timing))
+
+- `ROUTER_REQUEST`
+- `ROUTER_CANCEL` / `ROUTER_ERROR`
+
 #### ROUTER_REQUEST
 
 At the start of each navigation, the router will dispatch a `ROUTER_REQUEST` action, which has the following signature:
@@ -110,25 +129,6 @@ export type RouterErrorAction<
 
 The action contains the store state before the navigation. You can use it to restore the consistency of the store.
 
-#### Order of actions
-
-Success case:
-
-- `ROUTER_REQUEST`
-- `ROUTER_NAVIGATION`
-- `ROUTER_NAVIGATED`
-
-Error / Cancel case (with early navigation timing):
-
-- `ROUTER_REQUEST`
-- `ROUTER_NAVIGATION`
-- `ROUTER_CANCEL` / `ROUTER_ERROR`
-
-Error / Cancel case (with late navigation timing)
-
-- `ROUTER_REQUEST`
-- `ROUTER_CANCEL` / `ROUTER_ERROR`
-
 ## Setup
 
 ```ts
@@ -155,7 +155,5 @@ export class AppModule {}
 ## API Documentation
 
 - [Configuration Options](./api.md#configuration-options)
-- [Navigation actions](./api.md#navigation-actions)
-- [Effects](./api.md#effects)
 - [Custom Router State Serializer](./api.md#custom-router-state-serializer)
 - [Navigation Action Timing](./api.md#navigation-action-timing)

--- a/docs/router-store/README.md
+++ b/docs/router-store/README.md
@@ -14,7 +14,7 @@ Install @ngrx/router-store from npm:
 
 ## Usage
 
-@ngrx/router-store provides four navigation actions which are dispatched in a specific order. Effects can listen to these actions. The `routerReducer` provided by @ngrx/router-store updates its state with the latest router state given by the actions.
+@ngrx/router-store provides five navigation actions which are dispatched in a specific order. The `routerReducer` provided by @ngrx/router-store updates its state with the latest router state given by the actions.
 
 #### Order of actions
 

--- a/docs/router-store/README.md
+++ b/docs/router-store/README.md
@@ -35,97 +35,29 @@ Error / Cancel case (with late [Navigation Action Timing](./api.md#navigation-ac
 - `ROUTER_REQUEST`
 - `ROUTER_CANCEL` / `ROUTER_ERROR`
 
-#### ROUTER_REQUEST
+##### ROUTER_REQUEST
 
-At the start of each navigation, the router will dispatch a `ROUTER_REQUEST` action, which has the following signature:
+At the start of each navigation, the router will dispatch a `ROUTER_REQUEST` action.
 
-```ts
-export type RouterRequestPayload = {
-  event: NavigationStart;
-};
+##### ROUTER_NAVIGATION
 
-export type RouterRequestAction = {
-  type: typeof ROUTER_REQUEST;
-  payload: RouterRequestPayload;
-};
-```
-
-#### ROUTER_NAVIGATION
-
-During navigation, before any guards or resolvers run, the router will dispatch a `ROUTER_NAVIGATION` action, which has the following signature:
-
-```ts
-export type RouterNavigationPayload<T extends BaseRouterStoreState> = {
-  routerState: T;
-  event: RoutesRecognized;
-};
-
-export type RouterNavigationAction<
-  T extends BaseRouterStoreState = SerializedRouterStateSnapshot
-> = {
-  type: typeof ROUTER_NAVIGATION;
-  payload: RouterNavigationPayload<T>;
-};
-```
+During navigation, before any guards or resolvers run, the router will dispatch a `ROUTER_NAVIGATION` action.
 
 If you want the `ROUTER_NAVIGATION` to be dispatched after guards or resolvers run, change the [Navigation Action Timing](./api.md#navigation-action-timing).
 
-#### ROUTER_NAVIGATED
+##### ROUTER_NAVIGATED
 
-After a successful navigation, the router will dispatch a `ROUTER_NAVIGATED` action, which has the following signature:
+After a successful navigation, the router will dispatch a `ROUTER_NAVIGATED` action.
 
-```ts
-export type RouterNavigatedPayload = {
-  event: NavigationEnd;
-};
+##### ROUTER_CANCEL
 
-export type RouterNavigatedAction = {
-  type: typeof ROUTER_NAVIGATED;
-  payload: RouterNavigatedPayload;
-};
-```
-
-#### ROUTER_CANCEL
-
-When the navigation is cancelled, for example due to a guard saying that the user cannot access the requested page, the router will dispatch a `ROUTER_CANCEL` action, which has the following signature:
-
-```ts
-export type RouterCancelPayload<T, V extends BaseRouterStoreState> = {
-  routerState: V;
-  storeState: T;
-  event: NavigationCancel;
-};
-
-export type RouterCancelAction<
-  T,
-  V extends BaseRouterStoreState = SerializedRouterStateSnapshot
-> = {
-  type: typeof ROUTER_CANCEL;
-  payload: RouterCancelPayload<T, V>;
-};
-```
+When the navigation is cancelled, for example due to a guard saying that the user cannot access the requested page, the router will dispatch a `ROUTER_CANCEL` action. 
 
 The action contains the store state before the navigation. You can use it to restore the consistency of the store.
 
-#### ROUTER_ERROR
+##### ROUTER_ERROR
 
-When there is an error during navigation, the router will dispatch a `ROUTER_ERROR` action, which has the following signature:
-
-```ts
-export type RouterErrorPayload<T, V extends BaseRouterStoreState> = {
-  routerState: V;
-  storeState: T;
-  event: NavigationError;
-};
-
-export type RouterErrorAction<
-  T,
-  V extends BaseRouterStoreState = SerializedRouterStateSnapshot
-> = {
-  type: typeof ROUTER_ERROR;
-  payload: RouterErrorPayload<T, V>;
-};
-```
+When there is an error during navigation, the router will dispatch a `ROUTER_ERROR` action.
 
 The action contains the store state before the navigation. You can use it to restore the consistency of the store.
 

--- a/docs/router-store/README.md
+++ b/docs/router-store/README.md
@@ -14,31 +14,120 @@ Install @ngrx/router-store from npm:
 
 ## Usage
 
-During the navigation, before any guards or resolvers run, the router will dispatch a `ROUTER_NAVIGATION` action, which has the signature `RouterNavigationAction<T>`:
+@ngrx/router-store provides four navigation actions which are dispatched in a specific order. Effects can listen to these actions. The `routerReducer` provided by @ngrx/router-store updates its state with the latest router state given by the actions.
+
+#### ROUTER_REQUEST
+
+At the start of each navigation, the router will dispatch a `ROUTER_REQUEST` action, which has the following signature:
 
 ```ts
-/**
- * Payload of ROUTER_NAVIGATION.
- */
-export declare type RouterNavigationPayload<T> = {
+export type RouterRequestPayload = {
+  event: NavigationStart;
+};
+
+export type RouterRequestAction = {
+  type: typeof ROUTER_REQUEST;
+  payload: RouterRequestPayload;
+};
+```
+
+#### ROUTER_NAVIGATION
+
+During navigation, before any guards or resolvers run, the router will dispatch a `ROUTER_NAVIGATION` action, which has the following signature:
+
+```ts
+export type RouterNavigationPayload<T extends BaseRouterStoreState> = {
   routerState: T;
   event: RoutesRecognized;
 };
 
-/**
- * An action dispatched when the router navigates.
- */
-export declare type RouterNavigationAction<T = RouterStateSnapshot> = {
+export type RouterNavigationAction<
+  T extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
   type: typeof ROUTER_NAVIGATION;
   payload: RouterNavigationPayload<T>;
 };
 ```
 
-- Reducers receive this action, throwing an error in the reducer cancels navigation.
-- Effects can listen for this action.
-- The `ROUTER_CANCEL` action represents a guard canceling navigation.
-- A `ROUTER_ERROR` action represents a navigation error .
-- `ROUTER_CANCEL` and `ROUTER_ERROR` contain the store state before the navigation. Use the previous state to restore the consistency of the store.
+If you want the `ROUTER_NAVIGATION` to be dispatched after guards or resolvers run, change the [Navigation Action Timing](./api.md#navigation-action-timing).
+
+#### ROUTER_NAVIGATED
+
+After a successful navigation, the router will dispatch a `ROUTER_NAVIGATED` action, which has the following signature:
+
+```ts
+export type RouterNavigatedPayload = {
+  event: NavigationEnd;
+};
+
+export type RouterNavigatedAction = {
+  type: typeof ROUTER_NAVIGATED;
+  payload: RouterNavigatedPayload;
+};
+```
+
+#### ROUTER_CANCEL
+
+When the navigation is cancelled, for example due to a guard saying that the user cannot access the requested page, the router will dispatch a `ROUTER_CANCEL` action, which has the following signature:
+
+```ts
+export type RouterCancelPayload<T, V extends BaseRouterStoreState> = {
+  routerState: V;
+  storeState: T;
+  event: NavigationCancel;
+};
+
+export type RouterCancelAction<
+  T,
+  V extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
+  type: typeof ROUTER_CANCEL;
+  payload: RouterCancelPayload<T, V>;
+};
+```
+
+The action contains the store state before the navigation. You can use it to restore the consistency of the store.
+
+#### ROUTER_ERROR
+
+When there is an error during navigation, the router will dispatch a `ROUTER_ERROR` action, which has the following signature:
+
+```ts
+export type RouterErrorPayload<T, V extends BaseRouterStoreState> = {
+  routerState: V;
+  storeState: T;
+  event: NavigationError;
+};
+
+export type RouterErrorAction<
+  T,
+  V extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
+  type: typeof ROUTER_ERROR;
+  payload: RouterErrorPayload<T, V>;
+};
+```
+
+The action contains the store state before the navigation. You can use it to restore the consistency of the store.
+
+#### Order of actions
+
+Success case:
+
+- `ROUTER_REQUEST`
+- `ROUTER_NAVIGATION`
+- `ROUTER_NAVIGATED`
+
+Error / Cancel case (with early navigation timing):
+
+- `ROUTER_REQUEST`
+- `ROUTER_NAVIGATION`
+- `ROUTER_CANCEL` / `ROUTER_ERROR`
+
+Error / Cancel case (with late navigation timing)
+
+- `ROUTER_REQUEST`
+- `ROUTER_CANCEL` / `ROUTER_ERROR`
 
 ## Setup
 
@@ -69,3 +158,4 @@ export class AppModule {}
 - [Navigation actions](./api.md#navigation-actions)
 - [Effects](./api.md#effects)
 - [Custom Router State Serializer](./api.md#custom-router-state-serializer)
+- [Navigation Action Timing](./api.md#navigation-action-timing)

--- a/docs/router-store/api.md
+++ b/docs/router-store/api.md
@@ -17,97 +17,6 @@ interface StoreRouterConfig {
 - `serializer`: How a router snapshot is serialized. Defaults to `DefaultRouterStateSerializer`. See [Custom Router State Serializer](#custom-router-state-serializer) for more information.
 - `navigationActionTiming`: When the `ROUTER_NAVIGATION` is dispatched. Defaults to `NavigationActionTiming.PreActivation`. See [Navigation Action Timing](#navigation-action-timing) for more information.
 
-## Navigation actions
-
-Navigation actions are not provided as part of the router package. You provide your own
-custom navigation actions that use the `Router` within effects to navigate.
-
-```ts
-import { Action } from '@ngrx/store';
-import { NavigationExtras } from '@angular/router';
-
-export const GO = '[Router] Go';
-export const BACK = '[Router] Back';
-export const FORWARD = '[Router] Forward';
-
-export class Go implements Action {
-  readonly type = GO;
-
-  constructor(
-    public payload: {
-      path: any[];
-      query?: object;
-      extras?: NavigationExtras;
-    }
-  ) {}
-}
-
-export class Back implements Action {
-  readonly type = BACK;
-}
-
-export class Forward implements Action {
-  readonly type = FORWARD;
-}
-
-export type RouterActionsUnion = Go | Back | Forward;
-```
-
-```ts
-import * as RouterActions from './actions/router';
-
-store.dispatch(new RouterActions.Go({
-  path: ['/path', { routeParam: 1 }],
-  query: { page: 1 },
-  extras: { replaceUrl: false }
-});
-
-store.dispatch(new RouterActions.Back());
-
-store.dispatch(new RouterActions.Forward());
-```
-
-## Effects
-
-```ts
-import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
-import { Location } from '@angular/common';
-import { Effect, Actions, ofType } from '@ngrx/effects';
-import { map, tap } from 'rxjs/operators';
-import * as RouterActions from './actions/router';
-
-@Injectable()
-export class RouterEffects {
-  @Effect({ dispatch: false })
-  navigate$ = this.actions$.pipe(
-    ofType(RouterActions.GO),
-    map((action: RouterActions.Go) => action.payload),
-    tap(({ path, query: queryParams, extras }) =>
-      this.router.navigate(path, { queryParams, ...extras })
-    )
-  );
-
-  @Effect({ dispatch: false })
-  navigateBack$ = this.actions$.pipe(
-    ofType(RouterActions.BACK),
-    tap(() => this.location.back())
-  );
-
-  @Effect({ dispatch: false })
-  navigateForward$ = this.actions$.pipe(
-    ofType(RouterActions.FORWARD),
-    tap(() => this.location.forward())
-  );
-
-  constructor(
-    private actions$: Actions,
-    private router: Router,
-    private location: Location
-  ) {}
-}
-```
-
 ## Custom Router State Serializer
 
 During each navigation cycle, a `RouterNavigationAction` is dispatched with a snapshot of the state in its payload, the `RouterStateSnapshot`. The `RouterStateSnapshot` is a large complex structure, containing many pieces of information about the current state and what's rendered by the router. This can cause performance
@@ -115,9 +24,9 @@ issues when used with the Store Devtools. In most cases, you may only need a pie
 
 Additionally, the router state snapshot is a mutable object, which can cause issues when developing with [store freeze](https://github.com/brandonroberts/ngrx-store-freeze) to prevent direct state mutations. This can be avoided by using a custom serializer.
 
-Your custom serializer should implement the abstract class `RouterStateSerializer` and return a snapshot having at least the properties of `BaseRouterStoreState`.
+Your custom serializer should implement the abstract class `RouterStateSerializer` and return a snapshot which should have an interface extending `BaseRouterStoreState`.
 
-You can provide the serializer through the config (recommended) or through a provider.
+You then provide the serializer through the config.
 
 ```ts
 import { StoreModule, ActionReducerMap } from '@ngrx/store';
@@ -141,7 +50,6 @@ export interface State {
 
 @Injectable()
 export class CustomSerializer implements RouterStateSerializer<RouterStateUrl> {
-  constructor(/* If you need to, you can inject services, too */) {}
   serialize(routerState: RouterStateSnapshot): RouterStateUrl {
     let route = routerState.root;
 
@@ -169,10 +77,9 @@ export const reducers: ActionReducerMap<State> = {
       // routes
     ]),
     StoreRouterConnectingModule.forRoot({
-      serializer: RouterStateSerializer, // Recommended way
+      serializer: RouterStateSerializer,
     }),
   ],
-  // providers: [{ provide: RouterStateSerializer, useClass: CustomSerializer }], // Alternative way
 })
 export class AppModule {}
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This PR updates the router-store docs with information about the new actions and config.

One thing I came across during this is the section "Navigation actions", where it is said "Navigation actions are not provided as part of the router package". To me that seems confusing. Is this just really outdated or what is meant by that exactly?
