### PR TITLE
feat(effects): resubscribe to effects on error

### DIFF
--- a/modules/effects/spec/effect_creator.spec.ts
+++ b/modules/effects/spec/effect_creator.spec.ts
@@ -58,7 +58,7 @@ describe('createEffect()', () => {
         expectSnippet(`
           const effect = createEffect(() => ({ foo: 'a' }), { dispatch: false });
         `).toFail(
-          /Type '{ foo: string; }' is not assignable to type 'Observable<Action> | ((...args: any[]) => Observable<Action>)'./
+          /Type '{ foo: string; }' is not assignable to type 'Observable<unknown> | ((...args: any[]) => Observable<unknown>)'./
         );
       });
     });
@@ -73,7 +73,9 @@ describe('createEffect()', () => {
   it('should dispatch by default', () => {
     const effect: any = createEffect(() => of({ type: 'a' }));
 
-    expect(effect['__@ngrx/effects_create__']).toEqual({ dispatch: true });
+    expect(effect['__@ngrx/effects_create__']).toEqual(
+      jasmine.objectContaining({ dispatch: true })
+    );
   });
 
   it('should be possible to explicitly create a dispatching effect', () => {
@@ -81,7 +83,9 @@ describe('createEffect()', () => {
       dispatch: true,
     });
 
-    expect(effect['__@ngrx/effects_create__']).toEqual({ dispatch: true });
+    expect(effect['__@ngrx/effects_create__']).toEqual(
+      jasmine.objectContaining({ dispatch: true })
+    );
   });
 
   it('should be possible to create a non-dispatching effect', () => {
@@ -89,7 +93,9 @@ describe('createEffect()', () => {
       dispatch: false,
     });
 
-    expect(effect['__@ngrx/effects_create__']).toEqual({ dispatch: false });
+    expect(effect['__@ngrx/effects_create__']).toEqual(
+      jasmine.objectContaining({ dispatch: false })
+    );
   });
 
   it('should be possible to create a non-dispatching effect returning a non-action', () => {
@@ -97,7 +103,9 @@ describe('createEffect()', () => {
       dispatch: false,
     });
 
-    expect(effect['__@ngrx/effects_create__']).toEqual({ dispatch: false });
+    expect(effect['__@ngrx/effects_create__']).toEqual(
+      jasmine.objectContaining({ dispatch: false })
+    );
   });
 
   describe('getCreateEffectMetadata', () => {
@@ -106,14 +114,30 @@ describe('createEffect()', () => {
         a = createEffect(() => of({ type: 'a' }));
         b = createEffect(() => of({ type: 'b' }), { dispatch: true });
         c = createEffect(() => of({ type: 'c' }), { dispatch: false });
+        d = createEffect(() => of({ type: 'd' }), { resubscribeOnError: true });
+        e = createEffect(() => of({ type: 'd' }), {
+          resubscribeOnError: false,
+        });
+        f = createEffect(() => of({ type: 'e' }), {
+          dispatch: false,
+          resubscribeOnError: false,
+        });
+        g = createEffect(() => of({ type: 'e' }), {
+          dispatch: true,
+          resubscribeOnError: false,
+        });
       }
 
       const mock = new Fixture();
 
       expect(getCreateEffectMetadata(mock)).toEqual([
-        { propertyName: 'a', dispatch: true },
-        { propertyName: 'b', dispatch: true },
-        { propertyName: 'c', dispatch: false },
+        { propertyName: 'a', dispatch: true, resubscribeOnError: true },
+        { propertyName: 'b', dispatch: true, resubscribeOnError: true },
+        { propertyName: 'c', dispatch: false, resubscribeOnError: true },
+        { propertyName: 'd', dispatch: true, resubscribeOnError: true },
+        { propertyName: 'e', dispatch: true, resubscribeOnError: false },
+        { propertyName: 'f', dispatch: false, resubscribeOnError: false },
+        { propertyName: 'g', dispatch: true, resubscribeOnError: false },
       ]);
     });
 

--- a/modules/effects/spec/effect_decorator.spec.ts
+++ b/modules/effects/spec/effect_decorator.spec.ts
@@ -5,17 +5,30 @@ describe('@Effect()', () => {
     it('should get the effects metadata for a class instance', () => {
       class Fixture {
         @Effect() a: any;
-        @Effect() b: any;
+        @Effect({ dispatch: true })
+        b: any;
         @Effect({ dispatch: false })
         c: any;
+        @Effect({ resubscribeOnError: true })
+        d: any;
+        @Effect({ resubscribeOnError: false })
+        e: any;
+        @Effect({ dispatch: false, resubscribeOnError: false })
+        f: any;
+        @Effect({ dispatch: true, resubscribeOnError: false })
+        g: any;
       }
 
       const mock = new Fixture();
 
       expect(getEffectDecoratorMetadata(mock)).toEqual([
-        { propertyName: 'a', dispatch: true },
-        { propertyName: 'b', dispatch: true },
-        { propertyName: 'c', dispatch: false },
+        { propertyName: 'a', dispatch: true, resubscribeOnError: true },
+        { propertyName: 'b', dispatch: true, resubscribeOnError: true },
+        { propertyName: 'c', dispatch: false, resubscribeOnError: true },
+        { propertyName: 'd', dispatch: true, resubscribeOnError: true },
+        { propertyName: 'e', dispatch: true, resubscribeOnError: false },
+        { propertyName: 'f', dispatch: false, resubscribeOnError: false },
+        { propertyName: 'g', dispatch: true, resubscribeOnError: false },
       ]);
     });
 

--- a/modules/effects/spec/effects_metadata.spec.ts
+++ b/modules/effects/spec/effects_metadata.spec.ts
@@ -1,6 +1,7 @@
 import { getEffectsMetadata, getSourceMetadata } from '../src/effects_metadata';
 import { of } from 'rxjs';
 import { Effect, createEffect } from '..';
+import { EffectMetadata } from '../src/models';
 
 describe('Effects metadata', () => {
   describe('getSourceMetadata', () => {
@@ -11,17 +12,24 @@ describe('Effects metadata', () => {
         @Effect({ dispatch: false })
         c: any;
         d = createEffect(() => of({ type: 'a' }), { dispatch: false });
+        @Effect({ dispatch: false, resubscribeOnError: false })
+        e: any;
         z: any;
       }
 
       const mock = new Fixture();
+      const expected: EffectMetadata<Fixture>[] = [
+        { propertyName: 'a', dispatch: true, resubscribeOnError: true },
+        { propertyName: 'c', dispatch: false, resubscribeOnError: true },
+        { propertyName: 'b', dispatch: true, resubscribeOnError: true },
+        { propertyName: 'd', dispatch: false, resubscribeOnError: true },
+        { propertyName: 'e', dispatch: false, resubscribeOnError: false },
+      ];
 
-      expect(getSourceMetadata(mock)).toEqual([
-        { propertyName: 'a', dispatch: true },
-        { propertyName: 'c', dispatch: false },
-        { propertyName: 'b', dispatch: true },
-        { propertyName: 'd', dispatch: false },
-      ]);
+      expect(getSourceMetadata(mock)).toEqual(
+        jasmine.arrayContaining(expected)
+      );
+      expect(getSourceMetadata(mock).length).toEqual(expected.length);
     });
   });
 
@@ -36,17 +44,21 @@ describe('Effects metadata', () => {
         @Effect({ dispatch: false })
         e: any;
         f = createEffect(() => of({ type: 'f' }), { dispatch: false });
+        g = createEffect(() => of({ type: 'f' }), {
+          resubscribeOnError: false,
+        });
       }
 
       const mock = new Fixture();
 
       expect(getEffectsMetadata(mock)).toEqual({
-        a: { dispatch: true },
-        c: { dispatch: true },
-        e: { dispatch: false },
-        b: { dispatch: true },
-        d: { dispatch: true },
-        f: { dispatch: false },
+        a: { dispatch: true, resubscribeOnError: true },
+        c: { dispatch: true, resubscribeOnError: true },
+        e: { dispatch: false, resubscribeOnError: true },
+        b: { dispatch: true, resubscribeOnError: true },
+        d: { dispatch: true, resubscribeOnError: true },
+        f: { dispatch: false, resubscribeOnError: true },
+        g: { dispatch: true, resubscribeOnError: false },
       });
     });
 

--- a/modules/effects/spec/effects_metadata.spec.ts
+++ b/modules/effects/spec/effects_metadata.spec.ts
@@ -44,7 +44,7 @@ describe('Effects metadata', () => {
         @Effect({ dispatch: false })
         e: any;
         f = createEffect(() => of({ type: 'f' }), { dispatch: false });
-        g = createEffect(() => of({ type: 'f' }), {
+        g = createEffect(() => of({ type: 'g' }), {
           resubscribeOnError: false,
         });
       }

--- a/modules/effects/src/effect_decorator.ts
+++ b/modules/effects/src/effect_decorator.ts
@@ -1,5 +1,5 @@
 import { compose } from '@ngrx/store';
-import { EffectMetadata } from './models';
+import { EffectMetadata, EffectConfig } from './models';
 import { getSourceForInstance } from './utils';
 
 const METADATA_KEY = '__@ngrx/effects__';
@@ -7,7 +7,7 @@ const METADATA_KEY = '__@ngrx/effects__';
 export function Effect<T>({
   dispatch = true,
   resubscribeOnError = true,
-} = {}): PropertyDecorator {
+}: EffectConfig = {}): PropertyDecorator {
   return function<K extends Extract<keyof T, string>>(
     target: T,
     propertyName: K

--- a/modules/effects/src/effect_decorator.ts
+++ b/modules/effects/src/effect_decorator.ts
@@ -4,12 +4,22 @@ import { getSourceForInstance } from './utils';
 
 const METADATA_KEY = '__@ngrx/effects__';
 
-export function Effect<T>({ dispatch = true } = {}): PropertyDecorator {
+export function Effect<T>({
+  dispatch = true,
+  resubscribeOnError = true,
+} = {}): PropertyDecorator {
   return function<K extends Extract<keyof T, string>>(
     target: T,
     propertyName: K
   ) {
-    const metadata: EffectMetadata<T> = { propertyName, dispatch };
+    // Right now both createEffect and @Effect decorator set default values.
+    // Ideally that should only be done in one place that aggregates that info,
+    // for example in mergeEffects().
+    const metadata: EffectMetadata<T> = {
+      propertyName,
+      dispatch,
+      resubscribeOnError,
+    };
     setEffectMetadataEntries<T>(target, [metadata]);
   } as (target: {}, propertyName: string | symbol) => void;
 }

--- a/modules/effects/src/effect_notification.ts
+++ b/modules/effects/src/effect_notification.ts
@@ -10,21 +10,7 @@ export interface EffectNotification {
   notification: Notification<Action | null | undefined>;
 }
 
-export function verifyOutput(
-  output: EffectNotification,
-  reporter: ErrorHandler
-) {
-  reportErrorThrown(output, reporter);
-  reportInvalidActions(output, reporter);
-}
-
-function reportErrorThrown(output: EffectNotification, reporter: ErrorHandler) {
-  if (output.notification.kind === 'E') {
-    reporter.handleError(output.notification.error);
-  }
-}
-
-function reportInvalidActions(
+export function reportInvalidActions(
   output: EffectNotification,
   reporter: ErrorHandler
 ) {

--- a/modules/effects/src/effects_metadata.ts
+++ b/modules/effects/src/effects_metadata.ts
@@ -5,8 +5,12 @@ import { getEffectDecoratorMetadata } from './effect_decorator';
 export function getEffectsMetadata<T>(instance: T): EffectsMetadata<T> {
   const metadata: EffectsMetadata<T> = {};
 
-  for (const { propertyName, dispatch } of getSourceMetadata(instance)) {
-    metadata[propertyName] = { dispatch };
+  for (const {
+    propertyName,
+    dispatch,
+    resubscribeOnError,
+  } of getSourceMetadata(instance)) {
+    metadata[propertyName] = { dispatch, resubscribeOnError };
   }
 
   return metadata;

--- a/modules/effects/src/effects_resolver.ts
+++ b/modules/effects/src/effects_resolver.ts
@@ -1,28 +1,44 @@
 import { Action } from '@ngrx/store';
 import { merge, Notification, Observable } from 'rxjs';
-import { ignoreElements, map, materialize } from 'rxjs/operators';
+import { ignoreElements, map, materialize, catchError } from 'rxjs/operators';
 
 import { EffectNotification } from './effect_notification';
 import { getSourceMetadata } from './effects_metadata';
 import { getSourceForInstance } from './utils';
+import { ErrorHandler } from '@angular/core';
 
 export function mergeEffects(
-  sourceInstance: any
+  sourceInstance: any,
+  errorHandler?: ErrorHandler
 ): Observable<EffectNotification> {
   const sourceName = getSourceForInstance(sourceInstance).constructor.name;
 
-  const observables: Observable<any>[] = getSourceMetadata(sourceInstance).map(
-    ({ propertyName, dispatch }): Observable<EffectNotification> => {
-      const observable: Observable<any> =
+  const observables$: Observable<any>[] = getSourceMetadata(sourceInstance).map(
+    ({
+      propertyName,
+      dispatch,
+      resubscribeOnError,
+    }): Observable<EffectNotification> => {
+      const observable$: Observable<any> =
         typeof sourceInstance[propertyName] === 'function'
           ? sourceInstance[propertyName]()
           : sourceInstance[propertyName];
 
+      const resubscribable$ = resubscribeOnError
+        ? observable$.pipe(
+            catchError(error => {
+              if (errorHandler) errorHandler.handleError(error);
+              // Return observable that produces this particular effect
+              return observable$;
+            })
+          )
+        : observable$;
+
       if (dispatch === false) {
-        return observable.pipe(ignoreElements());
+        return resubscribable$.pipe(ignoreElements());
       }
 
-      const materialized$ = observable.pipe(materialize());
+      const materialized$ = resubscribable$.pipe(materialize());
 
       return materialized$.pipe(
         map(
@@ -38,5 +54,5 @@ export function mergeEffects(
     }
   );
 
-  return merge(...observables);
+  return merge(...observables$);
 }

--- a/modules/effects/src/models.ts
+++ b/modules/effects/src/models.ts
@@ -1,8 +1,12 @@
-export interface EffectMetadata<T> {
+export interface EffectConfig {
+  dispatch?: boolean;
+  resubscribeOnError?: boolean;
+}
+
+export interface EffectMetadata<T> extends Required<EffectConfig> {
   propertyName: Extract<keyof T, string>;
-  dispatch: boolean;
 }
 
 export type EffectsMetadata<T> = {
-  [key in Extract<keyof T, string>]?: { dispatch: boolean }
+  [key in Extract<keyof T, string>]?: EffectConfig
 };

--- a/projects/ngrx.io/content/guide/effects/lifecycle.md
+++ b/projects/ngrx.io/content/guide/effects/lifecycle.md
@@ -40,20 +40,20 @@ export class LogEffects {
 
 ### Resubscribe on Error
 
-Starting from NgRx V8 when error happens in the effect's main stream it is
-reported using Angular's `ErrorHandler` and the source effect is 
+Starting with version 8, when an error happens in the effect's main stream it is
+reported using Angular's `ErrorHandler`, and the source effect is 
 **automatically** resubscribe (instead of completeling), so it continues to 
-listen to any new dispatched Actions.
+listen to all dispatched Actions.
 
 Generally, errors should be handled by users and operators such as `mapToAction`
 should make it easier to do. However, for the cases where errors were missed, 
-this new behavior adds additional safety net.
+this new behavior adds an additional safety net.
 
-In some cases where particular RxJS operators are used the new behavior might
-produce unexpected results. For example, if the `startWith` operator is within 
+In some cases where particular RxJS operators are used, the new behavior might
+produce unexpected results. For example, if the `startWith` operator is within the
 effect's pipe then it will be triggered again.
 
-To remove resubscriptions add `{resubscribeOnError: false}` to `createEffect` 
+To disable resubscriptions add `{resubscribeOnError: false}` to the `createEffect` 
 metadata (second argument).
 
 <code-example header="disable-resubscribe.effects.ts">

--- a/projects/ngrx.io/content/guide/effects/lifecycle.md
+++ b/projects/ngrx.io/content/guide/effects/lifecycle.md
@@ -14,6 +14,8 @@ init$ = createEffect(() =>
 );
 </code-example>
 
+## Effect Metadata
+
 ### Non-dispatching Effects
 
 Sometimes you don't want effects to dispatch an action, for example when you only want to log or navigate based on an incoming action. But when an effect does not dispatch another action, the browser will crash because the effect is both 'subscribing' to and 'dispatching' the exact same action, causing an infinite loop. To prevent this, add `{ dispatch: false }` to the `createEffect` function as the second argument.
@@ -33,6 +35,40 @@ export class LogEffects {
     this.actions$.pipe(
       tap(action => console.log(action))
     ), { dispatch: false });
+}
+</code-example>
+
+### Resubscribe on Error
+
+Starting from NgRx V8 when error happens in the effect's main stream it is
+reported using Angular's `ErrorHandler` and the source effect is 
+**automatically** resubscribe (instead of completeling), so it continues to 
+listen to any new dispatched Actions.
+
+Generally, errors should be handled by users and operators such as `mapToAction`
+should make it easier to do. However, for the cases where errors were missed, 
+this new behavior adds additional safety net.
+
+In some cases where particular RxJS operators are used the new behavior might
+produce unexpected results. For example, if the `startWith` operator is within 
+effect's pipe then it will be triggered again.
+
+To remove resubscriptions add `{resubscribeOnError: false}` to `createEffect` 
+metadata (second argument).
+
+<code-example header="disable-resubscribe.effects.ts">
+import { Injectable } from '@angular/core';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { tap } from 'rxjs/operators';
+
+@Injectable()
+export class ErrorFreeEffects {
+  constructor(private actions$: Actions) {}
+  
+  disabledResubscriptionsActions$ = createEffect(() =>
+    this.actions$.pipe(
+      tap(action => console.log(action))
+    ), { resubscribeOnError: false });
 }
 </code-example>
 

--- a/projects/ngrx.io/content/guide/effects/lifecycle.md
+++ b/projects/ngrx.io/content/guide/effects/lifecycle.md
@@ -42,10 +42,10 @@ export class LogEffects {
 
 Starting with version 8, when an error happens in the effect's main stream it is
 reported using Angular's `ErrorHandler`, and the source effect is 
-**automatically** resubscribe (instead of completeling), so it continues to 
+**automatically** resubscribed to (instead of completing), so it continues to 
 listen to all dispatched Actions.
 
-Generally, errors should be handled by users and operators such as `mapToAction`
+Generally, errors should be handled by users, and operators such as `mapToAction`
 should make it easier to do. However, for the cases where errors were missed, 
 this new behavior adds an additional safety net.
 

--- a/projects/ngrx.io/content/guide/effects/testing.md
+++ b/projects/ngrx.io/content/guide/effects/testing.md
@@ -119,11 +119,15 @@ describe('My Effects', () => {
   });
 
   it('should register someSource$ that dispatches an action', () => {
-    expect(metadata.someSource$).toEqual({ dispatch: true });
+    expect(metadata.someSource$).toEqual(
+      jasmine.objectContaining({ dispatch: true })
+    );
   });
 
   it('should register someOtherSource$ that does not dispatch an action', () => {
-    expect(metadata.someOtherSource$).toEqual({ dispatch: false });
+    expect(metadata.someOtherSource$).toEqual(
+      jasmine.objectContaining({ dispatch: false })
+    );
   });
 
   it('should not register undecoratedSource$', () => {

--- a/projects/ngrx.io/content/guide/migration/v8.md
+++ b/projects/ngrx.io/content/guide/migration/v8.md
@@ -150,7 +150,7 @@ export const getNews: MemoizedSelector<State, Reaction> = createSelector(
 
 #### Resubscribe on Errors
 
-If error occurs (or it flattened into) main effect's pipe then it will be 
+If an error occurs (or is flattened) in the main effect's pipe then it will be 
 reported and the effect is resubscribed automatically. In cases when this new behavior is
 undesirable, it can be disabled using `{resubscribeOnError: false}` within the effect metadata
  (for each effect individually). [Learn more](/guide/effects/lifecycle#resubscribe-on-error).

--- a/projects/ngrx.io/content/guide/migration/v8.md
+++ b/projects/ngrx.io/content/guide/migration/v8.md
@@ -152,8 +152,8 @@ export const getNews: MemoizedSelector<State, Reaction> = createSelector(
 
 If error occurs (or it flattened into) main effect's pipe then it will be 
 reported and the effect is resubscribed automatically. In cases when this new behavior is
-undesirable, it can be turned off with `{resubscribeOnError: false}` metadata
-setting (for each effect individually). [Learn more](/guide/effects/lifecycle#resubscribe-on-error).
+undesirable, it can be disabled using `{resubscribeOnError: false}` within the effect metadata
+ (for each effect individually). [Learn more](/guide/effects/lifecycle#resubscribe-on-error).
 
 ### @ngrx/router-store
 

--- a/projects/ngrx.io/content/guide/migration/v8.md
+++ b/projects/ngrx.io/content/guide/migration/v8.md
@@ -146,6 +146,14 @@ export const getNews: MemoizedSelector<State, Reaction> = createSelector(
 );
 ```
 
+### @ngrx/effects
+
+#### Resubscribe on Errors
+
+If error occurs (or it flattened into) main effect's pipe then it will be 
+reported and the effect is resubscribed automatically. In cases when this new behavior is
+undesirable, it can be turned off with `{resubscribeOnError: false}` metadata
+setting (for each effect individually). [Learn more](/guide/effects/lifecycle#resubscribe-on-error).
 
 ### @ngrx/router-store
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When Errors happen in the main Actions stream that error is reported and the stream is closed

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes # https://github.com/ngrx/platform/issues/1851

## What is the new behavior?

For `{dispatch: true}`, which is the default Effect option, if the error occurs in the main actions stream, the effect will be resubscribed. This could result in unusual behavior (in cases where operators like `startWith` are used).

Resubscriptions can be turned off by setting `{resubscribeOnError: false}` in the effect metadata. 

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGE:

Prior to introduction of automatic resubscriptions on errors, all effects had effectively `{resubscribeOnError: false}` behavior. For the rare cases when this is still wanted please add `{resubscribeOnError: false}` to the effect metadata.

BEFORE:

```ts
login$ = createEffect(() =>
    this.actions$.pipe(
      ofType(LoginPageActions.login),
      mapToAction(
        // Happy path callback
        action => this.authService.login(action.credentials).pipe(
            map(user => AuthApiActions.loginSuccess({ user }))),
        // error callback
        error => AuthApiActions.loginFailure({ error }),
      ) 
    ));
```

AFTER:

```ts
login$ = createEffect(() =>
    this.actions$.pipe(
      ofType(LoginPageActions.login),
      mapToAction(
        // Happy path callback
        action => this.authService.login(action.credentials).pipe(
            map(user => AuthApiActions.loginSuccess({ user }))),
        // error callback
        error => AuthApiActions.loginFailure({ error }),
      )
    // Errors are handled and it is safe to disable resubscription 
    ), {resubscribeOnError: false });
```

## Other information
