### PR TITLE
chore: don't copy build files on copySchematicsCore

### DIFF
--- a/build/tasks.ts
+++ b/build/tasks.ts
@@ -10,6 +10,8 @@ import { ncp } from 'ncp';
  */
 export async function copySchematicsCore(config: Config) {
   (ncp as any).limit = 1;
+  const filter = (name: string) => !name.endsWith('BUILD.bazel');
+
   for (let pkg of util.getTopLevelPackages(config)) {
     const packageJson = fs
       .readFileSync(`${modulesDir}${pkg}/package.json`)
@@ -20,6 +22,7 @@ export async function copySchematicsCore(config: Config) {
       ncp(
         `${modulesDir}/schematics-core`,
         `${modulesDir}/${pkg}/schematics-core`,
+        { filter },
         function(err: any) {
           if (err) {
             return console.error(err);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Right now whenever we run the `schematics:copy` command, it will also copy the `BUILD.bazel` file.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
