### PR TITLE
docs(selectors): add missing comma in code sample

### DIFF
--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -332,7 +332,7 @@ export const selectLastStateTransitions = (count: number) => {
     // Combines the last `count` state values in array
     scan((acc, curr) => {
       return [ curr, acc[0], acc[1] ].filter(val => val !== undefined);
-    } [] as {foo: number; bar: string}[]) // XX: Explicit type hint for the array.
+    }, [] as {foo: number; bar: string}[]) // XX: Explicit type hint for the array.
                                           // Equivalent to what is emitted by the selector
   );
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Code sample for the `scan` operator is missing a comma in the arguments.

Closes #

## What is the new behavior?

Adds a missing comma in the scan operator code sample for the selectLastStateTransitions selector.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
