### PR TITLE
docs(store): remove typo in selectors docs

### DIFF
--- a/docs/store/selectors.md
+++ b/docs/store/selectors.md
@@ -108,7 +108,7 @@ ngOnInit() {
 }
 ```
 
-Keep in mind that a selector only keeps the previous input arguments in its cache. If you re-use this selector with another another multiply factor, the selector would always have to re-evaluate its value. This is because it's receiving both of the multiply factors (e.g. one time `2`, the other time `4`). In order to correctly memoize the selector, wrap the selector inside a factory function to create different instances of the selector.
+Keep in mind that a selector only keeps the previous input arguments in its cache. If you re-use this selector with another multiply factor, the selector would always have to re-evaluate its value. This is because it's receiving both of the multiply factors (e.g. one time `2`, the other time `4`). In order to correctly memoize the selector, wrap the selector inside a factory function to create different instances of the selector.
 
 The following is an example of using multiple counters differentiated by `id`.
 
@@ -370,7 +370,7 @@ export const selectLastStateTransitions = (count: number) => {
     scan((acc, curr) => {
       return [ curr, acc[0], acc[1] ].filter(val => val !== undefined);
     } [] as {foo: number; bar: string}[]) // XX: Explicit type hint for the array.
-                                          // Equivalent to what is emitted by the selelctor
+                                          // Equivalent to what is emitted by the selector
   );
 }
 ```

--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -105,7 +105,7 @@ ngOnInit() {
 }
 ```
 
-Keep in mind that a selector only keeps the previous input arguments in its cache. If you re-use this selector with another another multiply factor, the selector would always have to re-evaluate its value. This is because it's receiving both of the multiply factors (e.g. one time `2`, the other time `4`). In order to correctly memoize the selector, wrap the selector inside a factory function to create different instances of the selector.
+Keep in mind that a selector only keeps the previous input arguments in its cache. If you re-use this selector with another multiply factor, the selector would always have to re-evaluate its value. This is because it's receiving both of the multiply factors (e.g. one time `2`, the other time `4`). In order to correctly memoize the selector, wrap the selector inside a factory function to create different instances of the selector.
 
 The following is an example of using multiple counters differentiated by `id`.
 

--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -338,7 +338,7 @@ export const selectLastStateTransitions = (count: number) => {
     scan((acc, curr) => {
       return [ curr, acc[0], acc[1] ].filter(val => val !== undefined);
     } [] as {foo: number; bar: string}[]) // XX: Explicit type hint for the array.
-                                          // Equivalent to what is emitted by the selelctor
+                                          // Equivalent to what is emitted by the selector
   );
 }
 ```


### PR DESCRIPTION
Remove typos in the selectors docs

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Just two small typos in the selectors docs
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
