### PR TITLE
build: use PR URL as fallback for PR number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,11 +130,12 @@ jobs:
           command: |
             echo 'export CI_PREVIEW=true' >> $BASH_ENV
             echo 'export SHORT_GIT_HASH=$(git rev-parse --short $CIRCLE_SHA1)' >> $BASH_ENV
+            echo 'export CIRCLE_PULL_REQUEST_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | cut -d"/" -f7)' >> $BASH_ENV
             source $BASH_ENV
       - run: yarn setup 
       - run: npm rebuild node-sass
-      - run: yarn build-for next --progress false --base-href /pr$CIRCLE_PR_NUMBER-$SHORT_GIT_HASH/ --output-path dist/ngrx.io/pr$CIRCLE_PR_NUMBER-$SHORT_GIT_HASH/ && yarn copy-404-page
-      - run: cp -rf src/extra-files/next/. dist/ngrx.io/pr$CIRCLE_PR_NUMBER-$SHORT_GIT_HASH/
+      - run: yarn build-for next --progress false --base-href /pr$CIRCLE_PULL_REQUEST_NUMBER-$SHORT_GIT_HASH/ --output-path dist/ngrx.io/pr$CIRCLE_PULL_REQUEST_NUMBER-$SHORT_GIT_HASH/ && yarn copy-404-page
+      - run: cp -rf src/extra-files/next/. dist/ngrx.io/pr$CIRCLE_PULL_REQUEST_NUMBER-$SHORT_GIT_HASH/
       - run: yarn --cwd ../../ install && yarn --cwd ../../ run deploy:preview
       
 

--- a/build/tasks.ts
+++ b/build/tasks.ts
@@ -63,7 +63,10 @@ export async function publishDocsPreview() {
   const SOURCE_DIR = './projects/ngrx.io/dist/ngrx.io';
   const REPO_URL = 'git@github.com:ngrx/ngrx-io-previews.git';
   const REPO_DIR = `./tmp/docs-preview`;
-  const PR_NUMBER = process.env.CIRCLE_PR_NUMBER || '';
+  const PR_NUMBER = util.getPrNumber(
+    process.env.CIRCLE_PR_NUMBER,
+    process.env.CIRCLE_PULL_REQUEST_NUMBER
+  );
   const SHORT_SHA = process.env.SHORT_GIT_HASH;
   const owner = process.env.CIRCLE_PROJECT_USERNAME;
 
@@ -119,7 +122,10 @@ export async function prepareAndPublish(
 }
 
 export async function postGithubComment() {
-  const PR_NUMBER = process.env.CIRCLE_PR_NUMBER || '';
+  const PR_NUMBER = util.getPrNumber(
+    process.env.CIRCLE_PR_NUMBER,
+    process.env.CIRCLE_PULL_REQUEST_NUMBER
+  );
   const owner = process.env.CIRCLE_PROJECT_USERNAME;
 
   if (PR_NUMBER && owner === 'ngrx') {

--- a/build/util.ts
+++ b/build/util.ts
@@ -155,3 +155,13 @@ export async function sleep(ms: number) {
     setTimeout(resolve, ms);
   });
 }
+
+export function getPrNumber(prNumber: string, circlePR: string): string {
+  const PR_NUMBER = prNumber;
+
+  if (!PR_NUMBER && circlePR) {
+    return circlePR;
+  }
+
+  return PR_NUMBER;
+}

--- a/projects/ngrx.io/package.json
+++ b/projects/ngrx.io/package.json
@@ -65,7 +65,7 @@
     "~~build": "ng build",
     "post~~build": "yarn build-404-page",
     "~~http-server": "http-server",
-    "copy-404-page": "node --eval \"require('shelljs').cp('dist/ngrx.io/index.html', 'dist/ngrx.io/404.html')\""
+    "copy-404-page": "node scripts/copy-404-page"
   },
   "engines": {
     "node": ">=10.9.0 <11.2.0",

--- a/projects/ngrx.io/scripts/build-404-page.js
+++ b/projects/ngrx.io/scripts/build-404-page.js
@@ -6,7 +6,7 @@ const {join, resolve} = require('path');
 
 // Constants
 const CI_PREVIEW = process.env.CI_PREVIEW;
-const PR_NUMBER = process.env.CIRCLE_PR_NUMBER || '';
+const PR_NUMBER = process.env.CIRCLE_PR_NUMBER || process.env.CIRCLE_PULL_REQUEST_NUMBER;
 const SHORT_SHA = process.env.SHORT_GIT_HASH;
 const SRC_DIR = resolve(__dirname, '../src');
 const DIST_DIR = resolve(__dirname, '../dist/ngrx.io', CI_PREVIEW ? `pr${PR_NUMBER}-${SHORT_SHA}` : '');

--- a/projects/ngrx.io/scripts/copy-404-page.js
+++ b/projects/ngrx.io/scripts/copy-404-page.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+// Imports
+const { cp } = require('shelljs');
+
+// Constants
+const CI_PREVIEW = process.env.CI_PREVIEW;
+const PR_NUMBER = process.env.CIRCLE_PR_NUMBER || process.env.CIRCLE_PULL_REQUEST_NUMBER;
+const SHORT_SHA = process.env.SHORT_GIT_HASH;
+
+// Paths
+const SRC = `dist/ngrx.io/${CI_PREVIEW ? `pr${PR_NUMBER}-${SHORT_SHA}/` : ''}index.html`;
+const DIST = `dist/ngrx.io/${CI_PREVIEW ? `pr${PR_NUMBER}-${SHORT_SHA}/` : ''}404.html`;
+
+// copy
+cp(SRC, DIST);


### PR DESCRIPTION
Branches from ngrx/platform opened as pull requests don't generate previews because the PR_NUMBER field is not provided.
This checks the CIRCLE_PULL_REQUEST environment variable and extracts the PR_NUMBER from it

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
