### PR TITLE
docs(entity): add example for selectId

### DIFF
--- a/projects/ngrx.io/content/guide/entity/adapter.md
+++ b/projects/ngrx.io/content/guide/entity/adapter.md
@@ -6,7 +6,7 @@ A method for returning a generic entity adapter for a single entity state collec
 returned adapter provides many adapter methods for performing operations
 against the collection type. The method takes an object with 2 properties for configuration.
 
-- `selectId`: A `method` for selecting the primary id for the collection.
+- `selectId`: A `method` for selecting the primary id for the collection. Optional when the entity has a primary key of `id`
 - `sortComparer`: A compare function used to [sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) the collection. The comparer function is only needed if the collection needs to be sorted before being displayed. Set to `false` to leave the collection unsorted, which is more performant during CRUD operations.
 
 Usage:
@@ -24,11 +24,17 @@ export interface State extends EntityState<User> {
   selectedUserId: number;
 }
 
+export function selectUserId(a: User): string {
+  //In this case this would be optional since primary key is id
+  return a.id;
+}
+
 export function sortByName(a: User, b: User): number {
   return a.name.localeCompare(b.name);
 }
 
 export const adapter: EntityAdapter<User> = createEntityAdapter<User>({
+  selectId: selectUserId,
   sortComparer: sortByName,
 });
 ```


### PR DESCRIPTION
Including an example of selectId as well as a note stating that it is optional in the case of the PK being id.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Does for entity do not include selectId example

## What is the new behavior?

Adding an example as well as noting the case where selectId is optional

## Does this PR introduce a breaking change?

```
[ ] Yes
[ X] No
```
