### PR TITLE
feat(Effects): add OnInitEffects interface to dispatch an action on initialization

### DIFF
--- a/docs/effects/api.md
+++ b/docs/effects/api.md
@@ -50,31 +50,6 @@ Usage:
 export class FeatureModule {}
 ```
 
-### UPDATE_EFFECTS
-
-After feature effects are registered, an `UPDATE_EFFECTS` action is dispatched.
-
-```ts
-type UpdateEffects = {
-  type: typeof UPDATE_EFFECTS;
-  effects: string[];
-};
-```
-
-For example, when you register your feature module as `EffectsModule.forFeature([SomeEffectsClass, AnotherEffectsClass])`,
-it has `SomeEffectsClass` and `AnotherEffectsClass` in an array as its payload.
-
-To dispatch an action when the `SomeEffectsClass` effect has been registered, listen to the `UPDATE_EFFECTS` action and use the `effects` payload to filter out non-important effects.
-
-```ts
-@Effect()
-init = this.actions.pipe(
-  ofType<UpdateEffects>(UPDATE_EFFECTS)
-  filter(action => action.effects.includes('SomeEffectsClass')),
-  map(action => ...)
-);
-```
-
 ## Actions
 
 Stream of all actions dispatched in your application including actions dispatched by effect streams.

--- a/modules/effects/spec/integration.spec.ts
+++ b/modules/effects/spec/integration.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import { Store, Action } from '@ngrx/store';
+import {
+  EffectsModule,
+  OnInitEffects,
+  ROOT_EFFECTS_INIT,
+  OnIdentifyEffects,
+  EffectSources,
+} from '..';
+
+describe('NgRx Effects Integration spec', () => {
+  let dispatch: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        EffectsModule.forRoot([
+          RootEffectWithInitAction,
+          RootEffectWithoutLifecycle,
+          RootEffectWithInitActionWithPayload,
+        ]),
+        EffectsModule.forFeature([FeatEffectWithInitAction]),
+      ],
+      providers: [
+        {
+          provide: Store,
+          useValue: {
+            dispatch: jasmine.createSpy('dispatch'),
+          },
+        },
+      ],
+    });
+
+    const store = TestBed.get(Store) as Store<any>;
+
+    const effectSources = TestBed.get(EffectSources) as EffectSources;
+    effectSources.addEffects(new FeatEffectWithIdentifierAndInitAction('one'));
+    effectSources.addEffects(new FeatEffectWithIdentifierAndInitAction('two'));
+    effectSources.addEffects(new FeatEffectWithIdentifierAndInitAction('one'));
+
+    dispatch = store.dispatch as jasmine.Spy;
+  });
+
+  it('should dispatch init actions in the correct order', () => {
+    expect(dispatch.calls.count()).toBe(7);
+
+    // All of the root effects init actions are dispatched first
+    expect(dispatch.calls.argsFor(0)).toEqual([
+      { type: '[RootEffectWithInitAction]: INIT' },
+    ]);
+
+    expect(dispatch.calls.argsFor(1)).toEqual([new ActionWithPayload()]);
+
+    // After all of the root effects are registered, the ROOT_EFFECTS_INIT action is dispatched
+    expect(dispatch.calls.argsFor(2)).toEqual([{ type: ROOT_EFFECTS_INIT }]);
+
+    // After the root effects init, the feature effects are dispatched
+    expect(dispatch.calls.argsFor(3)).toEqual([
+      { type: '[FeatEffectWithInitAction]: INIT' },
+    ]);
+
+    expect(dispatch.calls.argsFor(4)).toEqual([
+      { type: '[FeatEffectWithIdentifierAndInitAction]: INIT' },
+    ]);
+
+    expect(dispatch.calls.argsFor(5)).toEqual([
+      { type: '[FeatEffectWithIdentifierAndInitAction]: INIT' },
+    ]);
+
+    // While the effect has the same identifier the init effect action is still being dispatched
+    expect(dispatch.calls.argsFor(6)).toEqual([
+      { type: '[FeatEffectWithIdentifierAndInitAction]: INIT' },
+    ]);
+  });
+
+  class RootEffectWithInitAction implements OnInitEffects {
+    ngrxOnInitEffects(): Action {
+      return { type: '[RootEffectWithInitAction]: INIT' };
+    }
+  }
+
+  class ActionWithPayload implements Action {
+    readonly type = '[RootEffectWithInitActionWithPayload]: INIT';
+    readonly payload = 47;
+  }
+
+  class RootEffectWithInitActionWithPayload implements OnInitEffects {
+    ngrxOnInitEffects(): Action {
+      return new ActionWithPayload();
+    }
+  }
+
+  class RootEffectWithoutLifecycle {}
+
+  class FeatEffectWithInitAction implements OnInitEffects {
+    ngrxOnInitEffects(): Action {
+      return { type: '[FeatEffectWithInitAction]: INIT' };
+    }
+  }
+
+  class FeatEffectWithIdentifierAndInitAction
+    implements OnInitEffects, OnIdentifyEffects {
+    ngrxOnIdentifyEffects(): string {
+      return this.effectIdentifier;
+    }
+
+    ngrxOnInitEffects(): Action {
+      return { type: '[FeatEffectWithIdentifierAndInitAction]: INIT' };
+    }
+
+    constructor(private effectIdentifier: string) {}
+  }
+});

--- a/modules/effects/src/effect_sources.ts
+++ b/modules/effects/src/effect_sources.ts
@@ -1,5 +1,5 @@
 import { ErrorHandler, Injectable } from '@angular/core';
-import { Action } from '@ngrx/store';
+import { Action, Store } from '@ngrx/store';
 import { Notification, Observable, Subject } from 'rxjs';
 import {
   dematerialize,
@@ -18,16 +18,24 @@ import {
   onRunEffectsKey,
   onRunEffectsFn,
   OnRunEffects,
+  onInitEffects,
 } from './lifecycle_hooks';
 
 @Injectable()
 export class EffectSources extends Subject<any> {
-  constructor(private errorHandler: ErrorHandler) {
+  constructor(private errorHandler: ErrorHandler, private store: Store<any>) {
     super();
   }
 
   addEffects(effectSourceInstance: any) {
     this.next(effectSourceInstance);
+
+    if (
+      onInitEffects in effectSourceInstance &&
+      typeof effectSourceInstance[onInitEffects] === 'function'
+    ) {
+      this.store.dispatch(effectSourceInstance[onInitEffects]());
+    }
   }
 
   /**

--- a/modules/effects/src/effects_feature_module.ts
+++ b/modules/effects/src/effects_feature_module.ts
@@ -1,38 +1,20 @@
 import { NgModule, Inject, Optional } from '@angular/core';
-import { StoreRootModule, StoreFeatureModule, Store } from '@ngrx/store';
+import { StoreRootModule, StoreFeatureModule } from '@ngrx/store';
 import { EffectsRootModule } from './effects_root_module';
 import { FEATURE_EFFECTS } from './tokens';
-import { getSourceForInstance } from './effects_metadata';
-
-export const UPDATE_EFFECTS = '@ngrx/effects/update-effects';
-export type UpdateEffects = {
-  type: typeof UPDATE_EFFECTS;
-  effects: string[];
-};
 
 @NgModule({})
 export class EffectsFeatureModule {
   constructor(
     root: EffectsRootModule,
-    store: Store<any>,
     @Inject(FEATURE_EFFECTS) effectSourceGroups: any[][],
     @Optional() storeRootModule: StoreRootModule,
     @Optional() storeFeatureModule: StoreFeatureModule
   ) {
-    effectSourceGroups.forEach(group => {
-      let effectSourceNames: string[] = [];
-
-      group.forEach(effectSourceInstance => {
-        root.addEffects(effectSourceInstance);
-
-        const { constructor } = getSourceForInstance(effectSourceInstance);
-        effectSourceNames.push(constructor.name);
-      });
-
-      store.dispatch(<UpdateEffects>{
-        type: UPDATE_EFFECTS,
-        effects: effectSourceNames,
-      });
-    });
+    effectSourceGroups.forEach(group =>
+      group.forEach(effectSourceInstance =>
+        root.addEffects(effectSourceInstance)
+      )
+    );
   }
 }

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -9,5 +9,4 @@ export { EffectsModule } from './effects_module';
 export { EffectSources } from './effect_sources';
 export { EffectNotification } from './effect_notification';
 export { ROOT_EFFECTS_INIT } from './effects_root_module';
-export { UPDATE_EFFECTS, UpdateEffects } from './effects_feature_module';
 export { OnIdentifyEffects, OnRunEffects } from './lifecycle_hooks';

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -9,4 +9,8 @@ export { EffectsModule } from './effects_module';
 export { EffectSources } from './effect_sources';
 export { EffectNotification } from './effect_notification';
 export { ROOT_EFFECTS_INIT } from './effects_root_module';
-export { OnIdentifyEffects, OnRunEffects } from './lifecycle_hooks';
+export {
+  OnIdentifyEffects,
+  OnRunEffects,
+  OnInitEffects,
+} from './lifecycle_hooks';

--- a/modules/effects/src/lifecycle_hooks.ts
+++ b/modules/effects/src/lifecycle_hooks.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs';
 import { EffectNotification } from '.';
+import { Action } from '@ngrx/store';
 
 /**
  * @description
@@ -19,13 +20,11 @@ import { EffectNotification } from '.';
  * class EffectWithIdentifier implements OnIdentifyEffects {
  * private effectIdentifier: string;
  *
- * ngrxOnIdentifyEffects  () {
+ * ngrxOnIdentifyEffects() {
  *   return this.effectIdentifier;
  * }
  *
- * constructor(identifier: string) {
- *  this.effectIdentifier = identifier;
- * }
+ * constructor(private effectIdentifier: string) {}
  * ```
  */
 export interface OnIdentifyEffects {
@@ -33,7 +32,7 @@ export interface OnIdentifyEffects {
    * @description
    * String identifier to differentiate effect instances.
    */
-  ngrxOnIdentifyEffects: () => string;
+  ngrxOnIdentifyEffects(): string;
 }
 
 export const onIdentifyEffectsKey: keyof OnIdentifyEffects =
@@ -79,3 +78,34 @@ export interface OnRunEffects {
 }
 
 export const onRunEffectsKey: keyof OnRunEffects = 'ngrxOnRunEffects';
+
+/**
+ * @description
+ * Interface to dispatch an action after effect registration.
+ *
+ * Implement this interface to dispatch a custom action after
+ * the effect has been added. You can listen to this action
+ * in the rest of the application to execute something after
+ * the effect is registered.
+ *
+ * @usageNotes
+ *
+ * ### Set an identifier for an Effects class
+ *
+ * ```ts
+ * class EffectWithInitAction implements OnInitEffects {
+ *
+ * ngrxOnInitEffects() {
+ *   return { type: '[EffectWithInitAction] Init' };
+ * }
+ * ```
+ */
+export interface OnInitEffects {
+  /**
+   * @description
+   * Action to be dispatched after the effect is registered.
+   */
+  ngrxOnInitEffects(): Action;
+}
+
+export const onInitEffects: keyof OnInitEffects = 'ngrxOnInitEffects';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

As mentioned in the issue, the solution we have now to dispatch an `INIT` effect action doesn't work in prod builds because the constructor name is mangled.

Closes #1447

## What is the new behavior?

This PR adds a new lifecycle hook `OnInitEffects` that dispatches a user-defined action on effect registration. I couldn't find another way to access the effect's name.

Personally, I also find this solution to be cleaner and more flexible than the previous one.

Right now I've made it so that only one action can be dispatched, but this can also be an array of actions if it's needed. Imho one action is sufficient and also follows our best practices to treat an action as a unique event.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The first commit reverts #1305 
The second commit adds the `OnInitEffects` hook. In this commit, I also changed the `OnIdentifyEffects` signature to be consistent with the other signatures.
