### PR TITLE
feat(Store): add META_REDUCERS replacement migration

### DIFF
--- a/modules/store/migrations/8_0_0/index.spec.ts
+++ b/modules/store/migrations/8_0_0/index.spec.ts
@@ -1,0 +1,113 @@
+import { Tree } from '@angular-devkit/schematics';
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { createPackageJson } from '../../../schematics-core/testing/create-package';
+
+describe('Store Migration 8_0_0', () => {
+  let appTree: UnitTestTree;
+  const collectionPath = path.join(__dirname, '../migration.json');
+  const pkgName = 'store';
+  beforeEach(() => {
+    appTree = new UnitTestTree(Tree.empty());
+    appTree.create(
+      '/tsconfig.json',
+      `
+        {
+          "include": [**./*.ts"]
+        }
+       `
+    );
+    createPackageJson('', pkgName, appTree);
+  });
+
+  it(`should replace the meta reducer imports`, () => {
+    const contents = `
+      import {
+        RuntimeChecks,
+        META_REDUCERS,
+        Store,
+        META_REDUCERS,
+        StoreModule,
+        META_REDUCERS as foo,
+      } from '@ngrx/store';`;
+    const expected = `
+      import {
+        RuntimeChecks,
+        USER_PROVIDED_META_REDUCERS,
+        Store,
+        USER_PROVIDED_META_REDUCERS,
+        StoreModule,
+        USER_PROVIDED_META_REDUCERS as foo,
+      } from '@ngrx/store';`;
+
+    appTree.create('./app.module.ts', contents);
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+
+    const newTree = runner.runSchematic(
+      `ngrx-${pkgName}-migration-02`,
+      {},
+      appTree
+    );
+    const file = newTree.readContent('app.module.ts');
+
+    expect(file).toBe(expected);
+  });
+
+  it(`should replace the meta reducer assignments`, () => {
+    const contents = `
+      @NgModule({
+        imports: [
+          CommonModule,
+          BrowserModule,
+          BrowserAnimationsModule,
+          HttpClientModule,
+          AuthModule,
+          AppRoutingModule,
+          StoreModule.forRoot(reducers),
+        ],
+        providers: [
+          {
+            provide: META_REDUCERS,
+            useValue: [fooReducer, barReducer]
+          }
+        ]
+        bootstrap: [AppComponent],
+      })
+      export class AppModule {}`;
+    const expected = `
+      @NgModule({
+        imports: [
+          CommonModule,
+          BrowserModule,
+          BrowserAnimationsModule,
+          HttpClientModule,
+          AuthModule,
+          AppRoutingModule,
+          StoreModule.forRoot(reducers),
+        ],
+        providers: [
+          {
+            provide: USER_PROVIDED_META_REDUCERS,
+            useValue: [fooReducer, barReducer]
+          }
+        ]
+        bootstrap: [AppComponent],
+      })
+      export class AppModule {}`;
+
+    appTree.create('./app.module.ts', contents);
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+
+    const newTree = runner.runSchematic(
+      `ngrx-${pkgName}-migration-02`,
+      {},
+      appTree
+    );
+    const file = newTree.readContent('app.module.ts');
+
+    expect(file).toBe(expected);
+  });
+});

