### PR TITLE
fix(router-store): Handle navigation error, cancel/error action contain real previous state

### DIFF
--- a/modules/router-store/spec/integration.spec.ts
+++ b/modules/router-store/spec/integration.spec.ts
@@ -1,6 +1,12 @@
-import { Component, Provider, Injectable } from '@angular/core';
+import { Component, Provider, Injectable, ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { NavigationEnd, Router, RouterStateSnapshot } from '@angular/router';
+import {
+  NavigationEnd,
+  Router,
+  RouterStateSnapshot,
+  NavigationCancel,
+  NavigationError,
+} from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store, StoreModule, ScannedActionsSubject } from '@ngrx/store';
 import { filter, first, mapTo, take } from 'rxjs/operators';
@@ -19,6 +25,7 @@ import {
   ROUTER_REQUEST,
   ROUTER_NAVIGATED,
   NavigationActionTiming,
+  RouterReducerState,
 } from '../src/router_store_module';
 
 describe('integration spec', () => {
@@ -119,7 +126,7 @@ describe('integration spec', () => {
       });
   });
 
-  it('should support rolling back if navigation gets canceled', (done: any) => {
+  it('should support rolling back if navigation gets canceled (navigation initialized through roter)', (done: any) => {
     const reducer = (state: string = '', action: RouterAction<any>): any => {
       if (action.type === ROUTER_NAVIGATION) {
         return {
@@ -176,9 +183,9 @@ describe('integration spec', () => {
           {
             type: 'store',
             state: {
-              url: '/next',
+              url: '/',
               lastAction: ROUTER_CANCEL,
-              storeState: { url: '/next', lastAction: ROUTER_NAVIGATION },
+              storeState: { url: '/', lastAction: ROUTER_NAVIGATION },
             },
           },
           { type: 'action', action: ROUTER_CANCEL },
@@ -189,7 +196,67 @@ describe('integration spec', () => {
       });
   });
 
-  it('should support rolling back if navigation errors', (done: any) => {
+  it('should support rolling back if navigation gets canceled (navigation initialized through store)', (done: any) => {
+    const CHANGE_ROUTE = 'CHANGE_ROUTE';
+    const reducer = (
+      state: RouterReducerState,
+      action: any
+    ): RouterReducerState => {
+      if (action.type === CHANGE_ROUTE) {
+        return {
+          state: { url: '/next', root: <any>{} },
+          navigationId: 123,
+        };
+      } else {
+        const nextState = routerReducer(state, action);
+        if (nextState && nextState.state) {
+          nextState.state.root = <any>{};
+        }
+        return nextState;
+      }
+    };
+
+    createTestModule({
+      reducers: { reducer },
+      canActivate: () => false,
+      config: { stateKey: 'reducer' },
+    });
+
+    const router: Router = TestBed.get(Router);
+    const store: Store<any> = TestBed.get(Store);
+    const log = logOfRouterAndActionsAndStore();
+
+    router
+      .navigateByUrl('/')
+      .then(() => {
+        log.splice(0);
+        store.dispatch({ type: CHANGE_ROUTE });
+        return waitForNavigation(router, NavigationCancel);
+      })
+      .then(() => {
+        expect(log).toEqual([
+          { type: 'router', event: 'NavigationStart', url: '/next' },
+          {
+            type: 'store',
+            state: { state: { url: '/next', root: {} }, navigationId: 123 },
+          },
+          { type: 'action', action: CHANGE_ROUTE },
+          { type: 'router', event: 'RoutesRecognized', url: '/next' },
+          { type: 'router', event: 'GuardsCheckStart', url: '/next' },
+          { type: 'router', event: 'GuardsCheckEnd', url: '/next' },
+          {
+            type: 'store',
+            state: { state: { url: '/', root: {} }, navigationId: 2 },
+          },
+          { type: 'action', action: ROUTER_CANCEL },
+          { type: 'router', event: 'NavigationCancel', url: '/next' },
+        ]);
+
+        done();
+      });
+  });
+
+  it('should support rolling back if navigation errors (navigation initialized through router)', (done: any) => {
     const reducer = (state: string = '', action: RouterAction<any>): any => {
       if (action.type === ROUTER_NAVIGATION) {
         return {
@@ -246,10 +313,78 @@ describe('integration spec', () => {
           {
             type: 'store',
             state: {
-              url: '/next',
+              url: '/',
               lastAction: ROUTER_ERROR,
-              storeState: { url: '/next', lastAction: ROUTER_NAVIGATION },
+              storeState: { url: '/', lastAction: ROUTER_NAVIGATION },
             },
+          },
+          { type: 'action', action: ROUTER_ERROR },
+          { type: 'router', event: 'NavigationError', url: '/next' },
+        ]);
+
+        done();
+      });
+  });
+
+  it('should support rolling back if navigation errors (navigation initialized through store)', (done: any) => {
+    const CHANGE_ROUTE = 'CHANGE_ROUTE';
+    const reducer = (
+      state: RouterReducerState,
+      action: any
+    ): RouterReducerState => {
+      if (action.type === CHANGE_ROUTE) {
+        return {
+          state: { url: '/next', root: <any>{} },
+          navigationId: 123,
+        };
+      } else {
+        const nextState = routerReducer(state, action);
+        if (nextState && nextState.state) {
+          nextState.state.root = <any>{};
+        }
+        return nextState;
+      }
+    };
+
+    class SilentErrorHandler implements ErrorHandler {
+      handleError() {
+        // don't log router navigation error to not pollute console output of test
+      }
+    }
+
+    createTestModule({
+      reducers: { reducer },
+      canActivate: () => {
+        throw new Error('BOOM!');
+      },
+      providers: [{provide: ErrorHandler, useClass: SilentErrorHandler}],
+      config: { stateKey: 'reducer' },
+    });
+
+    const router: Router = TestBed.get(Router);
+    const store: Store<any> = TestBed.get(Store);
+    const log = logOfRouterAndActionsAndStore();
+
+    router
+      .navigateByUrl('/')
+      .then(() => {
+        log.splice(0);
+          store.dispatch({ type: CHANGE_ROUTE });
+        return waitForNavigation(router, NavigationError);
+      })
+      .then(() => {
+        expect(log).toEqual([
+          { type: 'router', event: 'NavigationStart', url: '/next' },
+          {
+            type: 'store',
+            state: { state: { url: '/next', root: {} }, navigationId: 123 },
+          },
+          { type: 'action', action: CHANGE_ROUTE },
+          { type: 'router', event: 'RoutesRecognized', url: '/next' },
+          { type: 'router', event: 'GuardsCheckStart', url: '/next' },
+          {
+            type: 'store',
+            state: { state: { url: '/', root: {} }, navigationId: 2 },
           },
           { type: 'action', action: ROUTER_ERROR },
           { type: 'router', event: 'NavigationError', url: '/next' },
@@ -385,7 +520,7 @@ describe('integration spec', () => {
         { type: 'store', state: null }, // ROUTER_REQEST event in the store
         { type: 'action', action: ROUTER_REQUEST },
         { type: 'router', event: 'NavigationStart', url: '/load' },
-        { type: 'store', state: null },
+        { type: 'store', state: { url: '', navigationId: 1 } },
         { type: 'action', action: ROUTER_CANCEL },
         { type: 'router', event: 'NavigationCancel', url: '/load' },
       ]);
@@ -744,12 +879,9 @@ function createTestModule(
   TestBed.createComponent(AppCmp);
 }
 
-function waitForNavigation(router: Router) {
+function waitForNavigation(router: Router, event: any = NavigationEnd) {
   return router.events
-    .pipe(
-      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
-      first()
-    )
+    .pipe(filter(e => e instanceof event), first())
     .toPromise();
 }
 

--- a/modules/router-store/spec/integration.spec.ts
+++ b/modules/router-store/spec/integration.spec.ts
@@ -126,7 +126,7 @@ describe('integration spec', () => {
       });
   });
 
-  it('should support rolling back if navigation gets canceled (navigation initialized through roter)', (done: any) => {
+  it('should support rolling back if navigation gets canceled (navigation initialized through router)', (done: any) => {
     const reducer = (state: string = '', action: RouterAction<any>): any => {
       if (action.type === ROUTER_NAVIGATION) {
         return {
@@ -326,7 +326,7 @@ describe('integration spec', () => {
       });
   });
 
-  it('should support rolling back if navigation errors (navigation initialized through store)', (done: any) => {
+  it('should support rolling back if navigation errors and hand error to error handler (navigation initialized through store)', (done: any) => {
     const CHANGE_ROUTE = 'CHANGE_ROUTE';
     const reducer = (
       state: RouterReducerState,
@@ -346,18 +346,19 @@ describe('integration spec', () => {
       }
     };
 
+    const routerError = new Error('BOOM!');
     class SilentErrorHandler implements ErrorHandler {
-      handleError() {
-        // don't log router navigation error to not pollute console output of test
+      handleError(error: any) {
+        expect(error).toBe(routerError);
       }
     }
 
     createTestModule({
       reducers: { reducer },
       canActivate: () => {
-        throw new Error('BOOM!');
+        throw routerError;
       },
-      providers: [{provide: ErrorHandler, useClass: SilentErrorHandler}],
+      providers: [{ provide: ErrorHandler, useClass: SilentErrorHandler }],
       config: { stateKey: 'reducer' },
     });
 
@@ -369,7 +370,7 @@ describe('integration spec', () => {
       .navigateByUrl('/')
       .then(() => {
         log.splice(0);
-          store.dispatch({ type: CHANGE_ROUTE });
+        store.dispatch({ type: CHANGE_ROUTE });
         return waitForNavigation(router, NavigationError);
       })
       .then(() => {

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -3,6 +3,7 @@ import {
   InjectionToken,
   ModuleWithProviders,
   NgModule,
+  ErrorHandler,
 } from '@angular/core';
 import {
   NavigationCancel,
@@ -20,6 +21,7 @@ import {
   SerializedRouterStateSnapshot,
   BaseRouterStoreState,
 } from './serializer';
+import { withLatestFrom } from 'rxjs/operators';
 
 /**
  * An action dispatched when a router navigation request is fired.
@@ -291,7 +293,7 @@ export class StoreRouterConnectingModule {
     };
   }
 
-  private routerState: SerializedRouterStateSnapshot;
+  private routerState: SerializedRouterStateSnapshot | null;
   private storeState: any;
   private trigger = RouterTrigger.NONE;
 
@@ -301,7 +303,8 @@ export class StoreRouterConnectingModule {
     private store: Store<any>,
     private router: Router,
     private serializer: RouterStateSerializer<SerializedRouterStateSnapshot>,
-    @Inject(ROUTER_CONFIG) private config: StoreRouterConfig
+    @Inject(ROUTER_CONFIG) private config: StoreRouterConfig,
+    private errorHandler: ErrorHandler
   ) {
     this.stateKey = this.config.stateKey as string;
 
@@ -310,29 +313,31 @@ export class StoreRouterConnectingModule {
   }
 
   private setUpStoreStateListener(): void {
-    this.store.subscribe(state => {
-      this.storeState = state;
-    });
-    this.store.pipe(select(this.stateKey)).subscribe(() => {
-      this.navigateIfNeeded();
-    });
+    this.store
+      .pipe(select(this.stateKey), withLatestFrom(this.store))
+      .subscribe(([routerStoreState, storeState]) => {
+        this.navigateIfNeeded(routerStoreState, storeState);
+      });
   }
 
-  private navigateIfNeeded(): void {
-    if (
-      !this.storeState[this.stateKey] ||
-      !this.storeState[this.stateKey].state
-    ) {
+  private navigateIfNeeded(
+    routerStoreState: RouterReducerState,
+    storeState: any
+  ): void {
+    if (!routerStoreState || !routerStoreState.state) {
       return;
     }
     if (this.trigger === RouterTrigger.ROUTER) {
       return;
     }
 
-    const url = this.storeState[this.stateKey].state.url;
+    const url = routerStoreState.state.url;
     if (this.router.url !== url) {
+      this.storeState = storeState;
       this.trigger = RouterTrigger.STORE;
-      this.router.navigateByUrl(url);
+      this.router.navigateByUrl(url).catch(e => {
+        this.errorHandler.handleError(e);
+      });
     }
   }
 
@@ -342,32 +347,39 @@ export class StoreRouterConnectingModule {
       NavigationActionTiming.PostActivation;
     let routesRecognized: RoutesRecognized;
 
-    this.router.events.subscribe(event => {
-      if (event instanceof NavigationStart) {
-        if (this.trigger !== RouterTrigger.STORE) {
-          this.dispatchRouterRequest(event);
-        }
-      } else if (event instanceof RoutesRecognized) {
-        routesRecognized = event;
-        this.routerState = this.serializer.serialize(event.state);
-
-        if (!dispatchNavLate && this.trigger !== RouterTrigger.STORE) {
-          this.dispatchRouterNavigation(event);
-        }
-      } else if (event instanceof NavigationCancel) {
-        this.dispatchRouterCancel(event);
-      } else if (event instanceof NavigationError) {
-        this.dispatchRouterError(event);
-      } else if (event instanceof NavigationEnd) {
-        if (this.trigger !== RouterTrigger.STORE) {
-          if (dispatchNavLate) {
-            this.dispatchRouterNavigation(routesRecognized);
+    this.router.events
+      .pipe(withLatestFrom(this.store))
+      .subscribe(([event, storeState]) => {
+        if (event instanceof NavigationStart) {
+          this.routerState = this.serializer.serialize(
+            this.router.routerState.snapshot
+          );
+          if (this.trigger !== RouterTrigger.STORE) {
+            this.storeState = storeState;
+            this.dispatchRouterRequest(event);
           }
-          this.dispatchRouterNavigated(event);
+        } else if (event instanceof RoutesRecognized) {
+          routesRecognized = event;
+
+          if (!dispatchNavLate && this.trigger !== RouterTrigger.STORE) {
+            this.dispatchRouterNavigation(event);
+          }
+        } else if (event instanceof NavigationCancel) {
+          this.dispatchRouterCancel(event);
+          this.reset();
+        } else if (event instanceof NavigationError) {
+          this.dispatchRouterError(event);
+          this.reset();
+        } else if (event instanceof NavigationEnd) {
+          if (this.trigger !== RouterTrigger.STORE) {
+            if (dispatchNavLate) {
+              this.dispatchRouterNavigation(routesRecognized);
+            }
+            this.dispatchRouterNavigated(event);
+          }
+          this.reset();
         }
-        this.trigger = RouterTrigger.NONE;
-      }
-    });
+      });
   }
 
   private dispatchRouterRequest(event: NavigationStart): void {
@@ -377,20 +389,23 @@ export class StoreRouterConnectingModule {
   private dispatchRouterNavigation(
     lastRoutesRecognized: RoutesRecognized
   ): void {
+    const nextRouterState = this.serializer.serialize(
+      lastRoutesRecognized.state
+    );
     this.dispatchRouterAction(ROUTER_NAVIGATION, {
-      routerState: this.routerState,
+      routerState: nextRouterState,
       event: new RoutesRecognized(
         lastRoutesRecognized.id,
         lastRoutesRecognized.url,
         lastRoutesRecognized.urlAfterRedirects,
-        this.routerState
+        nextRouterState
       ),
     });
   }
 
   private dispatchRouterCancel(event: NavigationCancel): void {
     this.dispatchRouterAction(ROUTER_CANCEL, {
-      routerState: this.routerState,
+      routerState: this.routerState!,
       storeState: this.storeState,
       event,
     });
@@ -398,7 +413,7 @@ export class StoreRouterConnectingModule {
 
   private dispatchRouterError(event: NavigationError): void {
     this.dispatchRouterAction(ROUTER_ERROR, {
-      routerState: this.routerState,
+      routerState: this.routerState!,
       storeState: this.storeState,
       event: new NavigationError(event.id, event.url, `${event}`),
     });
@@ -415,5 +430,11 @@ export class StoreRouterConnectingModule {
     } finally {
       this.trigger = RouterTrigger.NONE;
     }
+  }
+
+  private reset() {
+    this.trigger = RouterTrigger.NONE;
+    this.storeState = null;
+    this.routerState = null;
   }
 }

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -303,8 +303,8 @@ export class StoreRouterConnectingModule {
     private store: Store<any>,
     private router: Router,
     private serializer: RouterStateSerializer<SerializedRouterStateSnapshot>,
-    @Inject(ROUTER_CONFIG) private config: StoreRouterConfig,
-    private errorHandler: ErrorHandler
+    private errorHandler: ErrorHandler,
+    @Inject(ROUTER_CONFIG) private config: StoreRouterConfig
   ) {
     this.stateKey = this.config.stateKey as string;
 
@@ -335,8 +335,8 @@ export class StoreRouterConnectingModule {
     if (this.router.url !== url) {
       this.storeState = storeState;
       this.trigger = RouterTrigger.STORE;
-      this.router.navigateByUrl(url).catch(e => {
-        this.errorHandler.handleError(e);
+      this.router.navigateByUrl(url).catch(error => {
+        this.errorHandler.handleError(error);
       });
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?

Fixes #1292, #1293 

- Error during navigation initiated by store is caught and handed to ErrorHandler
- `ROUTER_ERROR` / `ROUTER_CANCEL` action now contain previos router and store state 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
