### PR TITLE
docs(entity): detail limitation of entity state adapter

### DIFF
--- a/projects/ngrx.io/content/guide/entity/index.md
+++ b/projects/ngrx.io/content/guide/entity/index.md
@@ -14,12 +14,12 @@ Detailed installation instructions can be found on the [Installation](guide/enti
 
 ## Entity and class instances
 
-The Entity State adapter is only compatible with plain javascript objects. This means, for example, you cannot use it to store ES6 class instances. This limitation exists to enforce our desired "best practice" that you only use `@ngrx/store` to store plain javascript objects (as well as potentially reduce user-error bug reports). Some reasons why you should only store plain javascript objects in `@ngrx/store`.
+Entity promotes the use of plain JavaScript objects when managing collections. Type information with ES6 class instances will not be retained when entities are manage in a collection. The provides you with some assurances when managing these entities.
 
 1. Guarantee that the data structures contained in state don't themselves contain logic, reducing the chance that they'll mutate themselves
 2. State will always be serializable allowing you to store and rehydrate from browser storage mechanisms like local storage
 3. State can be inspected via the Redux Devtools.
 
-This will always be a core constraint of NgRx and will not change in the future. The [Redux docs](https://redux.js.org/faq/organizingstate#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state) may offer more insight into this constraint.
+This is one of the [core principle](docs#core-principles) of NgRx. The [Redux docs](https://redux.js.org/faq/organizingstate#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state) also offers more insight into this constraint.
 
 The proper way to interact with @ngrx/entities is to pass it in plain JavaScript objects that are typed with interfaces.

--- a/projects/ngrx.io/content/guide/entity/index.md
+++ b/projects/ngrx.io/content/guide/entity/index.md
@@ -14,12 +14,10 @@ Detailed installation instructions can be found on the [Installation](guide/enti
 
 ## Entity and class instances
 
-Entity promotes the use of plain JavaScript objects when managing collections. Type information with ES6 class instances will not be retained when entities are manage in a collection. The provides you with some assurances when managing these entities.
+Entity promotes the use of plain JavaScript objects when managing collections. *ES6 class instances will be transformed into plain javascript objects when entities are managed in a collection*. This provides you with some assurances when managing these entities:
 
-1. Guarantee that the data structures contained in state don't themselves contain logic, reducing the chance that they'll mutate themselves
-2. State will always be serializable allowing you to store and rehydrate from browser storage mechanisms like local storage
+1. Guarantee that the data structures contained in state don't themselves contain logic, reducing the chance that they'll mutate themselves.
+2. State will always be serializable allowing you to store and rehydrate from browser storage mechanisms like local storage.
 3. State can be inspected via the Redux Devtools.
 
-This is one of the [core principle](docs#core-principles) of NgRx. The [Redux docs](https://redux.js.org/faq/organizingstate#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state) also offers more insight into this constraint.
-
-The proper way to interact with @ngrx/entities is to pass it in plain JavaScript objects that are typed with interfaces.
+This is one of the [core principles](docs#core-principles) of NgRx. The [Redux docs](https://redux.js.org/faq/organizingstate#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state) also offers some more insight into this constraint.

--- a/projects/ngrx.io/content/guide/entity/index.md
+++ b/projects/ngrx.io/content/guide/entity/index.md
@@ -14,7 +14,7 @@ Detailed installation instructions can be found on the [Installation](guide/enti
 
 ## Entity and class instances
 
-Entity promotes the use of plain JavaScript objects when managing collections. *ES6 class instances will be transformed into plain javascript objects when entities are managed in a collection*. This provides you with some assurances when managing these entities:
+Entity promotes the use of plain JavaScript objects when managing collections. *ES6 class instances will be transformed into plain JavaScript objects when entities are managed in a collection*. This provides you with some assurances when managing these entities:
 
 1. Guarantee that the data structures contained in state don't themselves contain logic, reducing the chance that they'll mutate themselves.
 2. State will always be serializable allowing you to store and rehydrate from browser storage mechanisms like local storage.

--- a/projects/ngrx.io/content/guide/entity/index.md
+++ b/projects/ngrx.io/content/guide/entity/index.md
@@ -11,3 +11,7 @@ Entity provides an API to manipulate and query entity collections.
 ## Installation 
 
 Detailed installation instructions can be found on the [Installation](guide/entity/install) page.
+
+## Important! 
+
+The Entity State adapter is only compatible with plain javascript objects. This means, for example, you cannot use it to store ES6 class instances. See issue [#976](https://github.com/ngrx/platform/issues/976). Unfortunately for you, the linked issue does not explain *why* we made this decision.

--- a/projects/ngrx.io/content/guide/entity/index.md
+++ b/projects/ngrx.io/content/guide/entity/index.md
@@ -12,7 +12,7 @@ Entity provides an API to manipulate and query entity collections.
 
 Detailed installation instructions can be found on the [Installation](guide/entity/install) page.
 
-## Important! 
+## Entity and class instances
 
 The Entity State adapter is only compatible with plain javascript objects. This means, for example, you cannot use it to store ES6 class instances. This limitation exists to enforce our desired "best practice" that you only use `@ngrx/store` to store plain javascript objects (as well as potentially reduce user-error bug reports). Some reasons why you should only store plain javascript objects in `@ngrx/store`.
 

--- a/projects/ngrx.io/content/guide/entity/index.md
+++ b/projects/ngrx.io/content/guide/entity/index.md
@@ -14,4 +14,12 @@ Detailed installation instructions can be found on the [Installation](guide/enti
 
 ## Important! 
 
-The Entity State adapter is only compatible with plain javascript objects. This means, for example, you cannot use it to store ES6 class instances. See issue [#976](https://github.com/ngrx/platform/issues/976). Unfortunately for you, the linked issue does not explain *why* we made this decision.
+The Entity State adapter is only compatible with plain javascript objects. This means, for example, you cannot use it to store ES6 class instances. This limitation exists to enforce our desired "best practice" that you only use `@ngrx/store` to store plain javascript objects (as well as potentially reduce user-error bug reports). Some reasons why you should only store plain javascript objects in `@ngrx/store`.
+
+1. Guarantee that the data structures contained in state don't themselves contain logic, reducing the chance that they'll mutate themselves
+2. State will always be serializable allowing you to store and rehydrate from browser storage mechanisms like local storage
+3. State can be inspected via the Redux Devtools.
+
+This will always be a core constraint of NgRx and will not change in the future. The [Redux docs](https://redux.js.org/faq/organizingstate#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state) may offer more insight into this constraint.
+
+The proper way to interact with @ngrx/entities is to pass it in plain JavaScript objects that are typed with interfaces.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?

Added a section to `@ngrx/entity` overview page in the docs which mentions the ([apparently "known" but never described](https://github.com/ngrx/platform/issues/976#issuecomment-383615818)) limitation that the entity state adapter doesn't support es6 classes. Definitely spent a while trying to debug an issue caused by this limitation.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
