### PR TITLE
feat(store): add createReducer function

### DIFF
--- a/modules/store/spec/reducer_creator.spec.ts
+++ b/modules/store/spec/reducer_creator.spec.ts
@@ -1,0 +1,93 @@
+import { on, createReducer, createAction, props, union } from '@ngrx/store';
+import { expecter } from 'ts-snippet';
+
+describe('classes/reducer', function(): void {
+  const expectSnippet = expecter(
+    code => `
+// path goes from root
+import {createAction, props} from './modules/store/src/action_creator';
+import {on} from './modules/store/src/reducer_creator';
+  ${code}`,
+    {
+      moduleResolution: 'node',
+      target: 'es2015',
+    }
+  );
+
+  describe('base', () => {
+    const bar = createAction('[foobar] BAR', props<{ bar: number }>());
+    const foo = createAction('[foobar] FOO', props<{ foo: number }>());
+
+    describe('on', () => {
+      it('should enforce action property types', () => {
+        expectSnippet(`
+                    const foo = createAction('FOO', props<{ foo: number }>());
+                    on(foo, (state, action) => { const foo: string = action.foo; return state; });
+                `).toFail(/'number' is not assignable to type 'string'/);
+      });
+
+      it('should enforce action property names', () => {
+        expectSnippet(`
+                    const foo = createAction('FOO', props<{ foo: number }>());
+                    on(foo, (state, action) => { const bar: string = action.bar; return state; });
+                `).toFail(/'bar' does not exist on type/);
+      });
+
+      it('should support reducers with multiple actions', () => {
+        const both = union({ bar, foo });
+        const func = (state: {}, action: typeof both) => ({});
+        const result = on(foo, bar, func);
+        expect(result.types).toContain(bar.type);
+        expect(result.types).toContain(foo.type);
+      });
+    });
+
+    describe('createReducer', () => {
+      it('should create a reducer', () => {
+        interface State {
+          foo?: number;
+          bar?: number;
+        }
+
+        const fooBarReducer = createReducer<State>(
+          [
+            on(foo, (state, { foo }) => ({ ...state, foo })),
+            on(bar, (state, { bar }) => ({ ...state, bar })),
+          ],
+          {}
+        );
+
+        expect(typeof fooBarReducer).toEqual('function');
+
+        let state = fooBarReducer(undefined, { type: 'UNKNOWN' });
+        expect(state).toEqual({});
+
+        state = fooBarReducer(state, foo({ foo: 42 }));
+        expect(state).toEqual({ foo: 42 });
+
+        state = fooBarReducer(state, bar({ bar: 54 }));
+        expect(state).toEqual({ foo: 42, bar: 54 });
+      });
+
+      it('should support reducers with multiple actions', () => {
+        type State = string[];
+
+        const fooBarReducer = createReducer<State>(
+          [on(foo, bar, (state, { type }) => [...state, type])],
+          []
+        );
+
+        expect(typeof fooBarReducer).toEqual('function');
+
+        let state = fooBarReducer(undefined, { type: 'UNKNOWN' });
+        expect(state).toEqual([]);
+
+        state = fooBarReducer(state, foo({ foo: 42 }));
+        expect(state).toEqual(['[foobar] FOO']);
+
+        state = fooBarReducer(state, bar({ bar: 54 }));
+        expect(state).toEqual(['[foobar] FOO', '[foobar] BAR']);
+      });
+    });
+  });
+});

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -47,3 +47,4 @@ export {
   StoreRootModule,
   StoreFeatureModule,
 } from './store_module';
+export { on, createReducer } from './reducer_creator';

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -7,6 +7,10 @@ export declare interface TypedAction<T extends string> extends Action {
   readonly type: T;
 }
 
+export type ActionType<A> = A extends ActionCreator<infer T, infer C>
+  ? ReturnType<C> & { type: T }
+  : never;
+
 export type TypeId<T> = () => T;
 
 export type InitialState<T> = Partial<T> | TypeId<Partial<T>> | void;
