### PR TITLE
feat(Store): runtime checks

### DIFF
--- a/modules/router-store/spec/integration.spec.ts
+++ b/modules/router-store/spec/integration.spec.ts
@@ -253,7 +253,13 @@ describe('integration spec', () => {
       } else {
         const nextState = routerReducer(state, action);
         if (nextState && nextState.state) {
-          nextState.state.root = <any>{};
+          return {
+            ...nextState,
+            state: {
+              ...nextState.state,
+              root: {} as any,
+            },
+          };
         }
         return nextState;
       }
@@ -383,7 +389,13 @@ describe('integration spec', () => {
       } else {
         const nextState = routerReducer(state, action);
         if (nextState && nextState.state) {
-          nextState.state.root = <any>{};
+          return {
+            ...nextState,
+            state: {
+              ...nextState.state,
+              root: {} as any,
+            },
+          };
         }
         return nextState;
       }

--- a/modules/store/spec/meta-reducers/action_serialization_reducer.spec.ts
+++ b/modules/store/spec/meta-reducers/action_serialization_reducer.spec.ts
@@ -1,0 +1,23 @@
+import { actionSerializationCheckMetaReducer } from '../../src/meta-reducers';
+
+describe('actionSerializationCheckMetaReducer:', () => {
+  describe('valid action:', () => {
+    it('should not throw', () => {
+      expect(() =>
+        invokeReducer({ type: 'valid', payload: { id: 47 } })
+      ).not.toThrow();
+    });
+  });
+
+  describe('invalid action:', () => {
+    it('should throw', () => {
+      expect(() =>
+        invokeReducer({ type: 'invalid', payload: { date: new Date() } })
+      ).toThrow();
+    });
+  });
+
+  function invokeReducer(action: any) {
+    actionSerializationCheckMetaReducer(() => {})(undefined, action);
+  }
+});

--- a/modules/store/spec/meta-reducers/immutability_reducer.spec.ts
+++ b/modules/store/spec/meta-reducers/immutability_reducer.spec.ts
@@ -1,0 +1,57 @@
+import { immutabilityCheckMetaReducer } from '../../src/meta-reducers';
+
+describe('immutabilityCheckMetaReducer:', () => {
+  describe('actions:', () => {
+    it('should not throw if left untouched', () => {
+      expect(() => invokeReducer((action: any) => action)).not.toThrow();
+    });
+
+    it('should throw when mutating an action', () => {
+      expect(() =>
+        invokeReducer((action: any) => {
+          action.foo = '123';
+        })
+      ).toThrow();
+      expect(() =>
+        invokeReducer((action: any) => {
+          action.numbers.push(4);
+        })
+      ).toThrow();
+    });
+
+    function invokeReducer(reduce: Function) {
+      immutabilityCheckMetaReducer((state, action) => {
+        reduce(action);
+        return state;
+      })({}, { type: 'invoke', numbers: [1, 2, 3] });
+    }
+  });
+
+  describe('state:', () => {
+    it('should not throw if left untouched', () => {
+      expect(() =>
+        invokeReducer((state: any) => ({ ...state, foo: 'bar' }))
+      ).not.toThrow();
+    });
+
+    it('should throw when mutating state', () => {
+      expect(() =>
+        invokeReducer((state: any) => {
+          state.foo = '123';
+        })
+      ).toThrow();
+      expect(() =>
+        invokeReducer((state: any) => {
+          state.numbers.push(4);
+        })
+      ).toThrow();
+    });
+
+    function invokeReducer(reduce: Function) {
+      immutabilityCheckMetaReducer((state, _action) => reduce(state))(
+        { numbers: [1, 2, 3] },
+        { type: 'invoke' }
+      );
+    }
+  });
+});

--- a/modules/store/spec/meta-reducers/state_serialization_reducer.spec.ts
+++ b/modules/store/spec/meta-reducers/state_serialization_reducer.spec.ts
@@ -1,0 +1,25 @@
+import { stateSerializationCheckMetaReducer } from '../../src/meta-reducers';
+
+describe('stateSerializationCheckMetaReducer:', () => {
+  describe('valid next state:', () => {
+    it('should not throw', () => {
+      expect(() =>
+        invokeReducer({
+          nested: { number: 1, null: null },
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe('invalid next state:', () => {
+    it('should throw', () => {
+      expect(() => invokeReducer({ nested: { class: new Date() } })).toThrow();
+    });
+  });
+
+  function invokeReducer(nextState?: any) {
+    stateSerializationCheckMetaReducer(() => nextState)(undefined, {
+      type: 'invokeReducer',
+    });
+  }
+});

--- a/modules/store/spec/meta-reducers/utils.spec.ts
+++ b/modules/store/spec/meta-reducers/utils.spec.ts
@@ -1,0 +1,82 @@
+import {
+  getUnserializable,
+  throwIfUnserializable,
+} from '../../src/meta-reducers/utils';
+
+describe('getUnserializable:', () => {
+  describe('serializable value:', () => {
+    it('should not throw', () => {
+      expect(getUnserializable(1)).toBe(false);
+      expect(getUnserializable(true)).toBe(false);
+      expect(getUnserializable('string')).toBe(false);
+      expect(getUnserializable([1, 2, 3])).toBe(false);
+      expect(getUnserializable({})).toBe(false);
+      expect(
+        getUnserializable({
+          nested: { number: 1, undefined: undefined, null: null },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('unserializable value:', () => {
+    it('should throw', () => {
+      class TestClass {}
+
+      expect(getUnserializable()).toEqual({ value: undefined, path: ['root'] });
+      expect(getUnserializable(null)).toEqual({ value: null, path: ['root'] });
+
+      const date = new Date();
+      expect(getUnserializable({ date })).toEqual({
+        value: date,
+        path: ['date'],
+      });
+      expect(getUnserializable({ set: new Set([]) })).toEqual({
+        value: new Set([]),
+        path: ['set'],
+      });
+      expect(getUnserializable({ map: new Map([]) })).toEqual({
+        value: new Map([]),
+        path: ['map'],
+      });
+      expect(getUnserializable({ class: new TestClass() })).toEqual({
+        value: new TestClass(),
+        path: ['class'],
+      });
+      expect(
+        getUnserializable({
+          nested: { valid: true, class: new TestClass(), alsoValid: '' },
+          valid: [3],
+        })
+      ).toEqual({ value: new TestClass(), path: ['nested', 'class'] });
+    });
+  });
+});
+
+describe('throwIfUnserializable', () => {
+  describe('serializable', () => {
+    it('should not throw an error', () => {
+      expect(() => throwIfUnserializable(false, 'state')).not.toThrow();
+    });
+  });
+
+  describe('unserializable', () => {
+    it('should throw an error', () => {
+      expect(() =>
+        throwIfUnserializable({ path: ['root'], value: undefined }, 'state')
+      ).toThrowError(`Detected unserializable state at "root"`);
+      expect(() =>
+        throwIfUnserializable({ path: ['date'], value: new Date() }, 'action')
+      ).toThrowError(`Detected unserializable action at "date"`);
+      expect(() =>
+        throwIfUnserializable(
+          {
+            path: ['one', 'two', 'three'],
+            value: new Date(),
+          },
+          'state'
+        )
+      ).toThrowError(`Detected unserializable state at "one.two.three"`);
+    });
+  });
+});

--- a/modules/store/spec/runtime_checks.spec.ts
+++ b/modules/store/spec/runtime_checks.spec.ts
@@ -1,0 +1,294 @@
+import * as ngCore from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Store, StoreModule, META_REDUCERS } from '..';
+import { createActiveRuntimeChecks } from '../src/runtime_checks';
+import { RuntimeChecks } from '../src/models';
+
+describe('Runtime checks:', () => {
+  describe('createActiveRuntimeChecks:', () => {
+    it('should disable all checks by default', () => {
+      expect(createActiveRuntimeChecks()).toEqual({
+        strictStateSerializability: false,
+        strictActionSerializability: false,
+        strictImmutability: false,
+      });
+    });
+
+    it('should log a warning in dev mode when no configuration is provided', () => {
+      const spy = spyOn(console, 'warn');
+
+      createActiveRuntimeChecks();
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should not log a warning in dev mode when configuration is provided', () => {
+      const spy = spyOn(console, 'warn');
+
+      createActiveRuntimeChecks({});
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should not log a warning when not dev mode when no configuration is provided', () => {
+      spyOn(ngCore, 'isDevMode').and.returnValue(false);
+      const spy = spyOn(console, 'warn');
+
+      createActiveRuntimeChecks();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should allow the user to override the config', () => {
+      expect(
+        createActiveRuntimeChecks({
+          strictStateSerializability: true,
+          strictActionSerializability: true,
+          strictImmutability: true,
+        })
+      ).toEqual({
+        strictStateSerializability: true,
+        strictActionSerializability: true,
+        strictImmutability: true,
+      });
+    });
+
+    it('should disable runtime checks in production', () => {
+      spyOn(ngCore, 'isDevMode').and.returnValue(false);
+
+      expect(createActiveRuntimeChecks()).toEqual({
+        strictStateSerializability: false,
+        strictActionSerializability: false,
+        strictImmutability: false,
+      });
+    });
+  });
+
+  describe('Registering custom meta-reducers:', () => {
+    it('should invoke internal meta reducers before user defined meta reducers', () => {
+      let logs: string[] = [];
+      function metaReducerFactory(logMessage: string) {
+        return function metaReducer(reducer: any) {
+          return function(state: any, action: any) {
+            logs.push(logMessage);
+            return reducer(state, action);
+          };
+        };
+      }
+
+      TestBed.configureTestingModule({
+        imports: [
+          StoreModule.forRoot(
+            {},
+            {
+              metaReducers: [metaReducerFactory('user')],
+            }
+          ),
+        ],
+        providers: [
+          {
+            provide: META_REDUCERS,
+            useValue: metaReducerFactory('internal-single-one'),
+            multi: true,
+          },
+          {
+            provide: META_REDUCERS,
+            useValue: metaReducerFactory('internal-single-two'),
+            multi: true,
+          },
+        ],
+      });
+
+      const store: Store<any> = TestBed.get(Store);
+      const expected = ['internal-single-one', 'internal-single-two', 'user'];
+
+      expect(logs).toEqual(expected);
+      logs = [];
+
+      store.dispatch({ type: 'foo' });
+      expect(logs).toEqual(expected);
+    });
+  });
+
+  describe('State Serialization:', () => {
+    const invalidAction = () => ({ type: ErrorTypes.UnserializableState });
+
+    it('should throw when enabled', (done: DoneFn) => {
+      const store = setupStore({ strictStateSerializability: true });
+
+      store.subscribe({
+        error: err => {
+          expect(err).toMatch(/Detected unserializable state/);
+          done();
+        },
+      });
+
+      store.dispatch(invalidAction());
+    });
+
+    it('should not throw when disabled', (done: DoneFn) => {
+      const store = setupStore({ strictStateSerializability: false });
+
+      store.subscribe({
+        next: ({ state }) => {
+          if (state.invalidSerializationState) {
+            done();
+          }
+        },
+      });
+
+      store.dispatch(invalidAction());
+    });
+  });
+
+  describe('Action Serialization:', () => {
+    const invalidAction = () => ({
+      type: ErrorTypes.UnserializableAction,
+      invalid: new Date(),
+    });
+
+    it('should throw when enabled', (done: DoneFn) => {
+      const store = setupStore({ strictActionSerializability: true });
+
+      store.subscribe({
+        error: err => {
+          expect(err).toMatch(/Detected unserializable action/);
+          done();
+        },
+      });
+      store.dispatch(invalidAction());
+    });
+
+    it('should not throw when disabled', (done: DoneFn) => {
+      const store = setupStore({ strictActionSerializability: false });
+
+      store.subscribe({
+        next: ({ state }) => {
+          if (state.invalidSerializationAction) {
+            done();
+          }
+        },
+      });
+
+      store.dispatch(invalidAction());
+    });
+  });
+
+  describe('State Mutations', () => {
+    const invalidAction = () => ({
+      type: ErrorTypes.MutateState,
+    });
+
+    it('should throw when enabled', (done: DoneFn) => {
+      const store = setupStore({ strictImmutability: true });
+
+      store.subscribe({
+        error: _ => {
+          done();
+        },
+      });
+
+      store.dispatch(invalidAction());
+    });
+
+    it('should not throw when disabled', (done: DoneFn) => {
+      const store = setupStore({ strictImmutability: false });
+
+      store.subscribe({
+        next: ({ state }) => {
+          if (state.invalidMutationState) {
+            done();
+          }
+        },
+      });
+
+      store.dispatch(invalidAction());
+    });
+  });
+
+  describe('Action Mutations', () => {
+    const invalidAction = () => ({
+      type: ErrorTypes.MutateAction,
+      foo: 'foo',
+    });
+
+    it('should throw when enabled', (done: DoneFn) => {
+      const store = setupStore({ strictImmutability: true });
+
+      store.subscribe({
+        error: _ => {
+          done();
+        },
+      });
+
+      store.dispatch(invalidAction());
+    });
+
+    it('should not throw when disabled', (done: DoneFn) => {
+      const store = setupStore({ strictImmutability: false });
+
+      store.subscribe({
+        next: ({ state }) => {
+          if (state.invalidMutationAction) {
+            done();
+          }
+        },
+      });
+
+      store.dispatch(invalidAction());
+    });
+  });
+});
+
+function setupStore(runtimeChecks?: Partial<RuntimeChecks>): Store<any> {
+  TestBed.configureTestingModule({
+    imports: [
+      StoreModule.forRoot(
+        {
+          state: reducerWithBugs,
+        },
+        { runtimeChecks }
+      ),
+    ],
+  });
+
+  return TestBed.get(Store);
+}
+
+enum ErrorTypes {
+  UnserializableState = 'Action type producing unserializable state',
+  UnserializableAction = 'Action type producing unserializable action',
+  MutateAction = 'Action type producing action mutation',
+  MutateState = 'Action type producing state mutation',
+}
+
+function reducerWithBugs(state: any = {}, action: any) {
+  switch (action.type) {
+    case ErrorTypes.UnserializableState:
+      return {
+        invalidSerializationState: true,
+        invalid: new Date(),
+      };
+
+    case ErrorTypes.UnserializableAction: {
+      return {
+        invalidSerializationAction: true,
+      };
+    }
+
+    case ErrorTypes.MutateAction: {
+      action.foo = 'foo';
+      return {
+        invalidMutationAction: true,
+      };
+    }
+
+    case ErrorTypes.MutateState: {
+      state.invalidMutationState = true;
+      return state;
+    }
+
+    default:
+      return state;
+  }
+}

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -46,6 +46,7 @@ export {
   _FEATURE_REDUCERS,
   FEATURE_REDUCERS,
   _FEATURE_REDUCERS_TOKEN,
+  USER_PROVIDED_META_REDUCERS,
 } from './tokens';
 export {
   StoreModule,

--- a/modules/store/src/meta-reducers/action_serialization_reducer.ts
+++ b/modules/store/src/meta-reducers/action_serialization_reducer.ts
@@ -1,0 +1,13 @@
+import { ActionReducer } from '../models';
+import { getUnserializable, throwIfUnserializable } from './utils';
+
+export function actionSerializationCheckMetaReducer(
+  reducer: ActionReducer<any, any>
+): ActionReducer<any, any> {
+  return function(state, action) {
+    const unserializable = getUnserializable(action);
+    throwIfUnserializable(unserializable, 'action');
+
+    return reducer(state, action);
+  };
+}

--- a/modules/store/src/meta-reducers/immutability_reducer.ts
+++ b/modules/store/src/meta-reducers/immutability_reducer.ts
@@ -1,0 +1,32 @@
+import { ActionReducer } from '../models';
+import { isFunction, hasOwnProperty, isObjectLike } from './utils';
+
+export function immutabilityCheckMetaReducer(
+  reducer: ActionReducer<any, any>
+): ActionReducer<any, any> {
+  return function(state, action) {
+    const nextState = reducer(state, freeze(action));
+    return freeze(nextState);
+  };
+}
+
+function freeze(target: any) {
+  Object.freeze(target);
+
+  const targetIsFunction = isFunction(target);
+
+  Object.getOwnPropertyNames(target).forEach(prop => {
+    const propValue = target[prop];
+    if (
+      hasOwnProperty(target, prop) && targetIsFunction
+        ? prop !== 'caller' && prop !== 'callee' && prop !== 'arguments'
+        : true &&
+          (isObjectLike(propValue) || isFunction(propValue)) &&
+          !Object.isFrozen(propValue)
+    ) {
+      freeze(propValue);
+    }
+  });
+
+  return target;
+}

--- a/modules/store/src/meta-reducers/index.ts
+++ b/modules/store/src/meta-reducers/index.ts
@@ -1,0 +1,7 @@
+export {
+  stateSerializationCheckMetaReducer,
+} from './state_serialization_reducer';
+export {
+  actionSerializationCheckMetaReducer,
+} from './action_serialization_reducer';
+export { immutabilityCheckMetaReducer } from './immutability_reducer';

--- a/modules/store/src/meta-reducers/state_serialization_reducer.ts
+++ b/modules/store/src/meta-reducers/state_serialization_reducer.ts
@@ -1,0 +1,15 @@
+import { ActionReducer } from '../models';
+import { getUnserializable, throwIfUnserializable } from './utils';
+
+export function stateSerializationCheckMetaReducer(
+  reducer: ActionReducer<any, any>
+): ActionReducer<any, any> {
+  return function(state, action) {
+    const nextState = reducer(state, action);
+
+    const unserializable = getUnserializable(nextState);
+    throwIfUnserializable(unserializable, 'state');
+
+    return nextState;
+  };
+}

--- a/modules/store/src/meta-reducers/utils.ts
+++ b/modules/store/src/meta-reducers/utils.ts
@@ -1,0 +1,111 @@
+export function getUnserializable(
+  target?: any,
+  path: string[] = []
+): false | { path: string[]; value: any } {
+  // Guard against undefined and null, e.g. a reducer that returns undefined
+  if ((isUndefined(target) || isNull(target)) && path.length === 0) {
+    return {
+      path: ['root'],
+      value: target,
+    };
+  }
+
+  const keys = Object.keys(target);
+  return keys.reduce<false | { path: string[]; value: any }>((result, key) => {
+    if (result) {
+      return result;
+    }
+
+    const value = (target as any)[key];
+
+    if (
+      isUndefined(value) ||
+      isNull(value) ||
+      isNumber(value) ||
+      isBoolean(value) ||
+      isString(value) ||
+      isArray(value)
+    ) {
+      return false;
+    }
+
+    if (isPlainObject(value)) {
+      return getUnserializable(value, [...path, key]);
+    }
+
+    return {
+      path: [...path, key],
+      value,
+    };
+  }, false);
+}
+
+export function throwIfUnserializable(
+  unserializable: false | { path: string[]; value: any },
+  context: 'state' | 'action'
+) {
+  if (unserializable === false) {
+    return;
+  }
+
+  const unserializablePath = unserializable.path.join('.');
+  const error: any = new Error(
+    `Detected unserializable ${context} at "${unserializablePath}"`
+  );
+  error.value = unserializable.value;
+  error.unserializablePath = unserializablePath;
+  throw error;
+}
+
+/**
+ * Object Utilities
+ */
+
+export function isUndefined(target: any): target is undefined {
+  return target === undefined;
+}
+
+export function isNull(target: any): target is null {
+  return target === null;
+}
+
+export function isArray(target: any): target is Array<any> {
+  return Array.isArray(target);
+}
+
+export function isString(target: any): target is string {
+  return typeof target === 'string';
+}
+
+export function isBoolean(target: any): target is boolean {
+  return typeof target === 'boolean';
+}
+
+export function isNumber(target: any): target is number {
+  return typeof target === 'number';
+}
+
+export function isObjectLike(target: any): target is object {
+  return typeof target === 'object' && target !== null;
+}
+
+export function isObject(target: any): target is object {
+  return isObjectLike(target) && !isArray(target);
+}
+
+export function isPlainObject(target: any): target is object {
+  if (!isObject(target)) {
+    return false;
+  }
+
+  const targetPrototype = Object.getPrototypeOf(target);
+  return targetPrototype === Object.prototype || targetPrototype === null;
+}
+
+export function isFunction(target: any): target is Function {
+  return typeof target === 'function';
+}
+
+export function hasOwnProperty(target: object, propertyName: string): boolean {
+  return Object.prototype.hasOwnProperty.call(target, propertyName);
+}

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -26,7 +26,7 @@ export interface ActionReducerFactory<T, V extends Action = Action> {
   ): ActionReducer<T, V>;
 }
 
-export type MetaReducer<T, V extends Action = Action> = (
+export type MetaReducer<T = any, V extends Action = Action> = (
   reducer: ActionReducer<T, V>
 ) => ActionReducer<T, V>;
 
@@ -57,3 +57,8 @@ export type FunctionWithParametersType<P extends unknown[], R = void> = (
 export type ParametersType<T> = T extends (...args: infer U) => unknown
   ? U
   : never;
+export interface RuntimeChecks {
+  strictStateSerializability: boolean;
+  strictActionSerializability: boolean;
+  strictImmutability: boolean;
+}

--- a/modules/store/src/runtime_checks.ts
+++ b/modules/store/src/runtime_checks.ts
@@ -1,0 +1,95 @@
+import { isDevMode, Provider } from '@angular/core';
+import {
+  stateSerializationCheckMetaReducer,
+  actionSerializationCheckMetaReducer,
+  immutabilityCheckMetaReducer,
+} from './meta-reducers';
+import { RuntimeChecks, MetaReducer } from './models';
+import {
+  _USER_RUNTIME_CHECKS,
+  _ACTIVE_RUNTIME_CHECKS,
+  META_REDUCERS,
+} from './tokens';
+
+export function createActiveRuntimeChecks(
+  runtimeChecks?: Partial<RuntimeChecks>
+): RuntimeChecks {
+  if (isDevMode()) {
+    if (runtimeChecks === undefined) {
+      console.warn(
+        '@ngrx/store: runtime checks are currently opt-in but will be the default in the next major version, see https://ngrx.io/guide/migration/v8 for more information.'
+      );
+    }
+    return {
+      strictStateSerializability: false,
+      strictActionSerializability: false,
+      strictImmutability: false,
+      ...runtimeChecks,
+    };
+  }
+
+  return {
+    strictStateSerializability: false,
+    strictActionSerializability: false,
+    strictImmutability: false,
+  };
+}
+
+export function createStateSerializationCheckMetaReducer({
+  strictStateSerializability,
+}: RuntimeChecks): MetaReducer {
+  return reducer =>
+    strictStateSerializability
+      ? stateSerializationCheckMetaReducer(reducer)
+      : reducer;
+}
+
+export function createActionSerializationCheckMetaReducer({
+  strictActionSerializability,
+}: RuntimeChecks): MetaReducer {
+  return reducer =>
+    strictActionSerializability
+      ? actionSerializationCheckMetaReducer(reducer)
+      : reducer;
+}
+
+export function createImmutabilityCheckMetaReducer({
+  strictImmutability,
+}: RuntimeChecks): MetaReducer {
+  return reducer =>
+    strictImmutability ? immutabilityCheckMetaReducer(reducer) : reducer;
+}
+
+export function provideRuntimeChecks(
+  runtimeChecks?: Partial<RuntimeChecks>
+): Provider[] {
+  return [
+    {
+      provide: _USER_RUNTIME_CHECKS,
+      useValue: runtimeChecks,
+    },
+    {
+      provide: _ACTIVE_RUNTIME_CHECKS,
+      deps: [_USER_RUNTIME_CHECKS],
+      useFactory: createActiveRuntimeChecks,
+    },
+    {
+      provide: META_REDUCERS,
+      multi: true,
+      deps: [_ACTIVE_RUNTIME_CHECKS],
+      useFactory: createStateSerializationCheckMetaReducer,
+    },
+    {
+      provide: META_REDUCERS,
+      multi: true,
+      deps: [_ACTIVE_RUNTIME_CHECKS],
+      useFactory: createActionSerializationCheckMetaReducer,
+    },
+    {
+      provide: META_REDUCERS,
+      multi: true,
+      deps: [_ACTIVE_RUNTIME_CHECKS],
+      useFactory: createImmutabilityCheckMetaReducer,
+    },
+  ];
+}

--- a/modules/store/src/state.ts
+++ b/modules/store/src/state.ts
@@ -47,9 +47,12 @@ export class State<T> extends BehaviorSubject<any> implements OnDestroy {
       )
     );
 
-    this.stateSubscription = stateAndAction$.subscribe(({ state, action }) => {
-      this.next(state);
-      scannedActions.next(action);
+    this.stateSubscription = stateAndAction$.subscribe({
+      next: ({ state, action }) => {
+        this.next(state);
+        scannedActions.next(action);
+      },
+      error: err => this.error(err),
     });
   }
 

--- a/modules/store/src/tokens.ts
+++ b/modules/store/src/tokens.ts
@@ -1,4 +1,5 @@
 import { InjectionToken } from '@angular/core';
+import { RuntimeChecks, MetaReducer } from './models';
 
 export const _INITIAL_STATE = new InjectionToken(
   '@ngrx/store Internal Initial State'
@@ -16,7 +17,6 @@ export const INITIAL_REDUCERS = new InjectionToken(
 export const _INITIAL_REDUCERS = new InjectionToken(
   '@ngrx/store Internal Initial Reducers'
 );
-export const META_REDUCERS = new InjectionToken('@ngrx/store Meta Reducers');
 export const STORE_FEATURES = new InjectionToken('@ngrx/store Store Features');
 export const _STORE_REDUCERS = new InjectionToken(
   '@ngrx/store Internal Store Reducers'
@@ -38,4 +38,40 @@ export const _FEATURE_REDUCERS_TOKEN = new InjectionToken(
 );
 export const FEATURE_REDUCERS = new InjectionToken(
   '@ngrx/store Feature Reducers'
+);
+
+/**
+ * User-defined meta reducers from StoreModule.forRoot()
+ */
+export const USER_PROVIDED_META_REDUCERS = new InjectionToken<MetaReducer[]>(
+  '@ngrx/store User Provided Meta Reducers'
+);
+
+/**
+ * Meta reducers defined either internally by @ngrx/store or by library authors
+ */
+export const META_REDUCERS = new InjectionToken<MetaReducer[]>(
+  '@ngrx/store Meta Reducers'
+);
+
+/**
+ * Concats the user provided meta reducers and the meta reducers provided on the multi
+ * injection token
+ */
+export const _RESOLVED_META_REDUCERS = new InjectionToken<MetaReducer>(
+  '@ngrx/store Internal Resolved Meta Reducers'
+);
+
+/**
+ * Runtime checks defined by the user
+ */
+export const _USER_RUNTIME_CHECKS = new InjectionToken<RuntimeChecks>(
+  '@ngrx/store Internal User Runtime Checks Config'
+);
+
+/**
+ * Runtime checks currently in use
+ */
+export const _ACTIVE_RUNTIME_CHECKS = new InjectionToken<RuntimeChecks>(
+  '@ngrx/store Internal Runetime Checks'
 );

--- a/tests.js
+++ b/tests.js
@@ -1,12 +1,12 @@
 require('ts-node/register');
-const tsConfig = require("./tsconfig.json");
-const tsConfigPaths = require("tsconfig-paths");
- 
-const baseUrl = "./";
+const tsConfig = require('./tsconfig.json');
+const tsConfigPaths = require('tsconfig-paths');
+
+const baseUrl = './';
 
 tsConfigPaths.register({
-    baseUrl,
-    paths: tsConfig.compilerOptions.paths
+  baseUrl,
+  paths: tsConfig.compilerOptions.paths,
 });
 
 require('core-js/es7/reflect');
@@ -25,15 +25,21 @@ global.jasmine = runner.jasmine;
 
 require('zone.js/dist/jasmine-patch.js');
 
+// Override console.warn, otherwise we log too much to the console
+// This is because of the `runtimeChecks` warning when no runtime config is provided
+console.warn = () => {};
+
 const { getTestBed } = require('@angular/core/testing');
-const { ServerTestingModule, platformServerTesting } = require('@angular/platform-server/testing');
+const {
+  ServerTestingModule,
+  platformServerTesting,
+} = require('@angular/platform-server/testing');
 
 getTestBed().initTestEnvironment(ServerTestingModule, platformServerTesting());
 
 runner.loadConfig({
   spec_dir: 'modules',
-  spec_files: [ '**/*.spec.ts' ]
+  spec_files: ['**/*.spec.ts'],
 });
 
 runner.execute();
-


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #857

## What is the new behavior?

- [x] State serialization checks
- [x] Action serialization checks
- [x] Mutation checks

- [x] Remove ngrx-store-freeze ?
- [x] Remove non-serializable properties on the router ?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


BREAKING CHANGE:

The META_REDUCERS token has been renamed to USER_PROVIDED_META_REDUCERS
The META_REDUCERS token has become a multi token and can be used by
library authors

## Other information

Based of [feat/serialization-and-mutation-checks](https://github.com/ngrx/platform/tree/feat/serialization-and-mutation-checks)

This PR also affects #1539
