### PR TITLE
fix(RouterStore): serialize routeConfig inside the default serializer

### DIFF
--- a/modules/router-store/spec/serializer.spec.ts
+++ b/modules/router-store/spec/serializer.spec.ts
@@ -1,0 +1,101 @@
+import { RouterStateSnapshot } from '@angular/router';
+import { DefaultRouterStateSerializer } from '../src';
+
+describe('serializer', () => {
+  it('should serialize all properties', () => {
+    const serializer = new DefaultRouterStateSerializer();
+    const snapshot = createSnapshot();
+    const routerState = {
+      url: 'url',
+      root: snapshot,
+    } as RouterStateSnapshot;
+
+    const actual = serializer.serialize(routerState);
+    const expected = {
+      url: 'url',
+      root: createExpectedSnapshot(),
+    };
+    expect(actual).toEqual(expected);
+  });
+
+  it('should serialize with an empty routeConfig', () => {
+    const serializer = new DefaultRouterStateSerializer();
+    const snapshot = { ...createSnapshot(), routeConfig: null };
+    const routerState = {
+      url: 'url',
+      root: snapshot,
+    } as RouterStateSnapshot;
+
+    const actual = serializer.serialize(routerState);
+    const expected = {
+      url: 'url',
+      root: {
+        ...createExpectedSnapshot(),
+        routeConfig: null,
+        component: undefined,
+      },
+    };
+    expect(actual).toEqual(expected);
+  });
+
+  it('should serialize children', () => {
+    const serializer = new DefaultRouterStateSerializer();
+    const snapshot = {
+      ...createSnapshot(),
+      children: [createSnapshot('child')],
+    };
+    const routerState = {
+      url: 'url',
+      root: snapshot,
+    } as RouterStateSnapshot;
+
+    const actual = serializer.serialize(routerState);
+
+    const expected = {
+      url: 'url',
+      root: {
+        ...createExpectedSnapshot(),
+        firstChild: createExpectedSnapshot('child'),
+        children: [createExpectedSnapshot('child')],
+      },
+    };
+
+    expect(actual).toEqual(expected);
+  });
+
+  function createSnapshot(prefix = 'root'): any {
+    return {
+      params: `${prefix}-route.params`,
+      paramMap: `${prefix}-route.paramMap`,
+      data: `${prefix}-route.data`,
+      url: `${prefix}-route.url`,
+      outlet: `${prefix}-route.outlet`,
+      routeConfig: {
+        component: `${prefix}-route.routeConfig.component`,
+        path: `${prefix}-route.routeConfig.path`,
+        pathMatch: `${prefix}-route.routeConfig.pathMatch`,
+        redirectTo: `${prefix}-route.routeConfig.redirectTo`,
+        outlet: `${prefix}-route.routeConfig.outlet`,
+      },
+      queryParams: `${prefix}-route.queryParams`,
+      queryParamMap: `${prefix}-route.queryParamMap`,
+      fragment: `${prefix}-route.fragment`,
+      root: `${prefix}-route.root`,
+      parent: `${prefix}-route.parent`,
+      pathFromRoot: `${prefix}-route.params`,
+      firstChild: null,
+      children: [],
+    };
+  }
+
+  function createExpectedSnapshot(prefix = 'root') {
+    return {
+      ...createSnapshot(prefix),
+      component: `${prefix}-route.routeConfig.component`,
+      root: undefined,
+      parent: undefined,
+      firstChild: undefined,
+      pathFromRoot: undefined,
+    };
+  }
+});

--- a/modules/router-store/src/serializer.ts
+++ b/modules/router-store/src/serializer.ts
@@ -39,9 +39,15 @@ export class DefaultRouterStateSerializer
       data: route.data,
       url: route.url,
       outlet: route.outlet,
-      routeConfig: {
-        component: route.routeConfig ? route.routeConfig.component : undefined,
-      },
+      routeConfig: route.routeConfig
+        ? {
+            component: route.routeConfig.component,
+            path: route.routeConfig.path,
+            pathMatch: route.routeConfig.pathMatch,
+            redirectTo: route.routeConfig.redirectTo,
+            outlet: route.routeConfig.outlet,
+          }
+        : null,
       queryParams: route.queryParams,
       queryParamMap: route.queryParamMap,
       fragment: route.fragment,

--- a/projects/ngrx.io/content/guide/migration/v7.md
+++ b/projects/ngrx.io/content/guide/migration/v7.md
@@ -94,6 +94,26 @@ AFTER:
 StoreRouterConnectingModule.forRoot(),
 ```
 
+### ActivatedRouteSnapshot.RouteConfig
+
+The default router serializer now returns a `null` value for `routeConfig` when `routeConfig` doesn't exist on the `ActivatedRouteSnapshot` instead of an empty object.
+
+BEFORE:
+
+```json
+{
+  "routeConfig": {}
+}
+```
+
+AFTER:
+
+```json
+{
+  "routeConfig": null
+}
+```
+
 ## @ngrx/store-devtools
 
 The devtools is using the new `@ngrx/store-devtools/recompute` action to recompute its state instead of the `@ngrx/store/update-reducers` action.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `routeConfig` isn't being serialized in `DefaultRouterStateSerializer`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1363

## What is the new behavior?
The `routeConfig` is being serialized in `DefaultRouterStateSerializer`.
Note that not all properies are being serialized:

```ts
{
    // was already being serialized
    component?: Type<any>;

	// added properties to be serialized
    path?: string;
    pathMatch?: string;   
    redirectTo?: string;
    outlet?: string;

    // not being serialized
    matcher?: UrlMatcher;  
    canActivate?: any[];
    canActivateChild?: any[];
    canDeactivate?: any[];
    canLoad?: any[];
    data?: Data;
    resolve?: ResolveData;
    children?: Routes;
    loadChildren?: LoadChildren;
    runGuardsAndResolvers?: RunGuardsAndResolvers;
}
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The default router serializer now returns a `null` value for `routeConfig` when `routeConfig` doesn't exist on the `ActivatedRouteSnapshot` instead of an empty object.
 BEFORE:
 ```json
{
  "routeConfig": {}
}
```
 AFTER:
 ```json
{
  "routeConfig": null
}
```

## Other information
If this doesn't belong in the default serializer, feel free to close.
It's always possible for the impacted users to create there own serializer.

Closes #1363