### PR TITLE
docs: change typing of the actions stream in the testing docs

### DIFF
--- a/projects/ngrx.io/content/guide/effects/testing.md
+++ b/projects/ngrx.io/content/guide/effects/testing.md
@@ -14,14 +14,14 @@ import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { hot, cold } from 'jasmine-marbles';
-import { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 
 import { MyEffects } from './my-effects';
 import * as MyActions from '../actions/my-actions';
 
 describe('My Effects', () => {
   let effects: MyEffects;
-  let actions: Observable&lt;any&gt;;
+  let actions: Subject&lt;any&gt;;
 
   beforeEach(() => {
     TestBed.configureTestingModule({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`actions` stream is assigned a `ReplytSubject` later in the test case, so it can't only be an `Obserbale` as this type doesn't have a `next` method.

## What is the new behavior?

`actions` is now typed as a `Subject` to properly recognize the existence of the `next` method.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

