### PR TITLE
docs(changelog): fix `ofType` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ this.actions.ofType('INCREMENT')
 AFTER:
 
 ```
-import { ofType } from '@ngrx/store';
+import { ofType } from '@ngrx/effects';
 ...
 this.action.pipe(ofType('INCREMENT'))
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The CHANGELOG currently provides an incorrect example for the breaking change regarding `ofType`

Reference: https://ngrx.io/api/effects/ofType

## What is the new behavior?

The example has been fixed.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