--- a/modules/store/migrations/8_0_0/index.ts
+++ b/modules/store/migrations/8_0_0/index.ts
@@ -1,0 +1,120 @@
+import * as ts from 'typescript';
+import { Rule, chain, Tree } from '@angular-devkit/schematics';
+import { Path } from '@angular-devkit/core';
+import { ReplaceChange } from '@ngrx/store/schematics-core';
+
+const META_REDUCERS = 'META_REDUCERS';
+
+function updateMetaReducersToken(): Rule {
+  return (tree: Tree) => {
+    tree.visit(path => {
+      if (!path.endsWith('.ts')) {
+        return;
+      }
+
+      const sourceFile = ts.createSourceFile(
+        path,
+        tree.read(path)!.toString(),
+        ts.ScriptTarget.Latest
+      );
+
+      if (sourceFile.isDeclarationFile) {
+        return;
+      }
+
+      const createChange = (node: ts.Node) =>
+        new ReplaceChange(
+          path,
+          node.getStart(sourceFile),
+          META_REDUCERS,
+          'USER_PROVIDED_META_REDUCERS'
+        );
+
+      const changes: ReplaceChange[] = [];
+      changes.push(
+        ...findMetaReducersImportStatements(sourceFile, createChange)
+      );
+      changes.push(...findMetaReducersAssignment(sourceFile, createChange));
+
+      if (changes.length < 1) {
+        return;
+      }
+
+      const recorder = createChangeRecorder(tree, path, changes);
+      tree.commitUpdate(recorder);
+    });
+  };
+}
+
+export default function(): Rule {
+  return chain([updateMetaReducersToken()]);
+}
+
+function findMetaReducersImportStatements(
+  sourceFile: ts.SourceFile,
+  createChange: (node: ts.Node) => ReplaceChange
+) {
+  const metaReducerImports = sourceFile.statements
+    .filter(ts.isImportDeclaration)
+    .filter(isNgRxStoreImport)
+    .map(p =>
+      (p.importClause!.namedBindings! as ts.NamedImports).elements.filter(
+        isMetaReducersImportSpecifier
+      )
+    )
+    .reduce((imports, curr) => imports.concat(curr), []);
+
+  const changes = metaReducerImports.map(createChange);
+  return changes;
+
+  function isNgRxStoreImport(importDeclaration: ts.ImportDeclaration) {
+    return (
+      importDeclaration.moduleSpecifier.getText(sourceFile) === "'@ngrx/store'"
+    );
+  }
+
+  function isMetaReducersImportSpecifier(importSpecifier: ts.ImportSpecifier) {
+    const isImport = () => importSpecifier.name.text === META_REDUCERS;
+    const isRenamedImport = () =>
+      importSpecifier.propertyName &&
+      importSpecifier.propertyName.text === META_REDUCERS;
+
+    return (
+      ts.isImportSpecifier(importSpecifier) && (isImport() || isRenamedImport())
+    );
+  }
+}
+
+function findMetaReducersAssignment(
+  sourceFile: ts.SourceFile,
+  createChange: (node: ts.Node) => ReplaceChange
+) {
+  let changes: ReplaceChange[] = [];
+  ts.forEachChild(sourceFile, node => findMetaReducers(node, changes));
+  return changes;
+
+  function findMetaReducers(node: ts.Node, changes: ReplaceChange[]) {
+    if (
+      ts.isPropertyAssignment(node) &&
+      node.initializer.getText(sourceFile) === META_REDUCERS
+    ) {
+      changes.push(createChange(node.initializer));
+    }
+
+    ts.forEachChild(node, childNode => findMetaReducers(childNode, changes));
+  }
+}
+
+function createChangeRecorder(
+  tree: Tree,
+  path: Path,
+  changes: ReplaceChange[]
+) {
+  const recorder = tree.beginUpdate(path);
+  for (const change of changes) {
+    const action = <any>change;
+    recorder.remove(action.pos, action.oldText.length);
+    recorder.insertLeft(action.pos, action.newText);
+  }
+  return recorder;
+}

--- a/modules/store/migrations/BUILD
+++ b/modules/store/migrations/BUILD
@@ -17,6 +17,7 @@ ts_library(
     deps = [
         "//modules/store/schematics-core",
         "@npm//@angular-devkit/schematics",
+        "@npm//typescript",
     ],
 )
 

--- a/modules/store/migrations/migration.json
+++ b/modules/store/migrations/migration.json
@@ -6,6 +6,11 @@
       "description": "The road to v6",
       "version": "5.2",
       "factory": "./6_0_0/index"
+    },
+    "ngrx-store-migration-02": {
+      "description": "The road to v8",
+      "version": "7.0",
+      "factory": "./8_0_0/index"
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Users can provide meta reducers with `META_REDUCERS`

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?


Users can provide meta reducers with `USER_PROVIDED_META_REDUCERS`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


This migration will replace all `META_REDUCERS` occurrences to `USER_PROVIDED_META_REDUCERS` on `ng update` - this breaking change was introduced in #1613.
