### PR TITLE
feat(schematics): add project flag support to specify apps or libs

### DIFF
--- a/modules/schematics-core/testing/create-workspace.ts
+++ b/modules/schematics-core/testing/create-workspace.ts
@@ -3,13 +3,13 @@ import {
   SchematicTestRunner,
 } from '@angular-devkit/schematics/testing';
 
-const defaultWorkspaceOptions = {
+export const defaultWorkspaceOptions = {
   name: 'workspace',
   newProjectRoot: 'projects',
   version: '6.0.0',
 };
 
-const defaultAppOptions = {
+export const defaultAppOptions = {
   name: 'bar',
   inlineStyle: false,
   inlineTemplate: false,

--- a/modules/schematics/src/action/index.spec.ts
+++ b/modules/schematics/src/action/index.spec.ts
@@ -7,6 +7,8 @@ import { Schema as ActionOptions } from './schema';
 import {
   getTestProjectPath,
   createWorkspace,
+  defaultWorkspaceOptions,
+  defaultAppOptions,
 } from '../../../schematics-core/testing';
 
 describe('Action Schematic', () => {
@@ -16,7 +18,6 @@ describe('Action Schematic', () => {
   );
   const defaultOptions: ActionOptions = {
     name: 'foo',
-    // path: 'app',
     project: 'bar',
     spec: false,
     group: false,
@@ -29,6 +30,24 @@ describe('Action Schematic', () => {
 
   beforeEach(() => {
     appTree = createWorkspace(schematicRunner, appTree);
+  });
+
+  it('should create an action to specified project if provided', () => {
+    const options = {
+      ...defaultOptions,
+      project: 'baz',
+    };
+
+    const specifiedProjectPath = getTestProjectPath(defaultWorkspaceOptions, {
+      ...defaultAppOptions,
+      name: 'baz',
+    });
+
+    const tree = schematicRunner.runSchematic('action', options, appTree);
+    const files = tree.files;
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.actions.ts`)
+    ).toBeGreaterThanOrEqual(0);
   });
 
   it('should create one file', () => {

--- a/modules/schematics/src/action/schema.json
+++ b/modules/schematics/src/action/schema.json
@@ -18,6 +18,12 @@
       "description": "The path to create the component.",
       "visible": false
     },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "visible": false,
+      "aliases": ["p"]
+    },
     "spec": {
       "type": "boolean",
       "description": "Specifies if a spec file is generated.",

--- a/modules/schematics/src/container/index.spec.ts
+++ b/modules/schematics/src/container/index.spec.ts
@@ -4,7 +4,6 @@ import {
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
 import { Schema as ContainerOptions } from './schema';
-import {} from '../../schematics-core';
 import {
   getTestProjectPath,
   createWorkspace,
@@ -19,7 +18,6 @@ describe('Container Schematic', () => {
   const defaultOptions: ContainerOptions = {
     name: 'foo',
     project: 'bar',
-    // path: 'src/app',
     inlineStyle: false,
     inlineTemplate: false,
     changeDetection: 'Default',

--- a/modules/schematics/src/container/schema.json
+++ b/modules/schematics/src/container/schema.json
@@ -13,7 +13,8 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
-      "visible": false
+      "visible": false,
+      "aliases": ["p"]
     },
     "name": {
       "type": "string",

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -3,12 +3,13 @@ import {
   UnitTestTree,
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
-import {} from '../../schematics-core';
 import { Schema as EffectOptions } from './schema';
 import {
   getTestProjectPath,
   createWorkspace,
   createAppModuleWithEffects,
+  defaultWorkspaceOptions,
+  defaultAppOptions,
 } from '../../../schematics-core/testing';
 
 describe('Effect Schematic', () => {
@@ -19,7 +20,6 @@ describe('Effect Schematic', () => {
 
   const defaultOptions: EffectOptions = {
     name: 'foo',
-    // path: 'app',
     project: 'bar',
     spec: true,
     module: undefined,
@@ -35,6 +35,27 @@ describe('Effect Schematic', () => {
 
   beforeEach(() => {
     appTree = createWorkspace(schematicRunner, appTree);
+  });
+
+  it('should create an effect to specified project if provided', () => {
+    const options = {
+      ...defaultOptions,
+      project: 'baz',
+    };
+
+    const specifiedProjectPath = getTestProjectPath(defaultWorkspaceOptions, {
+      ...defaultAppOptions,
+      name: 'baz',
+    });
+
+    const tree = schematicRunner.runSchematic('effect', options, appTree);
+    const files = tree.files;
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo/foo.effects.spec.ts`)
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo/foo.effects.ts`)
+    ).toBeGreaterThanOrEqual(0);
   });
 
   it('should create an effect with a spec file', () => {

--- a/modules/schematics/src/effect/schema.json
+++ b/modules/schematics/src/effect/schema.json
@@ -18,6 +18,12 @@
       "description": "The path to create the component.",
       "visible": false
     },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "visible": false,
+      "aliases": ["p"]
+    },
     "flat": {
       "type": "boolean",
       "default": true,

--- a/modules/schematics/src/entity/index.spec.ts
+++ b/modules/schematics/src/entity/index.spec.ts
@@ -4,10 +4,11 @@ import {
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
 import { Schema as EntityOptions } from './schema';
-import {} from '../../schematics-core';
 import {
   getTestProjectPath,
   createWorkspace,
+  defaultWorkspaceOptions,
+  defaultAppOptions,
 } from '../../../schematics-core/testing';
 
 describe('Entity Schematic', () => {
@@ -18,7 +19,6 @@ describe('Entity Schematic', () => {
   const defaultOptions: EntityOptions = {
     name: 'foo',
     project: 'bar',
-    // path: 'app',
     spec: false,
   };
 
@@ -45,6 +45,30 @@ describe('Entity Schematic', () => {
     ).toBeGreaterThanOrEqual(0);
     expect(
       tree.files.indexOf(`${projectPath}/src/app/foo.reducer.ts`)
+    ).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should create 3 files of an entity to specified project if provided', () => {
+    const options = {
+      ...defaultOptions,
+      project: 'baz',
+    };
+
+    const specifiedProjectPath = getTestProjectPath(defaultWorkspaceOptions, {
+      ...defaultAppOptions,
+      name: 'baz',
+    });
+
+    const tree = schematicRunner.runSchematic('entity', options, appTree);
+    const files = tree.files;
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.actions.ts`)
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.model.ts`)
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.reducer.ts`)
     ).toBeGreaterThanOrEqual(0);
   });
 

--- a/modules/schematics/src/entity/schema.json
+++ b/modules/schematics/src/entity/schema.json
@@ -18,6 +18,12 @@
       "description": "The path to create the component.",
       "visible": false
     },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "visible": false,
+      "aliases": ["p"]
+    },
     "spec": {
       "type": "boolean",
       "description": "Specifies if a spec file is generated.",

--- a/modules/schematics/src/feature/index.spec.ts
+++ b/modules/schematics/src/feature/index.spec.ts
@@ -4,10 +4,11 @@ import {
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
 import { Schema as FeatureOptions } from './schema';
-import {} from '../../schematics-core';
 import {
   getTestProjectPath,
   createWorkspace,
+  defaultWorkspaceOptions,
+  defaultAppOptions,
 } from '../../../schematics-core/testing';
 
 describe('Feature Schematic', () => {
@@ -18,7 +19,6 @@ describe('Feature Schematic', () => {
   const defaultOptions: FeatureOptions = {
     name: 'foo',
     project: 'bar',
-    // path: 'app',
     module: '',
     spec: true,
     group: false,
@@ -54,6 +54,36 @@ describe('Feature Schematic', () => {
     ).toBeGreaterThanOrEqual(0);
   });
 
+  it('should create all files of a feature to specified project if provided', () => {
+    const options = {
+      ...defaultOptions,
+      project: 'baz',
+    };
+
+    const specifiedProjectPath = getTestProjectPath(defaultWorkspaceOptions, {
+      ...defaultAppOptions,
+      name: 'baz',
+    });
+
+    const tree = schematicRunner.runSchematic('feature', options, appTree);
+    const files = tree.files;
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.actions.ts`)
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.reducer.ts`)
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.reducer.spec.ts`)
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.effects.ts`)
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.effects.spec.ts`)
+    ).toBeGreaterThanOrEqual(0);
+  });
+
   it('should create all files of a feature within grouped folders if group is set', () => {
     const options = { ...defaultOptions, group: true };
 
@@ -85,12 +115,6 @@ describe('Feature Schematic', () => {
     };
 
     const tree = schematicRunner.runSchematic('feature', options, appTree);
-    const effectsFileContent = tree.readContent(
-      `${projectPath}/src/app/foo/effects/foo.effects.ts`
-    );
-    const reducerFileContent = tree.readContent(
-      `${projectPath}/src/app/foo/reducers/foo.reducer.ts`
-    );
     const moduleFileContent = tree.readContent(
       `${projectPath}/src/app/app.module.ts`
     );

--- a/modules/schematics/src/feature/schema.json
+++ b/modules/schematics/src/feature/schema.json
@@ -7,8 +7,14 @@
     "path": {
       "type": "string",
       "format": "path",
-      "description": "The path to create the component.",
+      "description": "The path to create the feature.",
       "visible": false
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "visible": false,
+      "aliases": ["p"]
     },
     "name": {
       "description": "The name of the feature.",

--- a/modules/schematics/src/reducer/index.spec.ts
+++ b/modules/schematics/src/reducer/index.spec.ts
@@ -4,11 +4,12 @@ import {
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
 import { Schema as ReducerOptions } from './schema';
-import {} from '../../schematics-core';
 import {
   getTestProjectPath,
   createReducers,
   createWorkspace,
+  defaultWorkspaceOptions,
+  defaultAppOptions,
 } from '../../../schematics-core/testing';
 
 describe('Reducer Schematic', () => {
@@ -19,7 +20,6 @@ describe('Reducer Schematic', () => {
   const defaultOptions: ReducerOptions = {
     name: 'foo',
     project: 'bar',
-    // path: 'app',
     spec: false,
   };
 
@@ -40,6 +40,24 @@ describe('Reducer Schematic', () => {
 
     expect(
       tree.files.indexOf(`${projectPath}/src/app/foo.reducer.ts`)
+    ).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should create a reducer to specified project if provided', () => {
+    const options = {
+      ...defaultOptions,
+      project: 'baz',
+    };
+
+    const specifiedProjectPath = getTestProjectPath(defaultWorkspaceOptions, {
+      ...defaultAppOptions,
+      name: 'baz',
+    });
+
+    const tree = schematicRunner.runSchematic('reducer', options, appTree);
+    const files = tree.files;
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/foo.reducer.ts`)
     ).toBeGreaterThanOrEqual(0);
   });
 

--- a/modules/schematics/src/reducer/schema.json
+++ b/modules/schematics/src/reducer/schema.json
@@ -18,6 +18,12 @@
       "description": "The path to create the component.",
       "visible": false
     },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "visible": false,
+      "aliases": ["p"]
+    },
     "spec": {
       "type": "boolean",
       "description": "Specifies if a spec file is generated.",

--- a/modules/schematics/src/store/index.spec.ts
+++ b/modules/schematics/src/store/index.spec.ts
@@ -4,12 +4,12 @@ import {
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
 import { Schema as StoreOptions } from './schema';
-import {} from '../../schematics-core';
 import {
   getTestProjectPath,
   createWorkspace,
+  defaultWorkspaceOptions,
+  defaultAppOptions,
 } from '../../../schematics-core/testing';
-import { getProject } from '../../../schematics-core';
 
 describe('Store Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
@@ -40,6 +40,24 @@ describe('Store Schematic', () => {
     const files = tree.files;
     expect(
       files.indexOf(`${projectPath}/src/app/reducers/index.ts`)
+    ).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should create the initial store to specified project if provided', () => {
+    const options = {
+      ...defaultOptions,
+      project: 'baz',
+    };
+
+    const specifiedProjectPath = getTestProjectPath(defaultWorkspaceOptions, {
+      ...defaultAppOptions,
+      name: 'baz',
+    });
+
+    const tree = schematicRunner.runSchematic('store', options, appTree);
+    const files = tree.files;
+    expect(
+      files.indexOf(`${specifiedProjectPath}/src/lib/reducers/index.ts`)
     ).toBeGreaterThanOrEqual(0);
   });
 

--- a/modules/schematics/src/store/schema.json
+++ b/modules/schematics/src/store/schema.json
@@ -18,6 +18,12 @@
       "description": "The path to create the component.",
       "visible": false
     },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "visible": false,
+      "aliases": ["p"]
+    },
     "flat": {
       "type": "boolean",
       "default": true,

--- a/projects/ngrx.io/content/guide/schematics/action.md
+++ b/projects/ngrx.io/content/guide/schematics/action.md
@@ -21,6 +21,12 @@ ng generate a ActionName [options]
 
 ### Options
 
+Provide the project name where the action files will be created.
+
+- `--project`
+  - Alias: `-p`
+  - Type: `string`
+
 Nest the actions file within a folder based on the action `name`.
 
 - `--flat`

--- a/projects/ngrx.io/content/guide/schematics/effect.md
+++ b/projects/ngrx.io/content/guide/schematics/effect.md
@@ -20,6 +20,12 @@ ng generate ef EffectName [options]
 
 ## Options
 
+Provide the project name where the effect files will be created.
+
+- `--project`
+  - Alias: `-p`
+  - Type: `string`
+
 Nest the effects file within a folder based by the effect `name`.
 
 - `--flat`

--- a/projects/ngrx.io/content/guide/schematics/entity.md
+++ b/projects/ngrx.io/content/guide/schematics/entity.md
@@ -20,6 +20,12 @@ ng generate en EntityName [options]
 
 ## Options
 
+Provide the project name where the entity files will be created.
+
+- `--project`
+  - Alias: `-p`
+  - Type: `string`
+
 Nest the effects file within a folder based on the entity `name`.
 
 - `--flat`

--- a/projects/ngrx.io/content/guide/schematics/feature.md
+++ b/projects/ngrx.io/content/guide/schematics/feature.md
@@ -20,6 +20,12 @@ ng generate f FeatureName [options]
 
 ## Options
 
+Provide the project name where the feature files will be created.
+
+- `--project`
+  - Alias: `-p`
+  - Type: `string`
+
 Nest the effects file within a folder based on the feature `name`.
 
 - `--flat`

--- a/projects/ngrx.io/content/guide/schematics/reducer.md
+++ b/projects/ngrx.io/content/guide/schematics/reducer.md
@@ -21,6 +21,12 @@ ng generate r ReducerName [options]
 
 ### Options
 
+Provide the project name where the reducer files will be created.
+
+- `--project`
+  - Alias: `-p`
+  - Type: `string`
+
 Nest the reducer file within a folder based on the reducer `name`.
 
 - `--flat`

--- a/projects/ngrx.io/content/guide/schematics/store.md
+++ b/projects/ngrx.io/content/guide/schematics/store.md
@@ -20,6 +20,12 @@ ng generate st State [options]
 
 ## Options
 
+Provide the project name where the state files will be created.
+
+- `--project`
+  - Alias: `-p`
+  - Type: `string`
+
 Provide the path to a file containing an `Angular Module` and the feature state will be added to its `imports` array using `StoreModule.forFeature` or `StoreModule.forRoot`.
 
 - `--module`


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1455

## What is the new behavior?

Now its possible to specify the project when generate actions, effects,
entities, features, reducers and stores.
The new flag is --project and his alias -p
Upgrade the documentation to add the new flag and his alias

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information