### PR TITLE
docs: order past events in descending order

### DIFF
--- a/projects/ngrx.io/src/app/custom-elements/events/event-list.component.spec.ts
+++ b/projects/ngrx.io/src/app/custom-elements/events/event-list.component.spec.ts
@@ -4,6 +4,7 @@ import { of } from 'rxjs';
 import { EventService } from './event.service';
 import { Event } from './event.model';
 import { EventDateRangePipe } from './event-date-range.pipe';
+import { EventOrderByPipe } from './event-order-by.pipe';
 
 const mockUpcomingEvents: Event[] = [
   {
@@ -35,7 +36,7 @@ describe('Event List Component', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ EventListComponent, EventDateRangePipe ],
+      declarations: [ EventListComponent, EventDateRangePipe, EventOrderByPipe ],
       providers: [{ provide: EventService, useClass: TestEventService }]
     });
 

--- a/projects/ngrx.io/src/app/custom-elements/events/event-list.component.ts
+++ b/projects/ngrx.io/src/app/custom-elements/events/event-list.component.ts
@@ -16,7 +16,7 @@ import { Observable } from 'rxjs';
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let upcomingEvent of upcomingEvents$ | async | eventOrderBy:'earlierToLater'">
+        <tr *ngFor="let upcomingEvent of upcomingEvents$ | async | eventOrderBy:'ascending'">
           <th><a [href]="upcomingEvent.url" [title]="upcomingEvent.name">{{upcomingEvent.name}}</a></th>
           <td>{{upcomingEvent.location}}</td>
           <td>{{upcomingEvent | eventDateRange}}</td>
@@ -33,7 +33,7 @@ import { Observable } from 'rxjs';
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let pastEvent of pastEvents$ | async | eventOrderBy:'laterToEarlier'">
+        <tr *ngFor="let pastEvent of pastEvents$ | async | eventOrderBy:'descending'">
           <th><a [href]="pastEvent.url" [title]="pastEvent.name">{{pastEvent.name}}</a></th>
           <td>{{pastEvent.location}}</td>
           <td>{{pastEvent | eventDateRange}}</td>

--- a/projects/ngrx.io/src/app/custom-elements/events/event-list.component.ts
+++ b/projects/ngrx.io/src/app/custom-elements/events/event-list.component.ts
@@ -16,7 +16,7 @@ import { Observable } from 'rxjs';
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let upcomingEvent of upcomingEvents$ | async">
+        <tr *ngFor="let upcomingEvent of upcomingEvents$ | async | eventOrderBy:'earlierToLater'">
           <th><a [href]="upcomingEvent.url" [title]="upcomingEvent.name">{{upcomingEvent.name}}</a></th>
           <td>{{upcomingEvent.location}}</td>
           <td>{{upcomingEvent | eventDateRange}}</td>
@@ -33,7 +33,7 @@ import { Observable } from 'rxjs';
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let pastEvent of pastEvents$ | async">
+        <tr *ngFor="let pastEvent of pastEvents$ | async | eventOrderBy:'laterToEarlier'">
           <th><a [href]="pastEvent.url" [title]="pastEvent.name">{{pastEvent.name}}</a></th>
           <td>{{pastEvent.location}}</td>
           <td>{{pastEvent | eventDateRange}}</td>

--- a/projects/ngrx.io/src/app/custom-elements/events/event-list.module.ts
+++ b/projects/ngrx.io/src/app/custom-elements/events/event-list.module.ts
@@ -4,10 +4,11 @@ import { WithCustomElementComponent } from '../element-registry';
 import { EventListComponent } from './event-list.component';
 import { EventService } from './event.service';
 import { EventDateRangePipe } from './event-date-range.pipe';
+import { EventOrderByPipe } from './event-order-by.pipe';
 
 @NgModule({
   imports: [ CommonModule ],
-  declarations: [ EventListComponent, EventDateRangePipe ],
+  declarations: [ EventListComponent, EventDateRangePipe, EventOrderByPipe ],
   entryComponents: [ EventListComponent ],
   providers: [ EventService ]
 })

