### PR TITLE
docs: open docs sidenav by default

### DIFF
--- a/projects/ngrx.io/content/navigation.json
+++ b/projects/ngrx.io/content/navigation.json
@@ -52,6 +52,11 @@
 
   "SideNav": [
     {
+      "url": "docs",
+      "title": "Docs",
+      "hidden": true
+    },
+    {
       "title": "Store",
       "children": [
         {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When opening the docs section for ngrx.io the sidenav closes by default.

Closes #

## What is the new behavior?

When clicking on the docs link the side nav stays/starts open. This matches the behavior on angular.io as an example.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
