### PR TITLE
feat(entity): add undefined to Dictionary's index signature

### DIFF
--- a/modules/entity/spec/BUILD
+++ b/modules/entity/spec/BUILD
@@ -9,6 +9,7 @@ ts_test_library(
     ),
     deps = [
         "//modules/entity",
+        "//modules/store",
         "@npm//rxjs",
     ],
 )
@@ -17,6 +18,5 @@ jasmine_node_test(
     name = "test",
     deps = [
         ":test_lib",
-        "//modules/entity",
     ],
 )

--- a/modules/entity/spec/state_selectors.spec.ts
+++ b/modules/entity/spec/state_selectors.spec.ts
@@ -92,7 +92,7 @@ describe('Entity State Selectors', () => {
 
     it('should type single entity from Dictonary as entity type or undefined', () => {
       // MemoizedSelector acts like a type checker
-      const singleEnitity: MemoizedSelector<
+      const singleEntity: MemoizedSelector<
         EntityState<BookModel>,
         BookModel | undefined
       > = createSelector(selectors.selectEntities, enitites => enitites[0]);

--- a/modules/entity/spec/state_selectors.spec.ts
+++ b/modules/entity/spec/state_selectors.spec.ts
@@ -6,6 +6,7 @@ import {
   AnimalFarm,
   TheGreatGatsby,
 } from './fixtures/book';
+import { MemoizedSelector, createSelector } from '@ngrx/store';
 
 describe('Entity State Selectors', () => {
   describe('Composed Selectors', () => {
@@ -87,6 +88,14 @@ describe('Entity State Selectors', () => {
       const entities = selectors.selectEntities(state);
 
       expect(entities).toEqual(state.entities);
+    });
+
+    it('should type single entity from Dictonary as entity type or undefined', () => {
+      // MemoizedSelector acts like a type checker
+      const singleEnitity: MemoizedSelector<
+        EntityState<BookModel>,
+        BookModel | undefined
+      > = createSelector(selectors.selectEntities, enitites => enitites[0]);
     });
 
     it('should create a selector for selecting the list of models', () => {

--- a/modules/entity/spec/state_selectors.spec.ts
+++ b/modules/entity/spec/state_selectors.spec.ts
@@ -90,7 +90,7 @@ describe('Entity State Selectors', () => {
       expect(entities).toEqual(state.entities);
     });
 
-    it('should type single entity from Dictonary as entity type or undefined', () => {
+    it('should type single entity from Dictionary as entity type or undefined', () => {
       // MemoizedSelector acts like a type checker
       const singleEntity: MemoizedSelector<
         EntityState<BookModel>,

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -9,11 +9,11 @@ export type IdSelectorNum<T> = (model: T) => number;
 export type IdSelector<T> = IdSelectorStr<T> | IdSelectorNum<T>;
 
 export interface DictionaryNum<T> {
-  [id: number]: T;
+  [id: number]: T | undefined;
 }
 
 export abstract class Dictionary<T> implements DictionaryNum<T> {
-  [id: string]: T;
+  [id: string]: T | undefined;
 }
 
 export interface UpdateStr<T> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Index signatures always return value and never return `undefined` 🤯

```ts
export class Dictionary {
  [id: string]: number;
}

const dict = new Dictionary();
dict[100] // <--- type is number
```
https://github.com/Microsoft/TypeScript/issues/13778

Typescript is telling me that I don't need to check because it's of type `number`. In reality it's actually `number | undefined`, and I should check for the `undefined`.

Suggestion in the bug from TS team is to add " `| undefined` at their definition sites".

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

This became particular painful when `MemoizedSelector<State, Result>` started to validate the return type of the selector to make sure it's actually `Result`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

If one relied on `Dictionary<Entity>` to not return `undefined` they would have to adjust the code.

## Does this PR introduce a breaking change?

Yes, it is. See 👆

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
