### PR TITLE
[docs/effects/api.md] defer can be lead to misconception

### DIFF
--- a/docs/effects/api.md
+++ b/docs/effects/api.md
@@ -146,8 +146,8 @@ export class SomeEffectsClass {
   constructor(private actions$: Actions) {}
 
   @Effect({ dispatch: false })
-  init$: Observable<any> = of(null)).pipe(
-    tap(() => console.log('init$')
+  init$: Observable<any> = of(null).pipe(
+    tap(() => console.log('init$'))
   );
 }
 ```

--- a/docs/effects/api.md
+++ b/docs/effects/api.md
@@ -146,8 +146,8 @@ export class SomeEffectsClass {
   constructor(private actions$: Actions) {}
 
   @Effect({ dispatch: false })
-  init$: Observable<any> = defer(() => of(null)).pipe(
-    tap(() => console.log('init$'))
+  init$: Observable<any> = of(null)).pipe(
+    tap(() => console.log('init$')
   );
 }
 ```


### PR DESCRIPTION
The part of the description `... executed directly -> after <- the effect...` can lead to misconception in relation to the `defer` observable. It doesnt matter whether the `defer` observable is there or not! The code will always executed directly after the effect class is loaded.
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
