### PR TITLE
feat(effects): allow ofType to handle ActionCreator

### DIFF
--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -1,5 +1,10 @@
 import { Inject, Injectable } from '@angular/core';
-import { Action, ScannedActionsSubject } from '@ngrx/store';
+import {
+  Action,
+  ActionCreator,
+  Creator,
+  ScannedActionsSubject,
+} from '@ngrx/store';
 import { Observable, OperatorFunction, Operator } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -21,6 +26,12 @@ export class Actions<V = Action> extends Observable<V> {
   }
 }
 
+// Module-private helper type
+type ActionExtractor<
+  T extends string | AC,
+  AC extends ActionCreator<string, Creator>,
+  E
+> = T extends string ? E : ReturnType<Extract<T, AC>>;
 /**
  * 'ofType' filters an Observable of Actions into an observable of the actions
  * whose type strings are passed to it.
@@ -44,39 +55,49 @@ export class Actions<V = Action> extends Observable<V> {
  * like `actions.ofType<AdditionAction>('add')`.
  */
 export function ofType<
-  V extends Extract<U, { type: T1 }>,
-  T1 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  U extends Action = Action,
+  V = T1 extends string ? E : ReturnType<Extract<T1, AC>>
 >(t1: T1): OperatorFunction<U, V>;
 export function ofType<
-  V extends Extract<U, { type: T1 | T2 }>,
-  T1 extends string = string,
-  T2 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 | T2 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  T2 extends string | AC,
+  U extends Action = Action,
+  V = ActionExtractor<T1 | T2, AC, E>
 >(t1: T1, t2: T2): OperatorFunction<U, V>;
 export function ofType<
-  V extends Extract<U, { type: T1 | T2 | T3 }>,
-  T1 extends string = string,
-  T2 extends string = string,
-  T3 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 | T2 | T3 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  T2 extends string | AC,
+  T3 extends string | AC,
+  U extends Action = Action,
+  V = ActionExtractor<T1 | T2 | T3, AC, E>
 >(t1: T1, t2: T2, t3: T3): OperatorFunction<U, V>;
 export function ofType<
-  V extends Extract<U, { type: T1 | T2 | T3 | T4 }>,
-  T1 extends string = string,
-  T2 extends string = string,
-  T3 extends string = string,
-  T4 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 | T2 | T3 | T4 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  T2 extends string | AC,
+  T3 extends string | AC,
+  T4 extends string | AC,
+  U extends Action = Action,
+  V = ActionExtractor<T1 | T2 | T3 | T4, AC, E>
 >(t1: T1, t2: T2, t3: T3, t4: T4): OperatorFunction<U, V>;
 export function ofType<
-  V extends Extract<U, { type: T1 | T2 | T3 | T4 | T5 }>,
-  T1 extends string = string,
-  T2 extends string = string,
-  T3 extends string = string,
-  T4 extends string = string,
-  T5 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 | T2 | T3 | T4 | T5 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  T2 extends string | AC,
+  T3 extends string | AC,
+  T4 extends string | AC,
+  T5 extends string | AC,
+  U extends Action = Action,
+  V = ActionExtractor<T1 | T2 | T3 | T4 | T5, AC, E>
 >(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5): OperatorFunction<U, V>;
 /**
  * Fallback for more than 5 arguments.
@@ -87,12 +108,27 @@ export function ofType<
  * arguments, to preserve backwards compatibility with old versions of ngrx.
  */
 export function ofType<V extends Action>(
-  ...allowedTypes: string[]
+  ...allowedTypes: Array<string | ActionCreator<string, Creator>>
 ): OperatorFunction<Action, V>;
 export function ofType(
-  ...allowedTypes: string[]
+  ...allowedTypes: Array<string | ActionCreator<string, Creator>>
 ): OperatorFunction<Action, Action> {
-  return filter((action: Action) =>
-    allowedTypes.some(type => type === action.type)
-  );
+  return filter((action: Action) => {
+    for (let typeOrActionCreator of allowedTypes) {
+      const actionCreatorType = (typeOrActionCreator as ActionCreator<
+        string,
+        Creator
+      >).type;
+      if (actionCreatorType !== undefined) {
+        // We are filtering by ActionCreator
+        if (actionCreatorType === action.type) {
+          return true;
+        }
+        // Comparing the string to type
+      } else if (typeOrActionCreator === action.type) {
+        return true;
+      }
+    }
+    return false;
+  });
 }

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -113,22 +113,15 @@ export function ofType<V extends Action>(
 export function ofType(
   ...allowedTypes: Array<string | ActionCreator<string, Creator>>
 ): OperatorFunction<Action, Action> {
-  return filter((action: Action) => {
-    for (let typeOrActionCreator of allowedTypes) {
-      const actionCreatorType = (typeOrActionCreator as ActionCreator<
-        string,
-        Creator
-      >).type;
-      if (actionCreatorType !== undefined) {
-        // We are filtering by ActionCreator
-        if (actionCreatorType === action.type) {
-          return true;
-        }
+  return filter((action: Action) =>
+    allowedTypes.some(typeOrActionCreator => {
+      if (typeof typeOrActionCreator === 'string') {
         // Comparing the string to type
-      } else if (typeOrActionCreator === action.type) {
-        return true;
+        return typeOrActionCreator === action.type;
       }
-    }
-    return false;
-  });
+
+      // We are filtering by ActionCreator
+      return typeOrActionCreator.type === action.type;
+    })
+  );
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Allows to filter Actions with `ofType(actionCreator)` as well as maintains previous behavior `ofType(actionCreator.type)`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