@@ -47,8 +51,10 @@ export type SelectorWithProps<State, Props, Result> = (
 
 export type Creator = (...args: any[]) => object;
 
-export type ActionCreator<T extends string, C extends Creator> = C &
-  TypedAction<T>;
+export type ActionCreator<
+  T extends string = string,
+  C extends Creator = Creator
+> = C & TypedAction<T>;
 
 export type FunctionWithParametersType<P extends unknown[], R = void> = (
   ...args: P

--- a/modules/store/src/reducer_creator.ts
+++ b/modules/store/src/reducer_creator.ts
@@ -1,18 +1,15 @@
-import { ActionCreator, ActionType, Action } from './models';
+import { ActionCreator, ActionReducer, ActionType, Action } from './models';
 
 // Return type of the `on` fn.
 export interface On<S> {
-  reducer: Reducer<S>;
+  reducer: ActionReducer<S>;
   types: string[];
 }
 
-export type Reducer<S, A extends Action = Action> = (state: S, action: A) => S;
-
 // Specialized Reducer that is aware of the Action type it needs to handle
-export type OnReducer<S, C extends ActionCreator[]> = Reducer<
-  S,
-  ActionType<C[number]>
->;
+export interface OnReducer<S, C extends ActionCreator[]> {
+  (state: S, action: ActionType<C[number]>): S;
+}
 
 export function on<C1 extends ActionCreator, S>(
   creator1: C1,
@@ -52,8 +49,8 @@ export function on(
 export function createReducer<S>(
   ons: On<S>[],
   initialState: S
-): Reducer<S | undefined> {
-  const map = new Map<string, Reducer<S>>();
+): ActionReducer<S> {
+  const map = new Map<string, ActionReducer<S>>();
   for (let on of ons) {
     for (let type of on.types) {
       map.set(type, on.reducer);

--- a/modules/store/src/reducer_creator.ts
+++ b/modules/store/src/reducer_creator.ts
@@ -1,21 +1,28 @@
 import { ActionCreator, ActionType, Action } from './models';
 
-export type On<S> = (state: S, action: Action) => S;
-export type OnReducer<S, C extends ActionCreator[]> = (
-  state: S,
-  action: ActionType<C[number]>
-) => S;
-export type Reducer<S> = (state: S | undefined, action: Action) => S;
+// Return type of the `on` fn.
+export interface On<S> {
+  reducer: Reducer<S>;
+  types: string[];
+}
+
+export type Reducer<S, A extends Action = Action> = (state: S, action: A) => S;
+
+// Specialized Reducer that is aware of the Action type it needs to handle
+export type OnReducer<S, C extends ActionCreator[]> = Reducer<
+  S,
+  ActionType<C[number]>
+>;
 
 export function on<C1 extends ActionCreator, S>(
   creator1: C1,
   reducer: OnReducer<S, [C1]>
-): { reducer: On<S>; types: string[] };
+): On<S>;
 export function on<C1 extends ActionCreator, C2 extends ActionCreator, S>(
   creator1: C1,
   creator2: C2,
   reducer: OnReducer<S, [C1, C2]>
-): { reducer: On<S>; types: string[] };
+): On<S>;
 export function on<
   C1 extends ActionCreator,
   C2 extends ActionCreator,
@@ -26,11 +33,11 @@ export function on<
   creator2: C2,
   creator3: C3,
   reducer: OnReducer<S, [C1, C2, C3]>
-): { reducer: On<S>; types: string[] };
+): On<S>;
 export function on<S>(
   creator: ActionCreator,
   ...rest: (ActionCreator | OnReducer<S, [ActionCreator]>)[]
-): { reducer: On<S>; types: string[] };
+): On<S>;
 export function on(
   ...args: (ActionCreator | Function)[]
 ): { reducer: Function; types: string[] } {
@@ -43,10 +50,10 @@ export function on(
 }
 
 export function createReducer<S>(
-  ons: { reducer: On<S>; types: string[] }[],
+  ons: On<S>[],
   initialState: S
-): Reducer<S> {
-  const map = new Map<string, On<S>>();
+): Reducer<S | undefined> {
+  const map = new Map<string, Reducer<S>>();
   for (let on of ons) {
     for (let type of on.types) {
       map.set(type, on.reducer);

--- a/modules/store/src/reducer_creator.ts
+++ b/modules/store/src/reducer_creator.ts
@@ -1,0 +1,59 @@
+import { ActionCreator, ActionType, Action } from './models';
+
+export type On<S> = (state: S, action: Action) => S;
+export type OnReducer<S, C extends ActionCreator[]> = (
+  state: S,
+  action: ActionType<C[number]>
+) => S;
+export type Reducer<S> = (state: S | undefined, action: Action) => S;
+
+export function on<C1 extends ActionCreator, S>(
+  creator1: C1,
+  reducer: OnReducer<S, [C1]>
+): { reducer: On<S>; types: string[] };
+export function on<C1 extends ActionCreator, C2 extends ActionCreator, S>(
+  creator1: C1,
+  creator2: C2,
+  reducer: OnReducer<S, [C1, C2]>
+): { reducer: On<S>; types: string[] };
+export function on<
+  C1 extends ActionCreator,
+  C2 extends ActionCreator,
+  C3 extends ActionCreator,
+  S
+>(
+  creator1: C1,
+  creator2: C2,
+  creator3: C3,
+  reducer: OnReducer<S, [C1, C2, C3]>
+): { reducer: On<S>; types: string[] };
+export function on<S>(
+  creator: ActionCreator,
+  ...rest: (ActionCreator | OnReducer<S, [ActionCreator]>)[]
+): { reducer: On<S>; types: string[] };
+export function on(
+  ...args: (ActionCreator | Function)[]
+): { reducer: Function; types: string[] } {
+  const reducer = args.pop() as Function;
+  const types = args.reduce(
+    (result, creator) => [...result, (creator as ActionCreator).type],
+    [] as string[]
+  );
+  return { reducer, types };
+}
+
+export function createReducer<S>(
+  ons: { reducer: On<S>; types: string[] }[],
+  initialState: S
+): Reducer<S> {
+  const map = new Map<string, On<S>>();
+  for (let on of ons) {
+    for (let type of on.types) {
+      map.set(type, on.reducer);
+    }
+  }
+  return function(state: S = initialState, action: Action): S {
+    const reducer = map.get(action.type);
+    return reducer ? reducer(state, action) : state;
+  };
+}

--- a/projects/example-app/src/app/app.module.ts
+++ b/projects/example-app/src/app/app.module.ts
@@ -12,7 +12,7 @@ import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { CoreModule } from '@example-app/core/core.module';
 import { AuthModule } from '@example-app/auth/auth.module';
 
-import { reducers, metaReducers } from '@example-app/reducers';
+import { ROOT_REDUCERS, metaReducers } from '@example-app/reducers';
 
 import { AppComponent } from '@example-app/core/containers/app.component';
 import { AppRoutingModule } from '@example-app/app-routing.module';
@@ -33,7 +33,7 @@ import { AppRoutingModule } from '@example-app/app-routing.module';
      * meta-reducer. This returns all providers for an @ngrx/store
      * based application.
      */
-    StoreModule.forRoot(reducers, {
+    StoreModule.forRoot(ROOT_REDUCERS, {
       metaReducers,
       runtimeChecks: {
         strictImmutability: true,

--- a/projects/example-app/src/app/auth/actions/auth-api.actions.ts
+++ b/projects/example-app/src/app/auth/actions/auth-api.actions.ts
@@ -12,9 +12,3 @@ export const loginFailure = createAction(
 );
 
 export const loginRedirect = createAction('[Auth/API] Login Redirect');
-
-// This is an alternative to union() type export. Work great when you need
-// to export only a single Action type.
-export type AuthApiActionsUnion = ReturnType<
-  typeof loginSuccess | typeof loginFailure | typeof loginRedirect
->;

--- a/projects/example-app/src/app/auth/actions/auth.actions.ts
+++ b/projects/example-app/src/app/auth/actions/auth.actions.ts
@@ -1,10 +1,7 @@
-import { createAction, union } from '@ngrx/store';
+import { createAction } from '@ngrx/store';
 
 export const logout = createAction('[Auth] Logout');
 export const logoutConfirmation = createAction('[Auth] Logout Confirmation');
 export const logoutConfirmationDismiss = createAction(
   '[Auth] Logout Confirmation Dismiss'
 );
-
-const all = union({ logout, logoutConfirmation, logoutConfirmationDismiss });
-export type AuthActionsUnion = typeof all;

--- a/projects/example-app/src/app/auth/actions/login-page.actions.ts
+++ b/projects/example-app/src/app/auth/actions/login-page.actions.ts
@@ -1,9 +1,7 @@
-import { createAction, props, union } from '@ngrx/store';
+import { createAction, props } from '@ngrx/store';
 import { Credentials } from '@example-app/auth/models/user';
 
 export const login = createAction(
   '[Login Page] Login',
   props<{ credentials: Credentials }>()
 );
-
-export type LoginPageActionsUnion = ReturnType<typeof login>;

--- a/projects/example-app/src/app/auth/reducers/auth.reducer.ts
+++ b/projects/example-app/src/app/auth/reducers/auth.reducer.ts
@@ -1,3 +1,4 @@
+import { createReducer, on } from '@ngrx/store';
 import { AuthApiActions, AuthActions } from '@example-app/auth/actions';
 import { User } from '@example-app/auth/models/user';
 
@@ -9,26 +10,12 @@ export const initialState: State = {
   user: null,
 };
 
-export function reducer(
-  state = initialState,
-  action: AuthApiActions.AuthApiActionsUnion | AuthActions.AuthActionsUnion
-): State {
-  switch (action.type) {
-    case AuthApiActions.loginSuccess.type: {
-      return {
-        ...state,
-        user: action.user,
-      };
-    }
-
-    case AuthActions.logout.type: {
-      return initialState;
-    }
-
-    default: {
-      return state;
-    }
-  }
-}
+export const reducer = createReducer<State>(
+  [
+    on(AuthApiActions.loginSuccess, (state, { user }) => ({ ...state, user })),
+    on(AuthActions.logout, () => initialState),
+  ],
+  initialState
+);
 
 export const getUser = (state: State) => state.user;

--- a/projects/example-app/src/app/auth/reducers/index.ts
+++ b/projects/example-app/src/app/auth/reducers/index.ts
@@ -1,7 +1,8 @@
 import {
   createSelector,
   createFeatureSelector,
-  ActionReducerMap,
+  Action,
+  combineReducers,
 } from '@ngrx/store';
 import * as fromRoot from '@example-app/reducers';
 import * as fromAuth from '@example-app/auth/reducers/auth.reducer';
@@ -16,10 +17,12 @@ export interface State extends fromRoot.State {
   auth: AuthState;
 }
 
-export const reducers: ActionReducerMap<AuthState, any> = {
-  status: fromAuth.reducer,
-  loginPage: fromLoginPage.reducer,
-};
+export function reducers(state: AuthState | undefined, action: Action) {
+  return combineReducers({
+    status: fromAuth.reducer,
+    loginPage: fromLoginPage.reducer,
+  })(state, action);
+}
 
 export const selectAuthState = createFeatureSelector<State, AuthState>('auth');
 

--- a/projects/example-app/src/app/auth/reducers/login-page.reducer.ts
+++ b/projects/example-app/src/app/auth/reducers/login-page.reducer.ts
@@ -1,4 +1,5 @@
 import { AuthApiActions, LoginPageActions } from '@example-app/auth/actions';
+import { createReducer, on } from '@ngrx/store';
 
 export interface State {
   error: string | null;
@@ -10,42 +11,27 @@ export const initialState: State = {
   pending: false,
 };
 
-export function reducer(
-  state = initialState,
-  action:
-    | AuthApiActions.AuthApiActionsUnion
-    | LoginPageActions.LoginPageActionsUnion
-): State {
-  switch (action.type) {
-    case LoginPageActions.login.type: {
-      return {
-        ...state,
-        error: null,
-        pending: true,
-      };
-    }
+export const reducer = createReducer<State>(
+  [
+    on(LoginPageActions.login, state => ({
+      ...state,
+      error: null,
+      pending: true,
+    })),
 
-    case AuthApiActions.loginSuccess.type: {
-      return {
-        ...state,
-        error: null,
-        pending: false,
-      };
-    }
-
-    case AuthApiActions.loginFailure.type: {
-      return {
-        ...state,
-        error: action.error,
-        pending: false,
-      };
-    }
-
-    default: {
-      return state;
-    }
-  }
-}
+    on(AuthApiActions.loginSuccess, state => ({
+      ...state,
+      error: null,
+      pending: false,
+    })),
+    on(AuthApiActions.loginFailure, (state, { error }) => ({
+      ...state,
+      error,
+      pending: false,
+    })),
+  ],
+  initialState
+);
 
 export const getError = (state: State) => state.error;
 export const getPending = (state: State) => state.pending;

--- a/projects/example-app/src/app/books/actions/book.actions.ts
+++ b/projects/example-app/src/app/books/actions/book.actions.ts
@@ -5,5 +5,3 @@ export const loadBook = createAction(
   '[Book Exists Guard] Load Book',
   props<{ book: Book }>()
 );
-
-export type BookActionsUnion = ReturnType<typeof loadBook>;

--- a/projects/example-app/src/app/books/actions/books-api.actions.ts
+++ b/projects/example-app/src/app/books/actions/books-api.actions.ts
@@ -1,4 +1,4 @@
-import { createAction, union, props } from '@ngrx/store';
+import { createAction, props } from '@ngrx/store';
 import { Book } from '@example-app/books/models/book';
 
 export const searchSuccess = createAction(
@@ -10,10 +10,3 @@ export const searchFailure = createAction(
   '[Books/API] Search Failure',
   props<{ errorMsg: string }>()
 );
-
-/**
- * Export a type alias of all actions in this action group
- * so that reducers can easily compose action types
- */
-const all = union({ searchSuccess, searchFailure });
-export type BooksApiActionsUnion = typeof all;

--- a/projects/example-app/src/app/books/actions/collection-api.actions.ts
+++ b/projects/example-app/src/app/books/actions/collection-api.actions.ts
@@ -1,4 +1,4 @@
-import { createAction, props, union } from '@ngrx/store';
+import { createAction, props } from '@ngrx/store';
 import { Book } from '@example-app/books/models/book';
 
 /**
@@ -39,13 +39,3 @@ export const loadBooksFailure = createAction(
   '[Collection/API] Load Books Failure',
   props<{ error: any }>()
 );
-
-const all = union({
-  addBookSuccess,
-  addBookFailure,
-  removeBookSuccess,
-  removeBookFailure,
-  loadBooksSuccess,
-  loadBooksFailure,
-});
-export type CollectionApiActionsUnion = typeof all;

--- a/projects/example-app/src/app/books/actions/collection-page.actions.ts
+++ b/projects/example-app/src/app/books/actions/collection-page.actions.ts
@@ -4,5 +4,3 @@ import { createAction } from '@ngrx/store';
  * Load Collection Action
  */
 export const loadCollection = createAction('[Collection Page] Load Collection');
-
-export type CollectionPageActionsUnion = ReturnType<typeof loadCollection>;

--- a/projects/example-app/src/app/books/actions/find-book-page.actions.ts
+++ b/projects/example-app/src/app/books/actions/find-book-page.actions.ts
@@ -4,5 +4,3 @@ export const searchBooks = createAction(
   '[Find Book Page] Search Books',
   props<{ query: string }>()
 );
-
-export type FindBookPageActionsUnion = ReturnType<typeof searchBooks>;

--- a/projects/example-app/src/app/books/actions/selected-book-page.actions.ts
+++ b/projects/example-app/src/app/books/actions/selected-book-page.actions.ts
@@ -1,4 +1,4 @@
-import { createAction, union, props } from '@ngrx/store';
+import { createAction, props } from '@ngrx/store';
 import { Book } from '@example-app/books/models/book';
 
 /**
@@ -16,7 +16,3 @@ export const removeBook = createAction(
   '[Selected Book Page] Remove Book',
   props<{ book: Book }>()
 );
-
-const all = union({ addBook, removeBook });
-
-export type SelectedBookPageActionsUnion = typeof all;

--- a/projects/example-app/src/app/books/actions/view-book-page.actions.ts
+++ b/projects/example-app/src/app/books/actions/view-book-page.actions.ts
@@ -4,5 +4,3 @@ export const selectBook = createAction(
   '[View Book Page] Select Book',
   props<{ id: string }>()
 );
-
-export type ViewBookPageActionsUnion = ReturnType<typeof selectBook>;

--- a/projects/example-app/src/app/books/reducers/books.reducer.ts
+++ b/projects/example-app/src/app/books/reducers/books.reducer.ts
@@ -6,6 +6,7 @@ import {
   ViewBookPageActions,
   CollectionApiActions,
 } from '@example-app/books/actions';
+import { createReducer, on } from '@ngrx/store';
 
 /**
  * @ngrx/entity provides a predefined interface for handling
@@ -40,50 +41,35 @@ export const initialState: State = adapter.getInitialState({
   selectedBookId: null,
 });
 
-export function reducer(
-  state = initialState,
-  action:
-    | BooksApiActions.BooksApiActionsUnion
-    | BookActions.BookActionsUnion
-    | ViewBookPageActions.ViewBookPageActionsUnion
-    | CollectionApiActions.CollectionApiActionsUnion
-): State {
-  switch (action.type) {
-    case BooksApiActions.searchSuccess.type:
-    case CollectionApiActions.loadBooksSuccess.type: {
-      /**
-       * The addMany function provided by the created adapter
-       * adds many records to the entity dictionary
-       * and returns a new state including those records. If
-       * the collection is to be sorted, the adapter will
-       * sort each record upon entry into the sorted array.
-       */
-      return adapter.addMany(action.books, state);
-    }
-
-    case BookActions.loadBook.type: {
-      /**
-       * The addOne function provided by the created adapter
-       * adds one record to the entity dictionary
-       * and returns a new state including that records if it doesn't
-       * exist already. If the collection is to be sorted, the adapter will
-       * insert the new record into the sorted array.
-       */
-      return adapter.addOne(action.book, state);
-    }
-
-    case ViewBookPageActions.selectBook.type: {
-      return {
-        ...state,
-        selectedBookId: action.id,
-      };
-    }
-
-    default: {
-      return state;
-    }
-  }
-}
+export const reducer = createReducer<State>(
+  [
+    /**
+     * The addMany function provided by the created adapter
+     * adds many records to the entity dictionary
+     * and returns a new state including those records. If
+     * the collection is to be sorted, the adapter will
+     * sort each record upon entry into the sorted array.
+     */
+    on(
+      BooksApiActions.searchSuccess,
+      CollectionApiActions.loadBooksSuccess,
+      (state, { books }) => adapter.addMany(books, state)
+    ),
+    /**
+     * The addOne function provided by the created adapter
+     * adds one record to the entity dictionary
+     * and returns a new state including that records if it doesn't
+     * exist already. If the collection is to be sorted, the adapter will
+     * insert the new record into the sorted array.
+     */
+    on(BookActions.loadBook, (state, { book }) => adapter.addOne(book, state)),
+    on(ViewBookPageActions.selectBook, (state, { id }) => ({
+      ...state,
+      selectedBookId: id,
+    })),
+  ],
+  initialState
+);
 
 /**
  * Because the data structure is defined within the reducer it is optimal to

--- a/projects/example-app/src/app/books/reducers/collection.reducer.ts
+++ b/projects/example-app/src/app/books/reducers/collection.reducer.ts
@@ -3,6 +3,7 @@ import {
   CollectionPageActions,
   CollectionApiActions,
 } from '@example-app/books/actions';
+import { createReducer, on } from '@ngrx/store';
 
 export interface State {
   loaded: boolean;
@@ -16,54 +17,43 @@ const initialState: State = {
   ids: [],
 };
 
-export function reducer(
-  state = initialState,
-  action:
-    | SelectedBookPageActions.SelectedBookPageActionsUnion
-    | CollectionPageActions.CollectionPageActionsUnion
-    | CollectionApiActions.CollectionApiActionsUnion
-): State {
-  switch (action.type) {
-    case CollectionPageActions.loadCollection.type: {
-      return {
-        ...state,
-        loading: true,
-      };
-    }
-
-    case CollectionApiActions.loadBooksSuccess.type: {
-      return {
-        loaded: true,
-        loading: false,
-        ids: action.books.map(book => book.id),
-      };
-    }
-
-    case CollectionApiActions.addBookSuccess.type:
-    case CollectionApiActions.removeBookFailure.type: {
-      if (state.ids.indexOf(action.book.id) > -1) {
-        return state;
+export const reducer = createReducer<State>(
+  [
+    on(CollectionPageActions.loadCollection, state => ({
+      ...state,
+      loading: true,
+      blha: true,
+    })),
+    on(CollectionApiActions.loadBooksSuccess, (state, { books }) => ({
+      loaded: true,
+      loading: false,
+      ids: books.map(book => book.id),
+    })),
+    // Supports handing multiple types of actions
+    on(
+      CollectionApiActions.addBookSuccess,
+      CollectionApiActions.removeBookFailure,
+      (state, { book }) => {
+        if (state.ids.indexOf(book.id) > -1) {
+          return state;
+        }
+        return {
+          ...state,
+          ids: [...state.ids, book.id],
+        };
       }
-
-      return {
+    ),
+    on(
+      CollectionApiActions.removeBookSuccess,
+      CollectionApiActions.addBookFailure,
+      (state, { book }) => ({
         ...state,
-        ids: [...state.ids, action.book.id],
-      };
-    }
-
-    case CollectionApiActions.removeBookSuccess.type:
-    case CollectionApiActions.addBookFailure.type: {
-      return {
-        ...state,
-        ids: state.ids.filter(id => id !== action.book.id),
-      };
-    }
-
-    default: {
-      return state;
-    }
-  }
-}
+        ids: state.ids.filter(id => id !== book.id),
+      })
+    ),
+  ],
+  initialState
+);
 
 export const getLoaded = (state: State) => state.loaded;
 

--- a/projects/example-app/src/app/books/reducers/collection.reducer.ts
+++ b/projects/example-app/src/app/books/reducers/collection.reducer.ts
@@ -22,7 +22,6 @@ export const reducer = createReducer<State>(
     on(CollectionPageActions.loadCollection, state => ({
       ...state,
       loading: true,
-      blha: true,
     })),
     on(CollectionApiActions.loadBooksSuccess, (state, { books }) => ({
       loaded: true,

--- a/projects/example-app/src/app/books/reducers/index.ts
+++ b/projects/example-app/src/app/books/reducers/index.ts
@@ -1,7 +1,8 @@
 import {
   createSelector,
   createFeatureSelector,
-  ActionReducerMap,
+  combineReducers,
+  Action,
 } from '@ngrx/store';
 import * as fromSearch from '@example-app/books/reducers/search.reducer';
 import * as fromBooks from '@example-app/books/reducers/books.reducer';
@@ -19,11 +20,14 @@ export interface State extends fromRoot.State {
   books: BooksState;
 }
 
-export const reducers: ActionReducerMap<BooksState, any> = {
-  search: fromSearch.reducer,
-  books: fromBooks.reducer,
-  collection: fromCollection.reducer,
-};
+/** Provide reducer in AoT-compilation happy way */
+export function reducers(state: BooksState | undefined, action: Action) {
+  return combineReducers({
+    search: fromSearch.reducer,
+    books: fromBooks.reducer,
+    collection: fromCollection.reducer,
+  })(state, action);
+}
 
 /**
  * A selector function is a map function factory. We pass it parameters and it

--- a/projects/example-app/src/app/books/reducers/search.reducer.ts
+++ b/projects/example-app/src/app/books/reducers/search.reducer.ts
@@ -2,6 +2,7 @@ import {
   BooksApiActions,
   FindBookPageActions,
 } from '@example-app/books/actions';
+import { createReducer, on } from '@ngrx/store';
 
 export interface State {
   ids: string[];
@@ -17,55 +18,37 @@ const initialState: State = {
   query: '',
 };
 
-export function reducer(
-  state = initialState,
-  action:
-    | BooksApiActions.BooksApiActionsUnion
-    | FindBookPageActions.FindBookPageActionsUnion
-): State {
-  switch (action.type) {
-    case FindBookPageActions.searchBooks.type: {
-      const query = action.query;
-
-      if (query === '') {
-        return {
-          ids: [],
-          loading: false,
-          error: '',
-          query,
-        };
-      }
-
-      return {
-        ...state,
-        loading: true,
-        error: '',
-        query,
-      };
-    }
-
-    case BooksApiActions.searchSuccess.type: {
-      return {
-        ids: action.books.map(book => book.id),
-        loading: false,
-        error: '',
-        query: state.query,
-      };
-    }
-
-    case BooksApiActions.searchFailure.type: {
-      return {
-        ...state,
-        loading: false,
-        error: action.errorMsg,
-      };
-    }
-
-    default: {
-      return state;
-    }
-  }
-}
+export const reducer = createReducer<State>(
+  [
+    on(FindBookPageActions.searchBooks, (state, { query }) => {
+      return query === ''
+        ? {
+            ...state,
+            loading: true,
+            error: '',
+            query,
+          }
+        : {
+            ids: [],
+            loading: false,
+            error: '',
+            query,
+          };
+    }),
+    on(BooksApiActions.searchSuccess, (state, { books }) => ({
+      ids: books.map(book => book.id),
+      loading: false,
+      error: '',
+      query: state.query,
+    })),
+    on(BooksApiActions.searchFailure, (state, { errorMsg }) => ({
+      ...state,
+      loading: false,
+      error: errorMsg,
+    })),
+  ],
+  initialState
+);
 
 export const getIds = (state: State) => state.ids;
 

--- a/projects/example-app/src/app/books/reducers/search.reducer.ts
+++ b/projects/example-app/src/app/books/reducers/search.reducer.ts
@@ -23,14 +23,14 @@ export const reducer = createReducer<State>(
     on(FindBookPageActions.searchBooks, (state, { query }) => {
       return query === ''
         ? {
-            ...state,
-            loading: true,
+            ids: [],
+            loading: false,
             error: '',
             query,
           }
         : {
-            ids: [],
-            loading: false,
+            ...state,
+            loading: true,
             error: '',
             query,
           };

--- a/projects/example-app/src/app/core/actions/layout.actions.ts
+++ b/projects/example-app/src/app/core/actions/layout.actions.ts
@@ -1,7 +1,4 @@
-import { createAction, union } from '@ngrx/store';
+import { createAction } from '@ngrx/store';
 
 export const openSidenav = createAction('[Layout] Open Sidenav');
 export const closeSidenav = createAction('[Layout] Close Sidenav');
-
-const all = union({ openSidenav, closeSidenav });
-export type LayoutActionsUnion = typeof all;

--- a/projects/example-app/src/app/core/reducers/layout.reducer.ts
+++ b/projects/example-app/src/app/core/reducers/layout.reducer.ts
@@ -1,4 +1,4 @@
-import { Action } from '@ngrx/store';
+import { createReducer, on } from '@ngrx/store';
 import { LayoutActions } from '@example-app/core/actions';
 
 export interface State {
@@ -9,23 +9,15 @@ const initialState: State = {
   showSidenav: false,
 };
 
-export function reducer(state: State = initialState, action: Action): State {
-  const specificAction = action as LayoutActions.LayoutActionsUnion;
-
-  switch (specificAction.type) {
-    case LayoutActions.closeSidenav.type:
-      return {
-        showSidenav: false,
-      };
-
-    case LayoutActions.openSidenav.type:
-      return {
-        showSidenav: true,
-      };
-
-    default:
-      return state;
-  }
-}
+export const reducer = createReducer<State>(
+  [
+    // Explicit 'State' return type for the 'on' functions is needed because
+    // otherwise the return types are narrowed to showSidenav: false instead of
+    // showSidenav: boolean (that State is asking for).
+    on(LayoutActions.closeSidenav, (): State => ({ showSidenav: false })),
+    on(LayoutActions.openSidenav, (): State => ({ showSidenav: true })),
+  ],
+  initialState
+);
 
 export const getShowSidenav = (state: State) => state.showSidenav;

--- a/projects/example-app/src/app/core/reducers/layout.reducer.ts
+++ b/projects/example-app/src/app/core/reducers/layout.reducer.ts
@@ -14,8 +14,8 @@ export const reducer = createReducer<State>(
     // Explicit 'State' return type for the 'on' functions is needed because
     // otherwise the return types are narrowed to showSidenav: false instead of
     // showSidenav: boolean (that State is asking for).
-    on(LayoutActions.closeSidenav, (): State => ({ showSidenav: false })),
-    on(LayoutActions.openSidenav, (): State => ({ showSidenav: true })),
+    on(LayoutActions.closeSidenav, state => ({ showSidenav: false })),
+    on(LayoutActions.openSidenav, state => ({ showSidenav: true })),
   ],
   initialState
 );

--- a/projects/example-app/src/app/reducers/index.ts
+++ b/projects/example-app/src/app/reducers/index.ts
@@ -5,6 +5,7 @@ import {
   MetaReducer,
   Action,
   combineReducers,
+  ActionReducerMap,
 } from '@ngrx/store';
 import { environment } from '../../environments/environment';
 import * as fromRouter from '@ngrx/router-store';
@@ -17,7 +18,7 @@ import * as fromRouter from '@ngrx/router-store';
  */
 
 import * as fromLayout from '@example-app/core/reducers/layout.reducer';
-import { SerializedRouterStateSnapshot } from '@ngrx/router-store';
+import { InjectionToken } from '@angular/core';
 
 /**
  * As mentioned, we treat each reducer like a table in a database. This means
@@ -33,12 +34,14 @@ export interface State {
  * These reducer functions are called with each dispatched action
  * and the current or initial state and return a new immutable state.
  */
-export function reducers(state: State | undefined, action: Action) {
-  return combineReducers({
+export const ROOT_REDUCERS = new InjectionToken<
+  ActionReducerMap<State, Action>
+>('Root reducers token', {
+  factory: () => ({
     layout: fromLayout.reducer,
     router: fromRouter.routerReducer,
-  })(state, action);
-}
+  }),
+});
 
 // console.log all actions
 export function logger(reducer: ActionReducer<State>): ActionReducer<State> {

--- a/projects/example-app/src/app/reducers/index.ts
+++ b/projects/example-app/src/app/reducers/index.ts
@@ -1,9 +1,10 @@
 import {
-  ActionReducerMap,
   createSelector,
   createFeatureSelector,
   ActionReducer,
   MetaReducer,
+  Action,
+  combineReducers,
 } from '@ngrx/store';
 import { environment } from '../../environments/environment';
 import * as fromRouter from '@ngrx/router-store';
@@ -16,6 +17,7 @@ import * as fromRouter from '@ngrx/router-store';
  */
 
 import * as fromLayout from '@example-app/core/reducers/layout.reducer';
+import { SerializedRouterStateSnapshot } from '@ngrx/router-store';
 
 /**
  * As mentioned, we treat each reducer like a table in a database. This means
@@ -23,7 +25,7 @@ import * as fromLayout from '@example-app/core/reducers/layout.reducer';
  */
 export interface State {
   layout: fromLayout.State;
-  router: fromRouter.RouterReducerState;
+  router: fromRouter.RouterReducerState<any>;
 }
 
 /**
@@ -31,10 +33,12 @@ export interface State {
  * These reducer functions are called with each dispatched action
  * and the current or initial state and return a new immutable state.
  */
-export const reducers: ActionReducerMap<State> = {
-  layout: fromLayout.reducer,
-  router: fromRouter.routerReducer,
-};
+export function reducers(state: State | undefined, action: Action) {
+  return combineReducers({
+    layout: fromLayout.reducer,
+    router: fromRouter.routerReducer,
+  })(state, action);
+}
 
 // console.log all actions
 export function logger(reducer: ActionReducer<State>): ActionReducer<State> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Introduces `createReducer` function, that has the same functionality as `reducer` from `ts-actions` (created by @cartant).

It helps remove Action unions and dramatically reduce the code needed for reducers. Compare:

<img width="1351" alt="Screen Shot 2019-04-13 at 1 13 55 PM" src="https://user-images.githubusercontent.com/2830407/56083123-ef4e5a80-5dee-11e9-9669-a243e1a62940.png">

However, there are a few caveats that are caused by https://github.com/Microsoft/TypeScript/issues/3755 and https://github.com/Microsoft/TypeScript/issues/7547#issuecomment-218017839 with the latter acknowledging current TS limitation. 

### Sometimes `reducer` functions in `on(...)` have to be explicitly typed with their return type. Let's look at the example:
``` ts
export interface State {
  showSidenav: boolean;
}

const initialState: State = {
  showSidenav: false,
};

export const reducer = createReducer<State>(
  [
    // Explicit 'State' return type for the 'on' functions is needed because
    // otherwise the return types are narrowed to showSidenav: false instead of
    // showSidenav: boolean (that State is asking for).
    on(LayoutActions.closeSidenav, (): State => ({ showSidenav: false })),
    on(LayoutActions.openSidenav, (): State => ({ showSidenav: true })),
  ],
  initialState
);
```
If the `State` in `on(LayoutActions.closeSidenav, (): State` is **not provided** it would narrow the type to `{showSidenav: false}` and `{showSidenav: true}` correspondingly, which would not match the interface of `State` (which is `{showSidenav: boolean}`).
TS highlights this as error, so providing the `State` is required

### Sometimes typos could be missed

Let's look at another example (reduced for brevity):
```ts
export interface State {
  error: string | null;
  pending: boolean;
}

export const initialState: State = {
  error: null,
  pending: false,
};

export const reducer = createReducer<State>(
  [
    on(AuthApiActions.loginFailure, (state, { error }) => ({
      ...state,
      error,
      ending: false, // <--- 'pending' with typo here - missed letter 'p'.
    })),
  ],
  initialState
);
```

Note the `ending: false`, that missed `p`. The original intention was to spread the state and **override** with `pending: false`, however because of the typo `pending` won't be overridden and instead extra `ending` property will be added.
This will not match the `State` interface, but `State` could be extended from this interface with type (because entire `state` of type `State` is spread).

switch-based reducer function catches these types of errors, because providing the return type of the `reducer` function is a norm: `function reducer(state: State = initialState, action: Action): State`.

**Solution:** This unfortunate error can be also caught by explicitly typing the `reducer` within `on`:
`on(AuthApiActions.loginFailure, (state, { error }): State => ({..})),`

For me, that's an acceptable solution. Maybe we should recommend to always type it. I wish the `createSelector<State>` would've caught it, but it's not currently possible due to TS limitations mentioned above.

Note: if the `State` typed could not be extracted from the returned object literal, the error would be displayed property even without explicit return type, e.g.:
```ts
 on(AuthApiActions.loginFailure, (state, { error }) => ({
      // ...state, comment out the spread
      error,
      ending: false, // <--- 'pending' with typo here - missed letter 'p'.
     // Error would be provided for this case, because State interface is not fulfilled.
    })),
``` 


<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

Closes # https://github.com/ngrx/platform/issues/1724

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
