### PR TITLE
docs: Fixed typo in Action documentation Login example text

### DIFF
--- a/projects/ngrx.io/content/guide/store/actions.md
+++ b/projects/ngrx.io/content/guide/store/actions.md
@@ -78,7 +78,7 @@ The `Login` action has very specific context about where the action came from an
 
 - The category of the action is captured within the square brackets `[]`.
 - The category is used to group actions for a particular area, whether it be a component page, backend API, or browser API.
-- The `Login` text after the category is a description about what event occurred from this actions. In this case, the user clicked a login button from the login page to attempt to authenticate with a username and password.
+- The `Login` text after the category is a description about what event occurred from this action. In this case, the user clicked a login button from the login page to attempt to authenticate with a username and password.
 
 ## Creating action unions
 

--- a/projects/ngrx.io/content/guide/store/actions.md
+++ b/projects/ngrx.io/content/guide/store/actions.md
@@ -104,7 +104,7 @@ Instead of putting the action type string directly in the class, the `[Login Pag
 
 ## Next Steps
 
-Actions only responsibility are to express unique events and intents. Learn how they are handled in the guides below.
+Action's only responsibilities are to express unique events and intents. Learn how they are handled in the guides below.
 
 - [Reducers](guide/store/reducers)
 - [Effects](guide/effects)


### PR DESCRIPTION
"The `Login` text after the category is a description about what event occurred from this actions."
Fixed typo by deleting the 's' in "...from this actions." to "...from this action."
"The `Login` text after the category is a description about what event occurred from this action."

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
"The `Login` text after the category is a description about what event occurred from this actions."

Closes #

## What is the new behavior?
"The `Login` text after the category is a description about what event occurred from this action."

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
