### PR TITLE
fix(store): call metareducer with the user's config initial state

### DIFF
--- a/modules/store/spec/modules.spec.ts
+++ b/modules/store/spec/modules.spec.ts
@@ -95,14 +95,13 @@ describe(`Store Modules`, () => {
     });
 
     it(`should accept configurations`, () => {
-      expect(featureAReducerFactory).toHaveBeenCalledWith(
-        { a: featureAReducer },
-        featureAInitial()
-      );
-      expect(rootReducerFactory).toHaveBeenCalledWith(
-        { fruit: rootFruitReducer },
-        rootInitial
-      );
+      expect(featureAReducerFactory).toHaveBeenCalledWith({
+        a: featureAReducer,
+      });
+
+      expect(rootReducerFactory).toHaveBeenCalledWith({
+        fruit: rootFruitReducer,
+      });
     });
 
     it(`should should use config.reducerFactory`, () => {

--- a/modules/store/src/utils.ts
+++ b/modules/store/src/utils.ts
@@ -4,6 +4,7 @@ import {
   ActionReducerFactory,
   ActionReducerMap,
   MetaReducer,
+  InitialState,
 } from './models';
 
 export function combineReducers<T, V extends Action = Action>(
@@ -92,10 +93,16 @@ export function createReducerFactory<T, V extends Action = Action>(
   metaReducers?: MetaReducer<T, V>[]
 ): ActionReducerFactory<T, V> {
   if (Array.isArray(metaReducers) && metaReducers.length > 0) {
-    return compose.apply(null, [...metaReducers, reducerFactory]);
+    reducerFactory = compose.apply(null, [...metaReducers, reducerFactory]);
   }
 
-  return reducerFactory;
+  return (reducers: ActionReducerMap<T, V>, initialState?: InitialState<T>) => {
+    const reducer = reducerFactory(reducers);
+    return (state: T | undefined, action: V) => {
+      state = state === undefined ? (initialState as T) : state;
+      return reducer(state, action);
+    };
+  };
 }
 
 export function createFeatureReducerFactory<T, V extends Action = Action>(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`metaReducers` for feature are called without the user's config initial state.

Closes #1464

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x] No
```

## Other information
