### PR TITLE
feat(RouterStore): add routerState  to action payload

### DIFF
--- a/modules/router-store/src/actions.ts
+++ b/modules/router-store/src/actions.ts
@@ -19,16 +19,19 @@ export const ROUTER_REQUEST = '@ngrx/router-store/request';
 /**
  * Payload of ROUTER_REQUEST
  */
-export type RouterRequestPayload = {
+export type RouterRequestPayload<T extends BaseRouterStoreState> = {
+  routerState: T;
   event: NavigationStart;
 };
 
 /**
  * An action dispatched when a router navigation request is fired.
  */
-export type RouterRequestAction = {
+export type RouterRequestAction<
+  T extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
   type: typeof ROUTER_REQUEST;
-  payload: RouterRequestPayload;
+  payload: RouterRequestPayload<T>;
 };
 
 /**
@@ -112,16 +115,19 @@ export const ROUTER_NAVIGATED = '@ngrx/router-store/navigated';
 /**
  * Payload of ROUTER_NAVIGATED.
  */
-export type RouterNavigatedPayload = {
+export type RouterNavigatedPayload<T extends BaseRouterStoreState> = {
+  routerState: T;
   event: NavigationEnd;
 };
 
 /**
  * An action dispatched after navigation has ended and new route is active.
  */
-export type RouterNavigatedAction = {
+export type RouterNavigatedAction<
+  T extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
   type: typeof ROUTER_NAVIGATED;
-  payload: RouterNavigatedPayload;
+  payload: RouterNavigatedPayload<T>;
 };
 
 /**
@@ -131,8 +137,8 @@ export type RouterAction<
   T,
   V extends BaseRouterStoreState = SerializedRouterStateSnapshot
 > =
-  | RouterRequestAction
+  | RouterRequestAction<V>
   | RouterNavigationAction<V>
   | RouterCancelAction<T, V>
   | RouterErrorAction<T, V>
-  | RouterNavigatedAction;
+  | RouterNavigatedAction<V>;

--- a/modules/router-store/src/actions.ts
+++ b/modules/router-store/src/actions.ts
@@ -19,7 +19,9 @@ export const ROUTER_REQUEST = '@ngrx/router-store/request';
 /**
  * Payload of ROUTER_REQUEST
  */
-export type RouterRequestPayload<T extends BaseRouterStoreState> = {
+export type RouterRequestPayload<
+  T extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
   routerState: T;
   event: NavigationStart;
 };
@@ -42,7 +44,9 @@ export const ROUTER_NAVIGATION = '@ngrx/router-store/navigation';
 /**
  * Payload of ROUTER_NAVIGATION.
  */
-export type RouterNavigationPayload<T extends BaseRouterStoreState> = {
+export type RouterNavigationPayload<
+  T extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
   routerState: T;
   event: RoutesRecognized;
 };
@@ -65,7 +69,10 @@ export const ROUTER_CANCEL = '@ngrx/router-store/cancel';
 /**
  * Payload of ROUTER_CANCEL.
  */
-export type RouterCancelPayload<T, V extends BaseRouterStoreState> = {
+export type RouterCancelPayload<
+  T,
+  V extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
   routerState: V;
   storeState: T;
   event: NavigationCancel;
@@ -90,7 +97,10 @@ export const ROUTER_ERROR = '@ngrx/router-store/error';
 /**
  * Payload of ROUTER_ERROR.
  */
-export type RouterErrorPayload<T, V extends BaseRouterStoreState> = {
+export type RouterErrorPayload<
+  T,
+  V extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
   routerState: V;
   storeState: T;
   event: NavigationError;
@@ -115,7 +125,9 @@ export const ROUTER_NAVIGATED = '@ngrx/router-store/navigated';
 /**
  * Payload of ROUTER_NAVIGATED.
  */
-export type RouterNavigatedPayload<T extends BaseRouterStoreState> = {
+export type RouterNavigatedPayload<
+  T extends BaseRouterStoreState = SerializedRouterStateSnapshot
+> = {
   routerState: T;
   event: NavigationEnd;
 };

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -13,6 +13,7 @@ import {
   RoutesRecognized,
   NavigationStart,
   Event,
+  RouterEvent,
 } from '@angular/router';
 import { select, Selector, Store } from '@ngrx/store';
 import { withLatestFrom } from 'rxjs/operators';
@@ -49,6 +50,12 @@ export interface StoreRouterConfig<
    * set this property to NavigationActionTiming.PostActivation.
    */
   navigationActionTiming?: NavigationActionTiming;
+}
+
+interface StoreRouterActionPayload {
+  event: RouterEvent;
+  routerState?: SerializedRouterStateSnapshot;
+  storeState?: any;
 }
 
 export enum NavigationActionTiming {
@@ -297,7 +304,10 @@ export class StoreRouterConnectingModule {
     this.dispatchRouterAction(ROUTER_NAVIGATED, { event });
   }
 
-  private dispatchRouterAction(type: string, payload: any): void {
+  private dispatchRouterAction(
+    type: string,
+    payload: StoreRouterActionPayload
+  ): void {
     this.trigger = RouterTrigger.ROUTER;
     try {
       this.store.dispatch({

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -301,7 +301,10 @@ export class StoreRouterConnectingModule {
   }
 
   private dispatchRouterNavigated(event: NavigationEnd): void {
-    this.dispatchRouterAction(ROUTER_NAVIGATED, { event });
+    const routerState = this.serializer.serialize(
+      this.router.routerState.snapshot
+    );
+    this.dispatchRouterAction(ROUTER_NAVIGATED, { event, routerState });
   }
 
   private dispatchRouterAction(

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -281,7 +281,6 @@ export class StoreRouterConnectingModule {
 
   private dispatchRouterCancel(event: NavigationCancel): void {
     this.dispatchRouterAction(ROUTER_CANCEL, {
-      routerState: this.routerState!,
       storeState: this.storeState,
       event,
     });
@@ -289,7 +288,6 @@ export class StoreRouterConnectingModule {
 
   private dispatchRouterError(event: NavigationError): void {
     this.dispatchRouterAction(ROUTER_ERROR, {
-      routerState: this.routerState!,
       storeState: this.storeState,
       event: new NavigationError(event.id, event.url, `${event}`),
     });
@@ -302,7 +300,13 @@ export class StoreRouterConnectingModule {
   private dispatchRouterAction(type: string, payload: any): void {
     this.trigger = RouterTrigger.ROUTER;
     try {
-      this.store.dispatch({ type, payload });
+      this.store.dispatch({
+        type,
+        payload: {
+          routerState: this.routerState,
+          ...payload,
+        },
+      });
     } finally {
       this.trigger = RouterTrigger.NONE;
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Only the `RouterNavigationAction`, `RouterCancelAction` and `RouterErrorAction` events had the `routerState` property in the payload.

Closes #1509

## What is the new behavior?

All of the router events will have the `routerState` property in the payload.
The `routerState` property is added to `RouterRequestAction` and `RouterNavigatedAction`


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

These actions were introduced in https://github.com/ngrx/platform/pull/1267 and I couldn't find why the `routerState` property isn't added. The rest of the actions had this property from version 4.0.0.
