### PR TITLE
docs: clarify that docs are for master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 
 ## Packages
 
+***Note:** The links below will take you to the master branch version of the docs.
+To view the docs corresponding to a specific release (which is probably what you want),
+you need to look up the commit ID for a release and browse the snapshot of this repo at that point
+in time. One way to do this is to view the ["releases"](https://github.com/ngrx/platform/releases)
+tab in github, click the commit hash link, and then click "browse files".*
+
 - [@ngrx/store](./docs/store/README.md) - RxJS powered state management for Angular applications, inspired by Redux
 - [@ngrx/effects](./docs/effects/README.md) - Side Effect model for @ngrx/store to model event sources as actions.
 - [@ngrx/router-store](./docs/router-store/README.md) - Bindings to connect the Angular Router to @ngrx/store

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 
 ***Note:** The links below will take you to the master branch version of the docs.
 To view the docs corresponding to a specific release (which is probably what you want),
-you need to look up the commit ID for a release and browse the snapshot of this repo at that point
-in time. One way to do this is to view the ["releases"](https://github.com/ngrx/platform/releases)
-tab in github, click the commit hash link, and then click "browse files".*
+the easiest way is to use git tags to browse a snapshot of the repo as it was for a release.
+One way to do this is to use github's branches toggle (which is by default labeled
+"Branches: Master" and is located on the far left of the green "clone or download" button, above).
+Click the toggle, click the "tags" tab in the overlay pane, and select the tag for a release.*
 
 - [@ngrx/store](./docs/store/README.md) - RxJS powered state management for Angular applications, inspired by Redux
 - [@ngrx/effects](./docs/effects/README.md) - Side Effect model for @ngrx/store to model event sources as actions.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 ***Note:** The links below will take you to the master branch version of the docs.
 To view the docs corresponding to a specific release (which is probably what you want),
 the easiest way is to use git tags to browse a snapshot of the repo as it was for a release.
-One way to do this is to use github's branches toggle (which is by default labeled
-"Branches: Master" and is located on the far left of the green "clone or download" button, above).
+One way to do this, is to use github's branches toggle (which is by default labeled
+"Branch: Master" and is located on the far left of the green "clone or download" button, above).
 Click the toggle, click the "tags" tab in the overlay pane, and select the tag for a release.*
 
 - [@ngrx/store](./docs/store/README.md) - RxJS powered state management for Angular applications, inspired by Redux


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Documentation content changes
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the docs linked to from the platform README are for the master branch / nightly builds. I often come back to the docs ahead of a major angular release (4->5, 5->6, 6->7) and I believe that every time I've looked at them they've reflected an unreleased api. This might be bad luck on my part, but I look at the docs infrequently enough that I always forget that they don't apply to the package version I'm using.

## What is the new behavior?

This PR adds a helpful message to the readme reminding folks that it's linking to the master branch version of the docs, and explaining how to find the docs for a specific release.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