--- a/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.spec.ts
+++ b/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.spec.ts
@@ -1,0 +1,178 @@
+import { Event } from './event.model';
+import { EventOrderByPipe } from './event-order-by.pipe';
+
+describe('Pipe: Event Order By', () => {
+  let pipe: EventOrderByPipe;
+
+  beforeEach(() => {
+    pipe = new EventOrderByPipe();
+  });
+
+  it('should return an empty array if the passed events array is null', () => {
+    expect(pipe.transform(null, 'earlierToLater')).toEqual([]);
+  });
+
+  describe('earlierToLater', () => {
+    it('should order an event with an earlier startDate before an event with a later startDate, '
+      + 'regardless of endDate', () => {
+      const earlierEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        startDate: new Date('2019-01-01'),
+        endDate: new Date('2019-01-04')
+      };
+
+      const laterEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        startDate: new Date('2019-01-02'),
+        endDate: new Date('2019-01-03')
+      };
+
+      expect(pipe.transform([laterEvent, earlierEvent], 'earlierToLater')).toEqual([earlierEvent, laterEvent]);
+    });
+
+    it('should order an event with only an endDate before an event with a startDate '
+      + 'if the first events endDate is before the second events startDate', () => {
+      const earlierEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        endDate: new Date('2019-01-02')
+      };
+
+      const laterEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        startDate: new Date('2019-01-03'),
+        endDate: new Date('2019-01-04')
+      };
+
+      expect(pipe.transform([laterEvent, earlierEvent], 'earlierToLater')).toEqual([earlierEvent, laterEvent]);
+    });
+
+    it('should order an event with a startDate before an event with only an endDate '
+      + 'if the first events startDate is before the second events endDate', () => {
+      const earlierEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        startDate: new Date('2019-01-01'),
+        endDate: new Date('2019-01-03')
+      };
+
+      const laterEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        endDate: new Date('2019-01-02')
+      };
+
+      expect(pipe.transform([laterEvent, earlierEvent], 'earlierToLater')).toEqual([earlierEvent, laterEvent]);
+    });
+
+    it('should order an event with only an endDate before an event with only an endDate '
+      + 'if the first events endDate is before the second events endDate', () => {
+      const earlierEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        endDate: new Date('2019-01-01')
+      };
+
+      const laterEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        endDate: new Date('2019-01-02')
+      };
+
+      expect(pipe.transform([laterEvent, earlierEvent], 'earlierToLater')).toEqual([earlierEvent, laterEvent]);
+    });
+  });
+
+  describe('laterToEarlier', () => {
+    it('should order an event with an earlier startDate after an event with a later startDate, '
+      + 'regardless of endDate', () => {
+      const earlierEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        startDate: new Date('2019-01-01'),
+        endDate: new Date('2019-01-04')
+      };
+
+      const laterEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        startDate: new Date('2019-01-02'),
+        endDate: new Date('2019-01-03')
+      };
+
+      expect(pipe.transform([earlierEvent, laterEvent], 'laterToEarlier')).toEqual([laterEvent, earlierEvent]);
+    });
+
+    it('should order an event with only an endDate after an event with a startDate '
+      + 'if the first events endDate is before the second events startDate', () => {
+      const earlierEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        endDate: new Date('2019-01-02')
+      };
+
+      const laterEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        startDate: new Date('2019-01-03'),
+        endDate: new Date('2019-01-04')
+      };
+
+      expect(pipe.transform([earlierEvent, laterEvent], 'laterToEarlier')).toEqual([laterEvent, earlierEvent]);
+    });
+
+    it('should order an event with a startDate after an event with only an endDate '
+      + 'if the first events startDate is before the second events endDate', () => {
+      const earlierEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        startDate: new Date('2019-01-01'),
+        endDate: new Date('2019-01-03')
+      };
+
+      const laterEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        endDate: new Date('2019-01-02')
+      };
+
+      expect(pipe.transform([earlierEvent, laterEvent], 'laterToEarlier')).toEqual([laterEvent, earlierEvent]);
+    });
+
+    it('should order an event with only an endDate after an event with only an endDate '
+      + 'if the first events endDate is before the second events endDate', () => {
+      const earlierEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        endDate: new Date('2019-01-01')
+      };
+
+      const laterEvent: Event = {
+        name: '',
+        url: '',
+        location: '',
+        endDate: new Date('2019-01-02')
+      };
+
+      expect(pipe.transform([earlierEvent, laterEvent], 'laterToEarlier')).toEqual([laterEvent, earlierEvent]);
+    });
+  });
+});

