### PR TITLE
feat(StoreDevtools): catch redux devtools errors

### DIFF
--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -133,7 +133,10 @@ export class DevtoolsExtension {
             state.nextActionId
           )
         : action;
-      this.extensionConnection.send(sanitizedAction, sanitizedState);
+
+      this.sendToReduxDevtools(() =>
+        this.extensionConnection.send(sanitizedAction, sanitizedState)
+      );
     } else {
       // Requires full state update
       const sanitizedLiftedState = {
@@ -146,10 +149,13 @@ export class DevtoolsExtension {
           ? sanitizeStates(this.config.stateSanitizer, state.computedStates)
           : state.computedStates,
       };
-      this.devtoolsExtension.send(
-        null,
-        sanitizedLiftedState,
-        this.getExtensionConfig(this.config)
+
+      this.sendToReduxDevtools(() =>
+        this.devtoolsExtension.send(
+          null,
+          sanitizedLiftedState,
+          this.getExtensionConfig(this.config)
+        )
       );
     }
   }
@@ -249,5 +255,16 @@ export class DevtoolsExtension {
       extensionOptions.maxAge = config.maxAge;
     }
     return extensionOptions;
+  }
+
+  private sendToReduxDevtools(send: Function) {
+    try {
+      send();
+    } catch (err) {
+      console.warn(
+        '@ngrx/store-devtools: something went wrong inside the redux devtools',
+        err
+      );
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Yesterday a new version of the redux devtools was published and was leading to some problems as mentioned in https://github.com/ngrx/platform/issues/1449.


## What is the new behavior?

This change wraps the redux devtools execution inside a `try catch` block, so that our applications can continue functioning as usual, but without the devtools.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
