### PR TITLE
feat(store): Expand createReducer type signature to support up to ten action creators

### DIFF
--- a/modules/store/src/reducer_creator.ts
+++ b/modules/store/src/reducer_creator.ts
@@ -31,6 +31,139 @@ export function on<
   creator3: C3,
   reducer: OnReducer<S, [C1, C2, C3]>
 ): On<S>;
+export function on<
+  C1 extends ActionCreator,
+  C2 extends ActionCreator,
+  C3 extends ActionCreator,
+  C4 extends ActionCreator,
+  S
+>(
+  creator1: C1,
+  creator2: C2,
+  creator3: C3,
+  creator4: C4,
+  reducer: OnReducer<S, [C1, C2, C3, C4]>
+): On<S>;
+export function on<
+  C1 extends ActionCreator,
+  C2 extends ActionCreator,
+  C3 extends ActionCreator,
+  C4 extends ActionCreator,
+  C5 extends ActionCreator,
+  S
+>(
+  creator1: C1,
+  creator2: C2,
+  creator3: C3,
+  creator4: C4,
+  creator5: C5,
+  reducer: OnReducer<S, [C1, C2, C3, C4, C5]>
+): On<S>;
+export function on<
+  C1 extends ActionCreator,
+  C2 extends ActionCreator,
+  C3 extends ActionCreator,
+  C4 extends ActionCreator,
+  C5 extends ActionCreator,
+  C6 extends ActionCreator,
+  S
+>(
+  creator1: C1,
+  creator2: C2,
+  creator3: C3,
+  creator4: C4,
+  creator5: C5,
+  creator6: C6,
+  reducer: OnReducer<S, [C1, C2, C3, C4, C5, C6]>
+): On<S>;
+export function on<
+  C1 extends ActionCreator,
+  C2 extends ActionCreator,
+  C3 extends ActionCreator,
+  C4 extends ActionCreator,
+  C5 extends ActionCreator,
+  C6 extends ActionCreator,
+  C7 extends ActionCreator,
+  S
+>(
+  creator1: C1,
+  creator2: C2,
+  creator3: C3,
+  creator4: C4,
+  creator5: C5,
+  creator6: C6,
+  creator7: C7,
+  reducer: OnReducer<S, [C1, C2, C3, C4, C5, C6, C7]>
+): On<S>;
+export function on<
+  C1 extends ActionCreator,
+  C2 extends ActionCreator,
+  C3 extends ActionCreator,
+  C4 extends ActionCreator,
+  C5 extends ActionCreator,
+  C6 extends ActionCreator,
+  C7 extends ActionCreator,
+  C8 extends ActionCreator,
+  S
+>(
+  creator1: C1,
+  creator2: C2,
+  creator3: C3,
+  creator4: C4,
+  creator5: C5,
+  creator6: C6,
+  creator7: C7,
+  creator8: C8,
+  reducer: OnReducer<S, [C1, C2, C3, C4, C5, C6, C7, C8]>
+): On<S>;
+export function on<
+  C1 extends ActionCreator,
+  C2 extends ActionCreator,
+  C3 extends ActionCreator,
+  C4 extends ActionCreator,
+  C5 extends ActionCreator,
+  C6 extends ActionCreator,
+  C7 extends ActionCreator,
+  C8 extends ActionCreator,
+  C9 extends ActionCreator,
+  S
+>(
+  creator1: C1,
+  creator2: C2,
+  creator3: C3,
+  creator4: C4,
+  creator5: C5,
+  creator6: C6,
+  creator7: C7,
+  creator8: C8,
+  creator9: C9,
+  reducer: OnReducer<S, [C1, C2, C3, C4, C5, C6, C7, C8, C9]>
+): On<S>;
+export function on<
+  C1 extends ActionCreator,
+  C2 extends ActionCreator,
+  C3 extends ActionCreator,
+  C4 extends ActionCreator,
+  C5 extends ActionCreator,
+  C6 extends ActionCreator,
+  C7 extends ActionCreator,
+  C8 extends ActionCreator,
+  C9 extends ActionCreator,
+  C10 extends ActionCreator,
+  S
+>(
+  creator1: C1,
+  creator2: C2,
+  creator3: C3,
+  creator4: C4,
+  creator5: C5,
+  creator6: C6,
+  creator7: C7,
+  creator8: C8,
+  creator9: C9,
+  creator10: C10,
+  reducer: OnReducer<S, [C1, C2, C3, C4, C5, C6, C7, C8, C9, C10]>
+): On<S>;
 export function on<S>(
   creator: ActionCreator,
   ...rest: (ActionCreator | OnReducer<S, [ActionCreator]>)[]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Current type signature only supports type inference for up to three action creators

## What is the new behavior?

This expands the type signature to support up to ten action creators. Highest I have internally is 7 so 10 felt like a good ceiling for now.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
