### PR TITLE
fix(StoreDevTools): rename action list filters

### DIFF
--- a/modules/store-devtools/spec/extension.spec.ts
+++ b/modules/store-devtools/spec/extension.spec.ts
@@ -374,15 +374,15 @@ describe('DevtoolsExtension', () => {
       });
     });
 
-    describe('with Action and actionsBlacklist', () => {
+    describe('with Action and actionsBlocklist', () => {
       const NORMAL_ACTION = 'NORMAL_ACTION';
-      const BLACKLISTED_ACTION = 'BLACKLISTED_ACTION';
+      const BLOCKED_ACTION = 'BLOCKED_ACTION';
 
       beforeEach(() => {
         devtoolsExtension = new DevtoolsExtension(
           reduxDevtoolsExtension,
           createConfig({
-            actionsBlacklist: [BLACKLISTED_ACTION],
+            actionsBlocklist: [BLOCKED_ACTION],
           }),
           <any>null
         );
@@ -390,7 +390,7 @@ describe('DevtoolsExtension', () => {
         devtoolsExtension.actions$.subscribe(() => null);
       });
 
-      it('should ignore blacklisted action', () => {
+      it('should ignore the blocked action', () => {
         const options = createOptions();
         const state = createState();
 
@@ -403,22 +403,22 @@ describe('DevtoolsExtension', () => {
           state
         );
         devtoolsExtension.notify(
-          new PerformAction({ type: BLACKLISTED_ACTION }, 1234567),
+          new PerformAction({ type: BLOCKED_ACTION }, 1234567),
           state
         );
         expect(extensionConnection.send).toHaveBeenCalledTimes(2);
       });
     });
 
-    describe('with Action and actionsWhitelist', () => {
+    describe('with Action and actionsSafelist', () => {
       const NORMAL_ACTION = 'NORMAL_ACTION';
-      const WHITELISTED_ACTION = 'WHITELISTED_ACTION';
+      const SAFE_ACTION = 'SAFE_ACTION';
 
       beforeEach(() => {
         devtoolsExtension = new DevtoolsExtension(
           reduxDevtoolsExtension,
           createConfig({
-            actionsWhitelist: [WHITELISTED_ACTION],
+            actionsSafelist: [SAFE_ACTION],
           }),
           <any>null
         );
@@ -426,7 +426,7 @@ describe('DevtoolsExtension', () => {
         devtoolsExtension.actions$.subscribe(() => null);
       });
 
-      it('should only keep whitelisted action', () => {
+      it('should only keep the safe action', () => {
         const options = createOptions();
         const state = createState();
 
@@ -439,7 +439,7 @@ describe('DevtoolsExtension', () => {
           state
         );
         devtoolsExtension.notify(
-          new PerformAction({ type: WHITELISTED_ACTION }, 1234567),
+          new PerformAction({ type: SAFE_ACTION }, 1234567),
           state
         );
         expect(extensionConnection.send).toHaveBeenCalledTimes(1);

--- a/modules/store-devtools/spec/integration.spec.ts
+++ b/modules/store-devtools/spec/integration.spec.ts
@@ -66,9 +66,9 @@ describe('Devtools Integration', () => {
     devtools.refresh();
   });
 
-  it('should not throw if actions are blacklisted', (done: any) => {
+  it('should not throw if actions are blocked', (done: any) => {
     const { store, devtools } = setup({
-      actionsBlacklist: ['FOO'],
+      actionsBlocklist: ['FOO'],
     });
     store.subscribe();
     devtools.dispatcher.subscribe((action: Action) => {
@@ -80,9 +80,9 @@ describe('Devtools Integration', () => {
     devtools.refresh();
   });
 
-  it('should not throw if actions are whitelisted', (done: any) => {
+  it('should not throw if actions are safe', (done: any) => {
     const { store, devtools } = setup({
-      actionsWhitelist: ['BAR'],
+      actionsSafelist: ['BAR'],
     });
     store.subscribe();
     devtools.dispatcher.subscribe((action: Action) => {

--- a/modules/store-devtools/spec/store.spec.ts
+++ b/modules/store-devtools/spec/store.spec.ts
@@ -478,9 +478,9 @@ describe('Store Devtools', () => {
       expect(fixture.getState()).toBe(5);
     });
 
-    it('should respect the blacklist option', () => {
+    it('should respect the blocked option', () => {
       const fixture = createStore(counter, {
-        actionsBlacklist: ['INCREMENT'],
+        actionsBlocklist: ['INCREMENT'],
       });
 
       expect(fixture.getState()).toBe(0);
@@ -517,9 +517,9 @@ describe('Store Devtools', () => {
       expect(fixture.getState()).toBe(5);
     });
 
-    it('should respect the whitelist option', () => {
+    it('should respect the safe option', () => {
       const fixture = createStore(counter, {
-        actionsWhitelist: ['DECREMENT'],
+        actionsSafelist: ['DECREMENT'],
       });
 
       expect(fixture.getState()).toBe(0);

--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -21,8 +21,8 @@ export class StoreDevtoolsConfig {
   serialize?: boolean | SerializationOptions;
   logOnly?: boolean;
   features?: any;
-  actionsBlacklist?: string[];
-  actionsWhitelist?: string[];
+  actionsBlocklist?: string[];
+  actionsSafelist?: string[];
   predicate?: Predicate;
 }
 

--- a/modules/store-devtools/src/devtools.ts
+++ b/modules/store-devtools/src/devtools.ts
@@ -87,8 +87,8 @@ export class StoreDevtools implements Observer<any> {
               reducedLiftedState = filterLiftedState(
                 reducedLiftedState,
                 config.predicate,
-                config.actionsWhitelist,
-                config.actionsBlacklist
+                config.actionsSafelist,
+                config.actionsBlocklist
               );
             }
             // Extension should be sent the sanitized lifted state

--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -113,8 +113,8 @@ export class DevtoolsExtension {
           currentState,
           action,
           this.config.predicate,
-          this.config.actionsWhitelist,
-          this.config.actionsBlacklist
+          this.config.actionsSafelist,
+          this.config.actionsBlocklist
         )
       ) {
         return;

--- a/modules/store-devtools/src/reducer.ts
+++ b/modules/store-devtools/src/reducer.ts
@@ -369,8 +369,8 @@ export function liftReducerWith(
               liftedState.computedStates[currentStateIndex],
               liftedAction,
               options.predicate,
-              options.actionsWhitelist,
-              options.actionsBlacklist
+              options.actionsSafelist,
+              options.actionsBlocklist
             ))
         ) {
           // If recording is paused or if the action should be ignored, overwrite the last state

--- a/modules/store-devtools/src/utils.ts
+++ b/modules/store-devtools/src/utils.ts
@@ -26,7 +26,7 @@ export function unliftState(liftedState: LiftedState) {
   const { computedStates, currentStateIndex } = liftedState;
 
   // At start up NgRx dispatches init actions,
-  // When these init actions are being filtered out by the predicate or black/white list options
+  // When these init actions are being filtered out by the predicate or safe/block list options
   // we don't have a complete computed states yet.
   // At this point it could happen that we're out of bounds, when this happens we fall back to the last known state
   if (currentStateIndex >= computedStates.length) {
@@ -112,7 +112,7 @@ export function sanitizeState(
  * Read the config and tell if actions should be filtered
  */
 export function shouldFilterActions(config: StoreDevtoolsConfig) {
-  return config.predicate || config.actionsWhitelist || config.actionsBlacklist;
+  return config.predicate || config.actionsSafelist || config.actionsBlocklist;
 }
 
 /**
@@ -121,8 +121,8 @@ export function shouldFilterActions(config: StoreDevtoolsConfig) {
 export function filterLiftedState(
   liftedState: LiftedState,
   predicate?: Predicate,
-  whitelist?: string[],
-  blacklist?: string[]
+  safelist?: string[],
+  blocklist?: string[]
 ): LiftedState {
   const filteredStagedActionIds: number[] = [];
   const filteredActionsById: LiftedActions = {};
@@ -136,8 +136,8 @@ export function filterLiftedState(
         liftedState.computedStates[idx],
         liftedAction,
         predicate,
-        whitelist,
-        blacklist
+        safelist,
+        blocklist
       )
     ) {
       return;
@@ -161,13 +161,13 @@ export function isActionFiltered(
   state: any,
   action: LiftedAction,
   predicate?: Predicate,
-  whitelist?: string[],
-  blacklist?: string[]
+  safelist?: string[],
+  blockedlist?: string[]
 ) {
   const predicateMatch = predicate && !predicate(state, action.action);
-  const whitelistMatch =
-    whitelist && !action.action.type.match(whitelist.join('|'));
-  const blacklistMatch =
-    blacklist && action.action.type.match(blacklist.join('|'));
-  return predicateMatch || whitelistMatch || blacklistMatch;
+  const safelistMatch =
+    safelist && !action.action.type.match(safelist.join('|'));
+  const blocklistMatch =
+    blockedlist && action.action.type.match(blockedlist.join('|'));
+  return predicateMatch || safelistMatch || blocklistMatch;
 }

--- a/projects/ngrx.io/content/guide/store-devtools/config.md
+++ b/projects/ngrx.io/content/guide/store-devtools/config.md
@@ -38,7 +38,7 @@ function - takes `state` object and index as arguments, and should return a `sta
 
 For more detailed information see [Redux DevTools Serialize](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize)
 
-### `actionsBlacklist` / `actionsWhitelist`
+### `actionsSafelist` / `actionsBlocklist`
 
 array of strings as regex - actions types to be hidden / shown in the monitors, [more information here](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#actionsblacklist--actionswhitelist).
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1557

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

BREAKING CHANGE:

`actionsWhitelist` is renamed to `actionsSafelist`
`actionsBlacklist` is renamed to `actionsBlocklist`

BEFORE:

```ts
StoreDevtoolsModule.instrument({
  actionsWhitelist: ['...'],
  actionsBlacklist: ['...']
})
```

AFTER:

```ts
StoreDevtoolsModule.instrument({
  actionsSafelist: ['...'],
  actionsBlocklist: ['...']
})
```
