### PR TITLE
fix(store): adjust mock store to handle selectors with props

### DIFF
--- a/modules/store/spec/BUILD
+++ b/modules/store/spec/BUILD
@@ -10,8 +10,8 @@ ts_test_library(
     ),
     deps = [
         "//modules/store",
-        "//modules/store/testing",
         "//modules/store/spec/fixtures",
+        "//modules/store/testing",
         "@npm//rxjs",
         "@npm//ts-snippet",
     ],

--- a/modules/store/spec/fixtures/BUILD
+++ b/modules/store/spec/fixtures/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["package.json"])
+
+load("//tools:defaults.bzl", "ng_module")
+
+ng_module(
+    name = "fixtures",
+    srcs = glob([
+        "*.ts",
+        "src/**/*.ts",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//modules/store",
+    ],
+)

--- a/modules/store/spec/store.spec.ts
+++ b/modules/store/spec/store.spec.ts
@@ -9,7 +9,6 @@ import {
   select,
   ReducerManagerDispatcher,
   UPDATE,
-  REDUCER_FACTORY,
   ActionReducer,
   Action,
 } from '../';
@@ -23,10 +22,7 @@ import {
   counterReducer2,
 } from './fixtures/counter';
 import Spy = jasmine.Spy;
-import any = jasmine.any;
-import { skip, take } from 'rxjs/operators';
-import { MockStore, provideMockStore } from '../testing';
-import { createSelector } from '../src/selector';
+import { take } from 'rxjs/operators';
 
 interface TestAppSchema {
   counter1: number;
@@ -445,180 +441,6 @@ describe('ngRx Store', () => {
         reducerFactory: jasmine.createSpy(`reducerFactory_${key}`),
       };
     }
-  });
-
-  describe('Mock Store', () => {
-    let mockStore: MockStore<TestAppSchema>;
-    const initialState = { counter1: 0, counter2: 1, counter4: 3 };
-    const stringSelector = 'counter4';
-    const memoizedSelector = createSelector(
-      () => initialState,
-      state => state.counter4
-    );
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          provideMockStore({
-            initialState,
-            selectors: [
-              { selector: stringSelector, value: 87 },
-              { selector: memoizedSelector, value: 98 },
-            ],
-          }),
-        ],
-      });
-
-      mockStore = TestBed.get(Store);
-    });
-
-    it('should set the initial state to a mocked one', (done: DoneFn) => {
-      const fixedState = {
-        counter1: 17,
-        counter2: 11,
-        counter3: 25,
-      };
-      mockStore.setState(fixedState);
-      mockStore.pipe(take(1)).subscribe({
-        next(val) {
-          expect(val).toEqual(fixedState);
-        },
-        error: done.fail,
-        complete: done,
-      });
-    });
-
-    it('should allow tracing dispatched actions', () => {
-      const action = { type: INCREMENT };
-      mockStore.scannedActions$
-        .pipe(skip(1))
-        .subscribe(scannedAction => expect(scannedAction).toEqual(action));
-      mockStore.dispatch(action);
-    });
-
-    it('should allow mocking of store.select with string selector using provideMockStore', () => {
-      const expectedValue = 87;
-
-      mockStore
-        .select(stringSelector)
-        .subscribe(result => expect(result).toBe(expectedValue));
-    });
-
-    it('should allow mocking of store.select with a memoized selector using provideMockStore', () => {
-      const expectedValue = 98;
-
-      mockStore
-        .select(memoizedSelector)
-        .subscribe(result => expect(result).toBe(expectedValue));
-    });
-
-    it('should allow mocking of store.pipe(select()) with a memoized selector using provideMockStore', () => {
-      const expectedValue = 98;
-
-      mockStore
-        .pipe(select(memoizedSelector))
-        .subscribe(result => expect(result).toBe(expectedValue));
-    });
-
-    it('should allow mocking of store.select with string selector using overrideSelector', () => {
-      const mockValue = 5;
-
-      mockStore.overrideSelector('counter1', mockValue);
-
-      mockStore
-        .select('counter1')
-        .subscribe(result => expect(result).toBe(mockValue));
-    });
-
-    it('should allow mocking of store.select with a memoized selector using overrideSelector', () => {
-      const mockValue = 5;
-      const selector = createSelector(
-        () => initialState,
-        state => state.counter1
-      );
-
-      mockStore.overrideSelector(selector, mockValue);
-
-      mockStore
-        .select(selector)
-        .subscribe(result => expect(result).toBe(mockValue));
-    });
-
-    it('should allow mocking of store.pipe(select()) with a memoized selector using overrideSelector', () => {
-      const mockValue = 5;
-      const selector = createSelector(
-        () => initialState,
-        state => state.counter2
-      );
-
-      mockStore.overrideSelector(selector, mockValue);
-
-      mockStore
-        .pipe(select(selector))
-        .subscribe(result => expect(result).toBe(mockValue));
-    });
-
-    it('should pass through unmocked selectors', () => {
-      const mockValue = 5;
-      const selector = createSelector(
-        () => initialState,
-        state => state.counter1
-      );
-      const selector2 = createSelector(
-        () => initialState,
-        state => state.counter2
-      );
-      const selector3 = createSelector(
-        selector,
-        selector2,
-        (sel1, sel2) => sel1 + sel2
-      );
-
-      mockStore.overrideSelector(selector, mockValue);
-
-      mockStore
-        .pipe(select(selector2))
-        .subscribe(result => expect(result).toBe(1));
-      mockStore
-        .pipe(select(selector3))
-        .subscribe(result => expect(result).toBe(6));
-    });
-
-    it('should allow you reset mocked selectors', () => {
-      const mockValue = 5;
-      const selector = createSelector(
-        () => initialState,
-        state => state.counter1
-      );
-      const selector2 = createSelector(
-        () => initialState,
-        state => state.counter2
-      );
-      const selector3 = createSelector(
-        selector,
-        selector2,
-        (sel1, sel2) => sel1 + sel2
-      );
-
-      mockStore
-        .pipe(select(selector3))
-        .subscribe(result => expect(result).toBe(1));
-
-      mockStore.overrideSelector(selector, mockValue);
-      mockStore.overrideSelector(selector2, mockValue);
-      selector3.release();
-
-      mockStore
-        .pipe(select(selector3))
-        .subscribe(result => expect(result).toBe(10));
-
-      mockStore.resetSelectors();
-      selector3.release();
-
-      mockStore
-        .pipe(select(selector3))
-        .subscribe(result => expect(result).toBe(1));
-    });
   });
 
   describe('Meta Reducers', () => {

--- a/modules/store/testing/spec/BUILD
+++ b/modules/store/testing/spec/BUILD
@@ -2,12 +2,13 @@ load("//tools:defaults.bzl", "jasmine_node_test", "ts_test_library")
 
 ts_test_library(
     name = "test_lib",
-    srcs = glob(["**/*.ts"],
+    srcs = glob(
+        ["**/*.ts"],
     ),
     deps = [
         "//modules/store",
-        "//modules/store/testing",
         "//modules/store/spec/fixtures",
+        "//modules/store/testing",
         "@npm//rxjs",
     ],
 )

--- a/modules/store/testing/spec/BUILD
+++ b/modules/store/testing/spec/BUILD
@@ -2,18 +2,13 @@ load("//tools:defaults.bzl", "jasmine_node_test", "ts_test_library")
 
 ts_test_library(
     name = "test_lib",
-    srcs = glob(
-        [
-            "*.ts",
-            "meta-reducers/**/*.ts",
-        ],
+    srcs = glob(["**/*.ts"],
     ),
     deps = [
         "//modules/store",
         "//modules/store/testing",
         "//modules/store/spec/fixtures",
         "@npm//rxjs",
-        "@npm//ts-snippet",
     ],
 )
 

--- a/modules/store/testing/spec/mock_store.spec.ts
+++ b/modules/store/testing/spec/mock_store.spec.ts
@@ -1,0 +1,261 @@
+import { TestBed } from '@angular/core/testing';
+import { INCREMENT } from '../../spec/fixtures/counter';
+import { skip, take } from 'rxjs/operators';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { Store, createSelector, select } from '@ngrx/store';
+
+interface TestAppSchema {
+  counter1: number;
+  counter2: number;
+  counter3: number;
+  counter4?: number;
+}
+
+describe('Mock Store', () => {
+  let mockStore: MockStore<TestAppSchema>;
+  const initialState = { counter1: 0, counter2: 1, counter4: 3 };
+  const stringSelector = 'counter4';
+  const memoizedSelector = createSelector(
+    () => initialState,
+    state => state.counter4
+  );
+  const selectorWithPropMocked = createSelector(
+    () => initialState,
+    (state: typeof initialState, add: number) => state.counter4 + add
+  );
+
+  const selectorWithProp = createSelector(
+    () => initialState,
+    (state: typeof initialState, add: number) => state.counter4 + add
+  );
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore({
+          initialState,
+          selectors: [
+            { selector: stringSelector, value: 87 },
+            { selector: memoizedSelector, value: 98 },
+            { selector: selectorWithPropMocked, value: 99 },
+          ],
+        }),
+      ],
+    });
+
+    mockStore = TestBed.get(Store);
+  });
+
+  afterEach(() => {
+    memoizedSelector.release();
+    selectorWithProp.release();
+    selectorWithPropMocked.release();
+    mockStore.resetSelectors();
+  });
+
+  it('should set the initial state to a mocked one', (done: DoneFn) => {
+    const fixedState = {
+      counter1: 17,
+      counter2: 11,
+      counter3: 25,
+    };
+    mockStore.setState(fixedState);
+    mockStore.pipe(take(1)).subscribe({
+      next(val) {
+        expect(val).toEqual(fixedState);
+      },
+      error: done.fail,
+      complete: done,
+    });
+  });
+
+  it('should allow tracing dispatched actions', () => {
+    const action = { type: INCREMENT };
+    mockStore.scannedActions$
+      .pipe(skip(1))
+      .subscribe(scannedAction => expect(scannedAction).toEqual(action));
+    mockStore.dispatch(action);
+  });
+
+  it('should allow mocking of store.select with string selector using provideMockStore', () => {
+    const expectedValue = 87;
+
+    mockStore
+      .select(stringSelector)
+      .subscribe(result => expect(result).toBe(expectedValue));
+  });
+
+  it('should allow mocking of store.select with a memoized selector using provideMockStore', () => {
+    const expectedValue = 98;
+
+    mockStore
+      .select(memoizedSelector)
+      .subscribe(result => expect(result).toBe(expectedValue));
+  });
+
+  it('should allow mocking of store.pipe(select()) with a memoized selector using provideMockStore', () => {
+    const expectedValue = 98;
+
+    mockStore
+      .pipe(select(memoizedSelector))
+      .subscribe(result => expect(result).toBe(expectedValue));
+  });
+
+  it('should allow mocking of store.select with a memoized selector with Prop using provideMockStore', () => {
+    const expectedValue = 99;
+
+    mockStore
+      .select(selectorWithPropMocked, 100)
+      .subscribe(result => expect(result).toBe(expectedValue));
+  });
+
+  it('should allow mocking of store.pipe(select()) with a memoized selector with Prop using provideMockStore', () => {
+    const expectedValue = 99;
+
+    mockStore
+      .pipe(select(selectorWithPropMocked, 200))
+      .subscribe(result => expect(result).toBe(expectedValue));
+  });
+
+  it('should allow mocking of store.select with string selector using overrideSelector', () => {
+    const mockValue = 5;
+
+    mockStore.overrideSelector('counter1', mockValue);
+
+    mockStore
+      .select('counter1')
+      .subscribe(result => expect(result).toBe(mockValue));
+  });
+
+  it('should allow mocking of store.select with a memoized selector using overrideSelector', () => {
+    const mockValue = 5;
+    const selector = createSelector(
+      () => initialState,
+      state => state.counter1
+    );
+
+    mockStore.overrideSelector(selector, mockValue);
+
+    mockStore
+      .select(selector)
+      .subscribe(result => expect(result).toBe(mockValue));
+  });
+
+  it('should allow mocking of store.pipe(select()) with a memoized selector using overrideSelector', () => {
+    const mockValue = 5;
+    const selector = createSelector(
+      () => initialState,
+      state => state.counter2
+    );
+
+    mockStore.overrideSelector(selector, mockValue);
+
+    mockStore
+      .pipe(select(selector))
+      .subscribe(result => expect(result).toBe(mockValue));
+  });
+
+  it('should allow mocking of store.select with a memoized selector with Prop using overrideSelector', () => {
+    const mockValue = 100;
+
+    mockStore.overrideSelector(selectorWithProp, mockValue);
+
+    mockStore
+      .select(selectorWithProp, 200)
+      .subscribe(result => expect(result).toBe(mockValue));
+  });
+
+  it('should allow mocking of store.pipe(select()) with a memoized selector with Prop using overrideSelector', () => {
+    const mockValue = 1000;
+
+    mockStore.overrideSelector(selectorWithProp, mockValue);
+
+    mockStore
+      .pipe(select(selectorWithProp, 200))
+      .subscribe(result => expect(result).toBe(mockValue));
+  });
+
+  it('should pass through unmocked selectors with Props using store.pipe(select())', () => {
+    const selectorWithProp = createSelector(
+      () => initialState,
+      (state: typeof initialState, add: number) => state.counter4 + add
+    );
+
+    mockStore
+      .pipe(select(selectorWithProp, 6))
+      .subscribe(result => expect(result).toBe(9));
+  });
+
+  it('should pass through unmocked selectors with Props using store.select', () => {
+    const selectorWithProp = createSelector(
+      () => initialState,
+      (state: typeof initialState, add: number) => state.counter4 + add
+    );
+
+    (mockStore as Store<{}>)
+      .select(selectorWithProp, 7)
+      .subscribe(result => expect(result).toBe(10));
+  });
+
+  it('should pass through unmocked selectors', () => {
+    const mockValue = 5;
+    const selector = createSelector(
+      () => initialState,
+      state => state.counter1
+    );
+    const selector2 = createSelector(
+      () => initialState,
+      state => state.counter2
+    );
+    const selector3 = createSelector(
+      selector,
+      selector2,
+      (sel1, sel2) => sel1 + sel2
+    );
+
+    mockStore.overrideSelector(selector, mockValue);
+
+    mockStore
+      .pipe(select(selector2))
+      .subscribe(result => expect(result).toBe(1));
+    mockStore
+      .pipe(select(selector3))
+      .subscribe(result => expect(result).toBe(6));
+  });
+
+  it('should allow you reset mocked selectors', () => {
+    const mockValue = 5;
+    const selector = createSelector(
+      () => initialState,
+      state => state.counter1
+    );
+    const selector2 = createSelector(
+      () => initialState,
+      state => state.counter2
+    );
+    const selector3 = createSelector(
+      selector,
+      selector2,
+      (sel1, sel2) => sel1 + sel2
+    );
+
+    mockStore
+      .pipe(select(selector3))
+      .subscribe(result => expect(result).toBe(1));
+
+    mockStore.overrideSelector(selector, mockValue);
+    mockStore.overrideSelector(selector2, mockValue);
+    selector3.release();
+
+    mockStore
+      .pipe(select(selector3))
+      .subscribe(result => expect(result).toBe(10));
+
+    mockStore.resetSelectors();
+    selector3.release();
+
+    mockStore
+      .pipe(select(selector3))
+      .subscribe(result => expect(result).toBe(1));
+  });
+});

--- a/modules/store/testing/src/mock_store.ts
+++ b/modules/store/testing/src/mock_store.ts
@@ -95,14 +95,14 @@ export class MockStore<T> extends Store<T> {
     MockStore.selectors.clear();
   }
 
-  select(selector: any) {
+  select(selector: any, prop?: any) {
     if (MockStore.selectors.has(selector)) {
       return new BehaviorSubject<any>(
         MockStore.selectors.get(selector)
       ).asObservable();
     }
 
-    return super.select(selector);
+    return super.select(selector, prop);
   }
 
   addReducer() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [c] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Mock store doesn't handle selectors with props

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes # https://github.com/ngrx/platform/issues/1864

## What is the new behavior?

Fixed it

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Refactored Mock Store tests out of store/spec
Added Bazel for it
Moved store/spec/fixtures into its own Bazel module
Added a number of tests for Mock Store
Added clean-up logic for Mock Store tests

