### PR TITLE
fix: createSelectorFactory should return a MemoizedSelector

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -489,7 +489,7 @@ export function createSelector<
 
 export function createSelector(
   ...input: any[]
-): Selector<any, any> | SelectorWithProps<any, any, any> {
+): MemoizedSelector<any, any> | MemoizedSelectorWithProps<any, any, any> {
   return createSelectorFactory(defaultMemoize)(...input);
 }
 

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -521,18 +521,18 @@ export type SelectorFactoryConfig<T = any, V = any> = {
 
 export function createSelectorFactory<T = any, V = any>(
   memoize: MemoizeFn
-): (...input: any[]) => Selector<T, V>;
+): (...input: any[]) => MemoizedSelector<T, V>;
 export function createSelectorFactory<T = any, V = any>(
   memoize: MemoizeFn,
   options: SelectorFactoryConfig<T, V>
-): (...input: any[]) => Selector<T, V>;
+): (...input: any[]) => MemoizedSelector<T, V>;
 export function createSelectorFactory<T = any, Props = any, V = any>(
   memoize: MemoizeFn
-): (...input: any[]) => SelectorWithProps<T, Props, V>;
+): (...input: any[]) => MemoizedSelectorWithProps<T, Props, V>;
 export function createSelectorFactory<T = any, Props = any, V = any>(
   memoize: MemoizeFn,
   options: SelectorFactoryConfig<T, V>
-): (...input: any[]) => SelectorWithProps<T, Props, V>;
+): (...input: any[]) => MemoizedSelectorWithProps<T, Props, V>;
 export function createSelectorFactory(
   memoize: MemoizeFn,
   options: SelectorFactoryConfig<any, any> = {
@@ -541,7 +541,7 @@ export function createSelectorFactory(
 ) {
   return function(
     ...input: any[]
-  ): Selector<any, any> | SelectorWithProps<any, any, any> {
+  ): MemoizedSelector<any, any> | MemoizedSelectorWithProps<any, any, any> {
     let args = input;
     if (Array.isArray(args[0])) {
       const [head, ...tail] = args;


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1849

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

BREAKING CHANGE:
The return type of the createSelectorFactory function is now a MemoizedSelector instead of a Selector

