### PR TITLE
docs(effects): expand ofType docs a bit, fixing typo

### DIFF
--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -25,8 +25,9 @@ export class Actions<V = Action> extends Observable<V> {
  * 'ofType' filters an Observable of Actions into an observable of the actions
  * whose type strings are passed to it.
  *
- * For example, `actions.pipe(ofType('add'))` returns an
- * `Observable<AddtionAction>`
+ * For example, if `actions` has type `Actions<Addition|Substraction>`, and
+ * the type of the `Addition` action is `add`, then
+ * `actions.pipe(ofType('add'))` returns an `Observable<AdditionAction>`.
  *
  * Properly typing this function is hard and requires some advanced TS tricks
  * below.

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -25,7 +25,7 @@ export class Actions<V = Action> extends Observable<V> {
  * 'ofType' filters an Observable of Actions into an observable of the actions
  * whose type strings are passed to it.
  *
- * For example, if `actions` has type `Actions<Addition|Substraction>`, and
+ * For example, if `actions` has type `Actions<AdditionAction|SubstractionAction>`, and
  * the type of the `Addition` action is `add`, then
  * `actions.pipe(ofType('add'))` returns an `Observable<AdditionAction>`.
  *


### PR DESCRIPTION


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] ~Tests for the changes have been added (for bug fixes / features)~ NA
- [ ] ~Documentation has been added / updated (for bug fixes / features)~ NA

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Initially, I've meant to fix the typo in "Addtion", but then I thought
it could help if the example was expanded a bit.

## What is the new behavior?

NA

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->