### PR TITLE
refactor(selectors): Capture the type of a selectors projector

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -12,17 +12,26 @@ export type MemoizeFn = (t: AnyFn) => MemoizedProjection;
 
 export type ComparatorFn = (a: any, b: any) => boolean;
 
-export interface MemoizedSelector<State, Result>
-  extends Selector<State, Result> {
+export type DefaultProjectorFn<T> = (...args: any[]) => T;
+
+export interface MemoizedSelector<
+  State,
+  Result,
+  ProjectorFn = DefaultProjectorFn<Result>
+> extends Selector<State, Result> {
   release(): void;
-  projector: AnyFn;
+  projector: ProjectorFn;
   setResult: (result?: Result) => void;
 }
 
-export interface MemoizedSelectorWithProps<State, Props, Result>
-  extends SelectorWithProps<State, Props, Result> {
+export interface MemoizedSelectorWithProps<
+  State,
+  Props,
+  Result,
+  ProjectorFn = DefaultProjectorFn<Result>
+> extends SelectorWithProps<State, Props, Result> {
   release(): void;
-  projector: AnyFn;
+  projector: ProjectorFn;
   setResult: (result?: Result) => void;
 }
 


### PR DESCRIPTION
- supply a default projector type to MemoizedSelector

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently selectors projector functions are typed as 'any'
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #
#1908 

## What is the new behavior?
`MemoizedSelector` extended to have a third parameter that has a default projector function that utilizes `Result` as type.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