--- a/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.spec.ts
+++ b/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.spec.ts
@@ -9,10 +9,10 @@ describe('Pipe: Event Order By', () => {
   });
 
   it('should return an empty array if the passed events array is null', () => {
-    expect(pipe.transform(null, 'earlierToLater')).toEqual([]);
+    expect(pipe.transform(null, 'ascending')).toEqual([]);
   });
 
-  describe('earlierToLater', () => {
+  describe('ascending', () => {
     it('should order an event with an earlier startDate before an event with a later startDate, '
       + 'regardless of endDate', () => {
       const earlierEvent: Event = {
@@ -31,7 +31,7 @@ describe('Pipe: Event Order By', () => {
         endDate: new Date('2019-01-03')
       };
 
-      expect(pipe.transform([laterEvent, earlierEvent], 'earlierToLater')).toEqual([earlierEvent, laterEvent]);
+      expect(pipe.transform([laterEvent, earlierEvent], 'ascending')).toEqual([earlierEvent, laterEvent]);
     });
 
     it('should order an event with only an endDate before an event with a startDate '
@@ -51,7 +51,7 @@ describe('Pipe: Event Order By', () => {
         endDate: new Date('2019-01-04')
       };
 
-      expect(pipe.transform([laterEvent, earlierEvent], 'earlierToLater')).toEqual([earlierEvent, laterEvent]);
+      expect(pipe.transform([laterEvent, earlierEvent], 'ascending')).toEqual([earlierEvent, laterEvent]);
     });
 
     it('should order an event with a startDate before an event with only an endDate '
@@ -71,7 +71,7 @@ describe('Pipe: Event Order By', () => {
         endDate: new Date('2019-01-02')
       };
 
-      expect(pipe.transform([laterEvent, earlierEvent], 'earlierToLater')).toEqual([earlierEvent, laterEvent]);
+      expect(pipe.transform([laterEvent, earlierEvent], 'ascending')).toEqual([earlierEvent, laterEvent]);
     });
 
     it('should order an event with only an endDate before an event with only an endDate '
@@ -90,11 +90,11 @@ describe('Pipe: Event Order By', () => {
         endDate: new Date('2019-01-02')
       };
 
-      expect(pipe.transform([laterEvent, earlierEvent], 'earlierToLater')).toEqual([earlierEvent, laterEvent]);
+      expect(pipe.transform([laterEvent, earlierEvent], 'ascending')).toEqual([earlierEvent, laterEvent]);
     });
   });
 
-  describe('laterToEarlier', () => {
+  describe('descending', () => {
     it('should order an event with an earlier startDate after an event with a later startDate, '
       + 'regardless of endDate', () => {
       const earlierEvent: Event = {
@@ -113,7 +113,7 @@ describe('Pipe: Event Order By', () => {
         endDate: new Date('2019-01-03')
       };
 
-      expect(pipe.transform([earlierEvent, laterEvent], 'laterToEarlier')).toEqual([laterEvent, earlierEvent]);
+      expect(pipe.transform([earlierEvent, laterEvent], 'descending')).toEqual([laterEvent, earlierEvent]);
     });
 
     it('should order an event with only an endDate after an event with a startDate '
@@ -133,7 +133,7 @@ describe('Pipe: Event Order By', () => {
         endDate: new Date('2019-01-04')
       };
 
-      expect(pipe.transform([earlierEvent, laterEvent], 'laterToEarlier')).toEqual([laterEvent, earlierEvent]);
+      expect(pipe.transform([earlierEvent, laterEvent], 'descending')).toEqual([laterEvent, earlierEvent]);
     });
 
     it('should order an event with a startDate after an event with only an endDate '
@@ -153,7 +153,7 @@ describe('Pipe: Event Order By', () => {
         endDate: new Date('2019-01-02')
       };
 
-      expect(pipe.transform([earlierEvent, laterEvent], 'laterToEarlier')).toEqual([laterEvent, earlierEvent]);
+      expect(pipe.transform([earlierEvent, laterEvent], 'descending')).toEqual([laterEvent, earlierEvent]);
     });
 
     it('should order an event with only an endDate after an event with only an endDate '
@@ -172,7 +172,7 @@ describe('Pipe: Event Order By', () => {
         endDate: new Date('2019-01-02')
       };
 
-      expect(pipe.transform([earlierEvent, laterEvent], 'laterToEarlier')).toEqual([laterEvent, earlierEvent]);
+      expect(pipe.transform([earlierEvent, laterEvent], 'descending')).toEqual([laterEvent, earlierEvent]);
     });
   });
 });

--- a/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.ts
+++ b/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { Event } from './event.model';
 
-type EventOrderBy = 'earlierToLater' | 'laterToEarlier';
+type EventOrderBy = 'ascending' | 'descending';
 
 /**
  * Transforms the events to sorted order earlier to later or later to earlier.
@@ -14,10 +14,10 @@ export class EventOrderByPipe implements PipeTransform {
       return [];
     }
     switch (orderBy) {
-      case 'earlierToLater': {
+      case 'ascending': {
         return events.sort((eventOne, eventTwo) => +(eventOne.startDate || eventOne.endDate) - +(eventTwo.startDate || eventTwo.endDate));
       }
-      case 'laterToEarlier': {
+      case 'descending': {
         return events.sort((eventOne, eventTwo) => +(eventTwo.startDate || eventTwo.endDate) - +(eventOne.startDate || eventOne.endDate));
       }
     }

--- a/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.ts
+++ b/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.ts
@@ -4,7 +4,7 @@ import { Event } from './event.model';
 type EventOrderBy = 'ascending' | 'descending';
 
 /**
- * Transforms the events to sorted order earlier to later or later to earlier.
+ * Transforms the events to sorted ascending or descending order by date.
  * If an event has a startDate, order based on it.  If not, use it's endDate.
  */
 @Pipe({name: 'eventOrderBy'})

--- a/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.ts
+++ b/projects/ngrx.io/src/app/custom-elements/events/event-order-by.pipe.ts
@@ -1,0 +1,25 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Event } from './event.model';
+
+type EventOrderBy = 'earlierToLater' | 'laterToEarlier';
+
+/**
+ * Transforms the events to sorted order earlier to later or later to earlier.
+ * If an event has a startDate, order based on it.  If not, use it's endDate.
+ */
+@Pipe({name: 'eventOrderBy'})
+export class EventOrderByPipe implements PipeTransform {
+  transform(events: Event[] | null, orderBy: EventOrderBy): Event[] {
+    if (events === null) {
+      return [];
+    }
+    switch (orderBy) {
+      case 'earlierToLater': {
+        return events.sort((eventOne, eventTwo) => +(eventOne.startDate || eventOne.endDate) - +(eventTwo.startDate || eventTwo.endDate));
+      }
+      case 'laterToEarlier': {
+        return events.sort((eventOne, eventTwo) => +(eventTwo.startDate || eventTwo.endDate) - +(eventOne.startDate || eventOne.endDate));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Follow up to #1617 

- Upcoming events are in soonest to latest order (JSON ordering, not enforced)
- Past events are in least recent to most recent order (JSON ordering, not enforced)

## What is the new behavior?

Enforces ordering on the events page:
- Upcoming events are in soonest to latest order (enforced)
- Past events are in most recent to least recent order (enforced)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information