### PR TITLE
feat(store): add protection from type property use

### DIFF
--- a/modules/store/spec/action_creator.spec.ts
+++ b/modules/store/spec/action_creator.spec.ts
@@ -77,6 +77,13 @@ describe('Action Creators', () => {
           const value = fooAction.bar;
       `).toFail(/'bar' does not exist on type/);
     });
+    it('should not allow type property', () => {
+      expectSnippet(`
+            const foo = createAction('FOO', (type: string) => ({type}));
+        `).toFail(
+        /Type '{ type: string; }' is not assignable to type '"type property is not allowed in action creators"/
+      );
+    });
   });
 
   describe('empty', () => {
@@ -140,6 +147,15 @@ describe('Action Creators', () => {
             const fooAction = foo({ foo: 42 });
             const value = fooAction.bar;
         `).toFail(/'bar' does not exist on type/);
+    });
+
+    it('should not allow type property', () => {
+      const foo = createAction('FOO', props<{ type: number }>() as any);
+      expectSnippet(`
+          const foo = createAction('FOO', props<{ type: number }>());
+        `).toFail(
+        /Argument of type '"type property is not allowed in action creators"' is not assignable to parameter of type/
+      );
     });
   });
 });

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -3,13 +3,13 @@ import {
   ActionCreator,
   TypedAction,
   FunctionWithParametersType,
-  ParametersType,
+  PropsReturnType,
+  DisallowTypeProperty,
 } from './models';
 
-/**
- * Action creators taken from ts-action library and modified a bit to better
- * fit current NgRx usage. Thank you Nicholas Jamieson (@cartant).
- */
+// Action creators taken from ts-action library and modified a bit to better
+// fit current NgRx usage. Thank you Nicholas Jamieson (@cartant).
+
 export function createAction<T extends string>(
   type: T
 ): ActionCreator<T, () => TypedAction<T>>;
@@ -17,20 +17,20 @@ export function createAction<T extends string, P extends object>(
   type: T,
   config: { _as: 'props'; _p: P }
 ): ActionCreator<T, (props: P) => P & TypedAction<T>>;
+export function createAction<
+  T extends string,
+  P extends any[],
+  R extends object
+>(
+  type: T,
+  creator: Creator<P, DisallowTypeProperty<R>>
+): FunctionWithParametersType<P, R & TypedAction<T>> & TypedAction<T>;
 export function createAction<T extends string, C extends Creator>(
   type: T,
-  creator: C
-): FunctionWithParametersType<
-  ParametersType<C>,
-  ReturnType<C> & TypedAction<T>
-> &
-  TypedAction<T>;
-export function createAction<T extends string>(
-  type: T,
-  config?: { _as: 'props' } | Creator
+  config?: { _as: 'props'; _p: object } | C
 ): Creator {
   if (typeof config === 'function') {
-    return defineType(type, (...args: unknown[]) => ({
+    return defineType(type, (...args: any[]) => ({
       ...config(...args),
       type,
     }));
@@ -40,8 +40,8 @@ export function createAction<T extends string>(
     case 'empty':
       return defineType(type, () => ({ type }));
     case 'props':
-      return defineType(type, (props: unknown) => ({
-        ...(props as object),
+      return defineType(type, (props: object) => ({
+        ...props,
         type,
       }));
     default:
@@ -49,8 +49,10 @@ export function createAction<T extends string>(
   }
 }
 
-export function props<P>(): { _as: 'props'; _p: P } {
-  return { _as: 'props', _p: undefined! };
+export function props<P extends object>(): PropsReturnType<P> {
+  // the return type does not match TypePropertyIsNotAllowed, so double casting
+  // is used.
+  return ({ _as: 'props', _p: undefined! } as unknown) as PropsReturnType<P>;
 }
 
 export function union<

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -27,7 +27,7 @@ export function createAction<
 ): FunctionWithParametersType<P, R & TypedAction<T>> & TypedAction<T>;
 export function createAction<T extends string, C extends Creator>(
   type: T,
-  config?: { _as: 'props'; _p: object } | C
+  config?: { _as: 'props' } | C
 ): Creator {
   if (typeof config === 'function') {
     return defineType(type, (...args: any[]) => ({

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -49,7 +49,24 @@ export type SelectorWithProps<State, Props, Result> = (
   props: Props
 ) => Result;
 
-export type Creator = (...args: any[]) => object;
+export type DisallowTypeProperty<T> = T extends { type: any }
+  ? TypePropertyIsNotAllowed
+  : T;
+
+export const typePropertyIsNotAllowedMsg =
+  'type property is not allowed in action creators';
+type TypePropertyIsNotAllowed = typeof typePropertyIsNotAllowedMsg;
+
+export type Creator<
+  P extends any[] = any[],
+  R extends object = object
+> = R extends { type: any }
+  ? TypePropertyIsNotAllowed
+  : FunctionWithParametersType<P, R>;
+
+export type PropsReturnType<T extends object> = T extends { type: any }
+  ? TypePropertyIsNotAllowed
+  : { _as: 'props'; _p: T };
 
 export type ActionCreator<
   T extends string = string,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

actions creators could use `type` property, even thought it would be overridden.

```ts
export const a = createAction('my action', props<{type: string}>());
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes https://github.com/ngrx/platform/issues/1917

## What is the new behavior?

Such usage will produce the error:
- with creator function
```
Type '{ type: string; }' is not assignable to type '"type property is not allowed in action creators"
```
- with `props`
```
Argument of type '"type property is not allowed in action creators"' is not assignable to parameter of type...
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
