### PR TITLE
fix(schematics): type actions and avoid endless loop in effect

### DIFF
--- a/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
+++ b/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts
@@ -1,9 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect<% if (feature) { %>, ofType<% } %> } from '@ngrx/effects';
-<% if (feature && api) { %>import { catchError, map, concatMap } from 'rxjs/operators';<% } %>
-<% if (feature && api) { %>import { EMPTY, of } from 'rxjs';<% } %>
-<% if (feature && api) { %>import { Load<%= classify(name) %>sFailure, Load<%= classify(name) %>sSuccess, <%= classify(name) %>ActionTypes, <%= classify(name) %>Actions } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
-<% if (feature && !api) { %>import { <%= classify(name) %>ActionTypes } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
+<% if (feature && api) { %>import { catchError, map, concatMap } from 'rxjs/operators';
+import { EMPTY, of } from 'rxjs';
+import { Load<%= classify(name) %>sFailure, Load<%= classify(name) %>sSuccess, <%= classify(name) %>ActionTypes, <%= classify(name) %>Actions } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';
+<% } %>
+<% if (feature && !api) { %>import { concatMap } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { <%= classify(name) %>ActionTypes, <%= classify(name) %>Actions } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';
+<% } %>
 
 @Injectable()
 export class <%= classify(name) %>Effects {
@@ -17,13 +21,16 @@ export class <%= classify(name) %>Effects {
         map(data => new Load<%= classify(name) %>sSuccess({ data })),
         catchError(error => of(new Load<%= classify(name) %>sFailure({ error }))))
     )
-  );
-<% } %>
+  );<% } %>
 <% if (feature && !api) { %>
   @Effect()
-  load<%= classify(name) %>s$ = this.actions$.pipe(ofType(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s));
+  load<%= classify(name) %>s$ = this.actions$.pipe(
+    ofType(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s),
+    /** An EMPTY observable only emits completion. Replace with your own observable API request */
+    concatMap(() => EMPTY)
+  );
 <% } %>
-<% if (feature && api) { %>
+<% if (feature) { %>
   constructor(private actions$: Actions<<%= classify(name) %>Actions>) {}
 <% } else { %>
   constructor(private actions$: Actions) {}

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -236,7 +236,7 @@ describe('Effect Schematic', () => {
     );
 
     expect(content).toMatch(
-      /import \{ FooActionTypes } from \'\.\.\/\.\.\/actions\/foo\/foo\.actions';/
+      /import \{ FooActionTypes, FooActions } from \'\.\.\/\.\.\/actions\/foo\/foo\.actions';/
     );
   });
 
@@ -250,12 +250,18 @@ describe('Effect Schematic', () => {
     expect(content).toMatch(
       /import { Actions, Effect, ofType } from '@ngrx\/effects';/
     );
+    expect(content).toMatch(/import { concatMap } from 'rxjs\/operators';/);
+    expect(content).toMatch(/import { EMPTY } from 'rxjs';/);
     expect(content).toMatch(
-      /import { FooActionTypes } from '\.\/foo.actions';/
+      /import { FooActionTypes, FooActions } from '\.\/foo.actions';/
     );
     expect(content).toMatch(/export class FooEffects/);
+    expect(content).toMatch(/loadFoos\$ = this\.actions\$.pipe\(/);
+    expect(content).toMatch(/ofType\(FooActionTypes\.LoadFoos\)/);
+    expect(content).toMatch(/concatMap\(\(\) => EMPTY\)/);
+
     expect(content).toMatch(
-      /loadFoos\$ = this\.actions\$.pipe\(ofType\(FooActionTypes\.LoadFoos\)\);/
+      /constructor\(private actions\$: Actions<FooActions>\) {}/
     );
   });
 
@@ -274,7 +280,7 @@ describe('Effect Schematic', () => {
     );
     expect(content).toMatch(/export class FooEffects/);
     expect(content).not.toMatch(
-      /loadFoos\$ = this\.actions\$.pipe\(ofType\(FooActionTypes\.LoadFoos\)\);/
+      /loadFoos\$ = this\.actions\$.pipe\(ofType\(FooActionTypes\.LoadFoos/
     );
   });
 


### PR DESCRIPTION
Two minor fixes for effects generated by `ng g feature`:

- Make the generated effect for 'ng g feature'  harmless by not dispatching any action
- type the 'Actions' injectable by default in feature effect

Closes #1573

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Documentation has been added / updated (for bug fixes / features)~~

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
