### PR TITLE
fix(Store): memoize selector arguments

### DIFF
--- a/modules/store/spec/selector.spec.ts
+++ b/modules/store/spec/selector.spec.ts
@@ -90,6 +90,7 @@ describe('Selectors', () => {
       selector(firstState);
       selector(firstState);
       selector(secondState);
+      selector(secondState);
 
       expect(incrementOne).toHaveBeenCalledTimes(2);
       expect(incrementTwo).toHaveBeenCalledTimes(2);
@@ -200,6 +201,7 @@ describe('Selectors', () => {
       selector(firstState, props);
       selector(firstState, props);
       selector(firstState, props);
+      selector(secondState, props);
       selector(secondState, props);
 
       expect(counter).toBe(2);
@@ -322,6 +324,7 @@ describe('Selectors', () => {
       selector(firstState);
       selector(firstState);
       selector(secondState);
+      selector(secondState);
 
       expect(incrementOne).toHaveBeenCalledTimes(2);
       expect(incrementTwo).toHaveBeenCalledTimes(2);
@@ -432,6 +435,7 @@ describe('Selectors', () => {
       selector(firstState, props);
       selector(firstState, props);
       selector(firstState, props);
+      selector(secondState, props);
       selector(secondState, props);
 
       expect(counter).toBe(2);

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -70,13 +70,14 @@ export function defaultMemoize(
       return lastResult;
     }
 
+    lastArguments = arguments;
+
     const newResult = projectionFn.apply(null, arguments);
     if (isResultEqual(lastResult, newResult)) {
       return lastResult;
     }
 
     lastResult = newResult;
-    lastArguments = arguments;
 
     return newResult;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1389
This was also being addressed in https://github.com/ngrx/platform/pull/1194#issuecomment-408423739 but was forgotten.

## What is the new behavior?

The arguments weren't being memoized when the result of the selector was equal to its previous result.

This fix moves the memoization of the arguments before the check if the results are equal.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Closes #1389