### PR TITLE
fix(schematics): avoid lastIndexOf error while creating store schematics (#1659)

### DIFF
--- a/modules/schematics/src/store/index.spec.ts
+++ b/modules/schematics/src/store/index.spec.ts
@@ -215,4 +215,27 @@ describe('Store Schematic', () => {
     );
     expect(content).toMatch(/export interface FeatureState {/);
   });
+
+  it('should fail if a feature state name is not specified', () => {
+    const options = {
+      ...defaultOptions,
+      name: undefined,
+      root: false,
+    };
+
+    expect(() => {
+      schematicRunner.runSchematic('store', options, appTree);
+    }).toThrowError('Please provide a name for the feature state');
+  });
+
+  it('should pass if a root state name is not specified', () => {
+    const options = {
+      ...defaultOptions,
+      name: undefined,
+    };
+
+    expect(() => {
+      schematicRunner.runSchematic('store', options, appTree);
+    }).not.toThrow();
+  });
 });

--- a/modules/schematics/src/store/index.ts
+++ b/modules/schematics/src/store/index.ts
@@ -131,9 +131,13 @@ function addImportToNgModule(options: StoreOptions): Rule {
 
 export default function(options: StoreOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
+    if (!options.name && !options.root) {
+      throw new Error(`Please provide a name for the feature state`);
+    }
+
     options.path = getProjectPath(host, options);
 
-    const parsedPath = parseName(options.path, options.name);
+    const parsedPath = parseName(options.path, options.name || '');
     options.name = parsedPath.name;
     options.path = parsedPath.path;
 


### PR DESCRIPTION
fix(schematics): avoid lastIndexOf error while creating store schematics (#1659)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1659

## What is the new behavior?

Now its possible to create a store schematic without a name if its called with the "--root" flag, otherwise a name is necessary.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
