### PR TITLE
docs(store): remove deprecated store.select()

### DIFF
--- a/docs/store/downgrade.md
+++ b/docs/store/downgrade.md
@@ -10,7 +10,7 @@ state, you will need to downgrade the Store service to use it in the AngularJS
 parts of your application.
 
 ```ts
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 import { downgradeInjectable } from '@angular/upgrade/static';
 import { module as ngModule } from 'angular';
 // app
@@ -28,7 +28,7 @@ export default ngModule('appName').controller('AngularJSController', [
   function($scope, $controller, ngrxStoreService) {
     // ...
     ngrxStoreService.dispatch(new MyActionClass(myPayload));
-    ngrxStoreService.select(mySelectorFunction).subscribe(/*...*/);
+    ngrxStoreService.pipe(select(mySelectorFunction)).subscribe(/*...*/);
     // ...
   },
 ]);

--- a/docs/store/selectors.md
+++ b/docs/store/selectors.md
@@ -280,23 +280,11 @@ This section covers some basics of how selectors compare to pipeable operators a
 
 ### Breaking Down the Basics
 
-#### Step 1: Select a non-empty state
+#### Select a non-empty state using pipeable operators
 
 Let's pretend we have a selector called `selectValues` and the component for displaying the data is only interested in defined values, i.e., it should not display empty states.
-The straight-forward solution is to apply the RxJS `filter` operator to the `Observable` returned by `store.select()`:
 
-```ts
-import { filter } from 'rxjs/operators';
-
-store
-  .select(selectValues)
-  .pipe(filter(val => val !== undefined))
-  .subscribe(/* .. */);
-```
-
-#### Step 2: Refactoring to pipeable operators
-
-The same behaviour can be achieved by re-writing the above piece of code to use only RxJS pipeable operators instead of the `store.select()` function:
+We can achieve this behaviour by using only RxJS pipeable operators:
 
 ```ts
 import { map, filter } from 'rxjs/operators';

--- a/docs/store/setup.md
+++ b/docs/store/setup.md
@@ -44,7 +44,7 @@ import { counter } from './counter';
 export class AppModule {}
 ```
 
-You can then inject the `Store` service into your components and services. Use `store.select` to
+You can then inject the `Store` service into your components and services. Use `select` to
 _select_ slice(s) of state:
 
 ```ts


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Updates documentation to no longer reference `store.select`

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
  
The documentation uses `store.select`  
  
Issue Number: #1313 

## What is the new behavior?

The documentation uses `store.pipe(select())`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
