### PR TITLE
 refactor(effects,router-store,store-devtools,store) add type parameter to ModuleWithProviders for Ivy

### DIFF
--- a/modules/effects/src/effects_module.ts
+++ b/modules/effects/src/effects_module.ts
@@ -8,7 +8,9 @@ import { EffectsRunner } from './effects_runner';
 
 @NgModule({})
 export class EffectsModule {
-  static forFeature(featureEffects: Type<any>[]): ModuleWithProviders {
+  static forFeature(
+    featureEffects: Type<any>[]
+  ): ModuleWithProviders<EffectsFeatureModule> {
     return {
       ngModule: EffectsFeatureModule,
       providers: [
@@ -23,7 +25,9 @@ export class EffectsModule {
     };
   }
 
-  static forRoot(rootEffects: Type<any>[]): ModuleWithProviders {
+  static forRoot(
+    rootEffects: Type<any>[]
+  ): ModuleWithProviders<EffectsRootModule> {
     return {
       ngModule: EffectsRootModule,
       providers: [

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -135,7 +135,9 @@ enum RouterTrigger {
   ],
 })
 export class StoreRouterConnectingModule {
-  static forRoot(config: StoreRouterConfig = {}): ModuleWithProviders {
+  static forRoot(
+    config: StoreRouterConfig = {}
+  ): ModuleWithProviders<StoreRouterConnectingModule> {
     return {
       ngModule: StoreRouterConnectingModule,
       providers: [

--- a/modules/store-devtools/src/instrument.ts
+++ b/modules/store-devtools/src/instrument.ts
@@ -50,7 +50,9 @@ export function createStateObservable(
 
 @NgModule({})
 export class StoreDevtoolsModule {
-  static instrument(options: StoreDevtoolsOptions = {}): ModuleWithProviders {
+  static instrument(
+    options: StoreDevtoolsOptions = {}
+  ): ModuleWithProviders<StoreDevtoolsModule> {
     return {
       ngModule: StoreDevtoolsModule,
       providers: [

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -91,13 +91,13 @@ export class StoreModule {
   static forRoot<T, V extends Action = Action>(
     reducers: ActionReducerMap<T, V> | InjectionToken<ActionReducerMap<T, V>>,
     config?: StoreConfig<T, V>
-  ): ModuleWithProviders;
+  ): ModuleWithProviders<StoreRootModule>;
   static forRoot(
     reducers:
       | ActionReducerMap<any, any>
       | InjectionToken<ActionReducerMap<any, any>>,
     config: StoreConfig<any, any> = {}
-  ): ModuleWithProviders {
+  ): ModuleWithProviders<StoreRootModule> {
     return {
       ngModule: StoreRootModule,
       providers: [
@@ -146,12 +146,12 @@ export class StoreModule {
     featureName: string,
     reducers: ActionReducerMap<T, V> | InjectionToken<ActionReducerMap<T, V>>,
     config?: StoreConfig<T, V>
-  ): ModuleWithProviders;
+  ): ModuleWithProviders<StoreFeatureModule>;
   static forFeature<T, V extends Action = Action>(
     featureName: string,
     reducer: ActionReducer<T, V> | InjectionToken<ActionReducer<T, V>>,
     config?: StoreConfig<T, V>
-  ): ModuleWithProviders;
+  ): ModuleWithProviders<StoreFeatureModule>;
   static forFeature(
     featureName: string,
     reducers:
@@ -160,7 +160,7 @@ export class StoreModule {
       | ActionReducer<any, any>
       | InjectionToken<ActionReducer<any, any>>,
     config: StoreConfig<any, any> = {}
-  ): ModuleWithProviders {
+  ): ModuleWithProviders<StoreFeatureModule> {
     return {
       ngModule: StoreFeatureModule,
       providers: [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The new compiler (Ivy) gets its metadata exclusively from reading .d.ts files. This means that any type information lost in the TypeScript compilation is not available when compiling downstream packages. We need to preserve the type of the NgModule returned by a ModuleWithProviders, so a generic type parameter is added to the latter. That type parameter currently has a default (any) but will be removed, requiring all code to specify it.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
