### PR TITLE
feat(RouterStore): remove unserializable properties

### DIFF
--- a/modules/router-store/spec/serializer.spec.ts
+++ b/modules/router-store/spec/serializer.spec.ts
@@ -89,13 +89,20 @@ describe('serializer', () => {
   }
 
   function createExpectedSnapshot(prefix = 'root') {
+    const snapshot = createSnapshot(prefix);
     return {
-      ...createSnapshot(prefix),
-      component: `${prefix}-route.routeConfig.component`,
+      ...snapshot,
+      paramMap: undefined,
+      queryParamMap: undefined,
+      component: undefined,
       root: undefined,
       parent: undefined,
       firstChild: undefined,
       pathFromRoot: undefined,
+      routeConfig: {
+        ...snapshot.routeConfig,
+        component: undefined,
+      },
     };
   }
 });

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -318,6 +318,9 @@ export class StoreRouterConnectingModule {
         payload: {
           routerState: this.routerState,
           ...payload,
+          // Make the router event serializable
+          // Creates a POJO from a class instance
+          event: { ...payload.event },
         },
       });
     } finally {

--- a/modules/router-store/src/serializer.ts
+++ b/modules/router-store/src/serializer.ts
@@ -35,13 +35,13 @@ export class DefaultRouterStateSerializer
     const children = route.children.map(c => this.serializeRoute(c));
     return {
       params: route.params,
-      paramMap: route.paramMap,
+      paramMap: undefined as any,
       data: route.data,
       url: route.url,
       outlet: route.outlet,
       routeConfig: route.routeConfig
         ? {
-            component: route.routeConfig.component,
+            component: undefined as any,
             path: route.routeConfig.path,
             pathMatch: route.routeConfig.pathMatch,
             redirectTo: route.routeConfig.redirectTo,
@@ -49,11 +49,9 @@ export class DefaultRouterStateSerializer
           }
         : null,
       queryParams: route.queryParams,
-      queryParamMap: route.queryParamMap,
+      queryParamMap: undefined as any,
       fragment: route.fragment,
-      component: (route.routeConfig
-        ? route.routeConfig.component
-        : undefined) as any,
+      component: undefined as any,
       root: undefined as any,
       parent: undefined as any,
       firstChild: children[0],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGE:

There are a few properties in `DefaultRouterStateSerializer` that aren't
seriazable. These properties `paramMap`, `queryParamMap`, `component`
and `routerConfig.component` are removed from the state.

## Other information

This change is needed for #1613
