### PR TITLE
perf: fine tune schematics

### DIFF
--- a/modules/data/schematics-core/index.ts
+++ b/modules/data/schematics-core/index.ts
@@ -33,6 +33,7 @@ export {
   ReplaceChange,
   createReplaceChange,
   createChangeRecorder,
+  commitChanges,
 } from './utility/change';
 
 export { AppConfig, getWorkspace, getWorkspacePath } from './utility/config';

--- a/modules/data/schematics-core/utility/ast-utils.ts
+++ b/modules/data/schematics-core/utility/ast-utils.ts
@@ -687,7 +687,7 @@ export function replaceImport(
     })
     .filter(({ hit }) => hit)
     .map(({ specifier, text }) =>
-      createReplaceChange(sourceFile, path, specifier!, text!, importToBe)
+      createReplaceChange(sourceFile, specifier!, text!, importToBe)
     );
 
   return changes;

--- a/modules/data/schematics-core/utility/change.ts
+++ b/modules/data/schematics-core/utility/change.ts
@@ -136,12 +136,16 @@ export class ReplaceChange implements Change {
 
 export function createReplaceChange(
   sourceFile: ts.SourceFile,
-  path: Path,
   node: ts.Node,
   oldText: string,
   newText: string
 ): ReplaceChange {
-  return new ReplaceChange(path, node.getStart(sourceFile), oldText, newText);
+  return new ReplaceChange(
+    sourceFile.fileName,
+    node.getStart(sourceFile),
+    oldText,
+    newText
+  );
 }
 
 export function createChangeRecorder(
@@ -161,4 +165,14 @@ export function createChangeRecorder(
     }
   }
   return recorder;
+}
+
+export function commitChanges(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length === 0) {
+    return false;
+  }
+
+  const recorder = createChangeRecorder(tree, path, changes);
+  tree.commitUpdate(recorder);
+  return true;
 }

--- a/modules/data/schematics-core/utility/visit-utils.ts
+++ b/modules/data/schematics-core/utility/visit-utils.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { Tree } from '@angular-devkit/schematics';
+import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
   tree: Tree,
@@ -10,24 +10,35 @@ export function visitTSSourceFiles<Result = void>(
   ) => Result | undefined
 ): Result | undefined {
   let result: Result | undefined = undefined;
-
-  tree.visit(path => {
-    if (!path.endsWith('.ts')) {
-      return;
-    }
-
-    const sourceFile = ts.createSourceFile(
-      path,
-      tree.read(path)!.toString(),
-      ts.ScriptTarget.Latest
-    );
-
-    if (sourceFile.isDeclarationFile) {
-      return;
-    }
-
+  for (const sourceFile of visit(tree.root)) {
     result = visitor(sourceFile, tree, result);
-  });
+  }
 
   return result;
+}
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        const source = ts.createSourceFile(
+          entry.path,
+          content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        yield source;
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules') {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
 }

--- a/modules/data/schematics/ng-add/index.ts
+++ b/modules/data/schematics/ng-add/index.ts
@@ -22,7 +22,6 @@ import {
   createChangeRecorder,
 } from '@ngrx/data/schematics-core';
 import { Schema as EntityDataOptions } from './schema';
-import { Path } from '@angular-devkit/core';
 
 function addNgRxDataToPackageJson() {
   return (host: Tree, context: SchematicContext) => {
@@ -133,9 +132,9 @@ function renameNgrxDataModule(options: EntityDataOptions) {
       }
 
       const changes = [
-        ...findNgrxDataImports(sourceFile, path, ngrxDataImports),
-        ...findNgrxDataImportDeclarations(sourceFile, path, ngrxDataImports),
-        ...findNgrxDataReplacements(sourceFile, path),
+        ...findNgrxDataImports(sourceFile, ngrxDataImports),
+        ...findNgrxDataImportDeclarations(sourceFile, ngrxDataImports),
+        ...findNgrxDataReplacements(sourceFile),
       ];
 
       if (changes.length === 0) {
@@ -150,13 +149,11 @@ function renameNgrxDataModule(options: EntityDataOptions) {
 
 function findNgrxDataImports(
   sourceFile: ts.SourceFile,
-  path: Path,
   imports: ts.ImportDeclaration[]
 ) {
   const changes = imports.map(specifier =>
     createReplaceChange(
       sourceFile,
-      path,
       specifier.moduleSpecifier,
       "'ngrx-data'",
       "'@ngrx/data'"
@@ -168,7 +165,6 @@ function findNgrxDataImports(
 
 function findNgrxDataImportDeclarations(
   sourceFile: ts.SourceFile,
-  path: Path,
   imports: ts.ImportDeclaration[]
 ) {
   const changes = imports
@@ -198,7 +194,6 @@ function findNgrxDataImportDeclarations(
     .map(({ specifier, text }) =>
       createReplaceChange(
         sourceFile,
-        path,
         specifier!,
         text!,
         (renames as any)[text!]
@@ -208,7 +203,7 @@ function findNgrxDataImportDeclarations(
   return changes;
 }
 
-function findNgrxDataReplacements(sourceFile: ts.SourceFile, path: Path) {
+function findNgrxDataReplacements(sourceFile: ts.SourceFile) {
   const renameKeys = Object.keys(renames);
   let changes: ReplaceChange[] = [];
   ts.forEachChild(sourceFile, node => find(node, changes));
@@ -252,7 +247,6 @@ function findNgrxDataReplacements(sourceFile: ts.SourceFile, path: Path) {
       changes.push(
         createReplaceChange(
           sourceFile,
-          path,
           change.node,
           change.text,
           (renames as any)[change.text]

--- a/modules/data/tsconfig-build.json
+++ b/modules/data/tsconfig-build.json
@@ -11,6 +11,7 @@
     "noEmitOnError": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "downlevelIteration": true,
     "outDir": "../../dist/packages/data",
     "paths": {
       "@ngrx/store": ["../../dist/packages/store"],

--- a/modules/effects/schematics-core/index.ts
+++ b/modules/effects/schematics-core/index.ts
@@ -33,6 +33,7 @@ export {
   ReplaceChange,
   createReplaceChange,
   createChangeRecorder,
+  commitChanges,
 } from './utility/change';
 
 export { AppConfig, getWorkspace, getWorkspacePath } from './utility/config';

--- a/modules/effects/schematics-core/utility/ast-utils.ts
+++ b/modules/effects/schematics-core/utility/ast-utils.ts
@@ -687,7 +687,7 @@ export function replaceImport(
     })
     .filter(({ hit }) => hit)
     .map(({ specifier, text }) =>
-      createReplaceChange(sourceFile, path, specifier!, text!, importToBe)
+      createReplaceChange(sourceFile, specifier!, text!, importToBe)
     );
 
   return changes;

--- a/modules/effects/schematics-core/utility/change.ts
+++ b/modules/effects/schematics-core/utility/change.ts
@@ -136,12 +136,16 @@ export class ReplaceChange implements Change {
 
 export function createReplaceChange(
   sourceFile: ts.SourceFile,
-  path: Path,
   node: ts.Node,
   oldText: string,
   newText: string
 ): ReplaceChange {
-  return new ReplaceChange(path, node.getStart(sourceFile), oldText, newText);
+  return new ReplaceChange(
+    sourceFile.fileName,
+    node.getStart(sourceFile),
+    oldText,
+    newText
+  );
 }
 
 export function createChangeRecorder(
@@ -161,4 +165,14 @@ export function createChangeRecorder(
     }
   }
   return recorder;
+}
+
+export function commitChanges(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length === 0) {
+    return false;
+  }
+
+  const recorder = createChangeRecorder(tree, path, changes);
+  tree.commitUpdate(recorder);
+  return true;
 }

--- a/modules/effects/schematics-core/utility/visit-utils.ts
+++ b/modules/effects/schematics-core/utility/visit-utils.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { Tree } from '@angular-devkit/schematics';
+import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
   tree: Tree,
@@ -10,24 +10,35 @@ export function visitTSSourceFiles<Result = void>(
   ) => Result | undefined
 ): Result | undefined {
   let result: Result | undefined = undefined;
-
-  tree.visit(path => {
-    if (!path.endsWith('.ts')) {
-      return;
-    }
-
-    const sourceFile = ts.createSourceFile(
-      path,
-      tree.read(path)!.toString(),
-      ts.ScriptTarget.Latest
-    );
-
-    if (sourceFile.isDeclarationFile) {
-      return;
-    }
-
+  for (const sourceFile of visit(tree.root)) {
     result = visitor(sourceFile, tree, result);
-  });
+  }
 
   return result;
+}
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        const source = ts.createSourceFile(
+          entry.path,
+          content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        yield source;
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules') {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
 }

--- a/modules/effects/tsconfig-build.json
+++ b/modules/effects/tsconfig-build.json
@@ -11,6 +11,7 @@
     "noEmitOnError": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "downlevelIteration": true,
     "outDir": "../../dist/packages/effects",
     "paths": {
       "@ngrx/store": ["../../dist/packages/store"]

--- a/modules/entity/schematics-core/index.ts
+++ b/modules/entity/schematics-core/index.ts
@@ -33,6 +33,7 @@ export {
   ReplaceChange,
   createReplaceChange,
   createChangeRecorder,
+  commitChanges,
 } from './utility/change';
 
 export { AppConfig, getWorkspace, getWorkspacePath } from './utility/config';

--- a/modules/entity/schematics-core/utility/ast-utils.ts
+++ b/modules/entity/schematics-core/utility/ast-utils.ts
@@ -687,7 +687,7 @@ export function replaceImport(
     })
     .filter(({ hit }) => hit)
     .map(({ specifier, text }) =>
-      createReplaceChange(sourceFile, path, specifier!, text!, importToBe)
+      createReplaceChange(sourceFile, specifier!, text!, importToBe)
     );
 
   return changes;

--- a/modules/entity/schematics-core/utility/change.ts
+++ b/modules/entity/schematics-core/utility/change.ts
@@ -136,12 +136,16 @@ export class ReplaceChange implements Change {
 
 export function createReplaceChange(
   sourceFile: ts.SourceFile,
-  path: Path,
   node: ts.Node,
   oldText: string,
   newText: string
 ): ReplaceChange {
-  return new ReplaceChange(path, node.getStart(sourceFile), oldText, newText);
+  return new ReplaceChange(
+    sourceFile.fileName,
+    node.getStart(sourceFile),
+    oldText,
+    newText
+  );
 }
 
 export function createChangeRecorder(
@@ -161,4 +165,14 @@ export function createChangeRecorder(
     }
   }
   return recorder;
+}
+
+export function commitChanges(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length === 0) {
+    return false;
+  }
+
+  const recorder = createChangeRecorder(tree, path, changes);
+  tree.commitUpdate(recorder);
+  return true;
 }

--- a/modules/entity/schematics-core/utility/visit-utils.ts
+++ b/modules/entity/schematics-core/utility/visit-utils.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { Tree } from '@angular-devkit/schematics';
+import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
   tree: Tree,
@@ -10,24 +10,35 @@ export function visitTSSourceFiles<Result = void>(
   ) => Result | undefined
 ): Result | undefined {
   let result: Result | undefined = undefined;
-
-  tree.visit(path => {
-    if (!path.endsWith('.ts')) {
-      return;
-    }
-
-    const sourceFile = ts.createSourceFile(
-      path,
-      tree.read(path)!.toString(),
-      ts.ScriptTarget.Latest
-    );
-
-    if (sourceFile.isDeclarationFile) {
-      return;
-    }
-
+  for (const sourceFile of visit(tree.root)) {
     result = visitor(sourceFile, tree, result);
-  });
+  }
 
   return result;
+}
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        const source = ts.createSourceFile(
+          entry.path,
+          content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        yield source;
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules') {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
 }

--- a/modules/entity/tsconfig-build.json
+++ b/modules/entity/tsconfig-build.json
@@ -11,6 +11,7 @@
     "noEmitOnError": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "downlevelIteration": true,
     "outDir": "../../dist/packages/entity",
     "paths": {
       "@ngrx/store": ["../../dist/packages/store"]

--- a/modules/router-store/schematics-core/index.ts
+++ b/modules/router-store/schematics-core/index.ts
@@ -33,6 +33,7 @@ export {
   ReplaceChange,
   createReplaceChange,
   createChangeRecorder,
+  commitChanges,
 } from './utility/change';
 
 export { AppConfig, getWorkspace, getWorkspacePath } from './utility/config';

--- a/modules/router-store/schematics-core/utility/ast-utils.ts
+++ b/modules/router-store/schematics-core/utility/ast-utils.ts
@@ -687,7 +687,7 @@ export function replaceImport(
     })
     .filter(({ hit }) => hit)
     .map(({ specifier, text }) =>
-      createReplaceChange(sourceFile, path, specifier!, text!, importToBe)
+      createReplaceChange(sourceFile, specifier!, text!, importToBe)
     );
 
   return changes;

--- a/modules/router-store/schematics-core/utility/change.ts
+++ b/modules/router-store/schematics-core/utility/change.ts
@@ -136,12 +136,16 @@ export class ReplaceChange implements Change {
 
 export function createReplaceChange(
   sourceFile: ts.SourceFile,
-  path: Path,
   node: ts.Node,
   oldText: string,
   newText: string
 ): ReplaceChange {
-  return new ReplaceChange(path, node.getStart(sourceFile), oldText, newText);
+  return new ReplaceChange(
+    sourceFile.fileName,
+    node.getStart(sourceFile),
+    oldText,
+    newText
+  );
 }
 
 export function createChangeRecorder(
@@ -161,4 +165,14 @@ export function createChangeRecorder(
     }
   }
   return recorder;
+}
+
+export function commitChanges(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length === 0) {
+    return false;
+  }
+
+  const recorder = createChangeRecorder(tree, path, changes);
+  tree.commitUpdate(recorder);
+  return true;
 }

--- a/modules/router-store/schematics-core/utility/visit-utils.ts
+++ b/modules/router-store/schematics-core/utility/visit-utils.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { Tree } from '@angular-devkit/schematics';
+import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
   tree: Tree,
@@ -10,24 +10,35 @@ export function visitTSSourceFiles<Result = void>(
   ) => Result | undefined
 ): Result | undefined {
   let result: Result | undefined = undefined;
-
-  tree.visit(path => {
-    if (!path.endsWith('.ts')) {
-      return;
-    }
-
-    const sourceFile = ts.createSourceFile(
-      path,
-      tree.read(path)!.toString(),
-      ts.ScriptTarget.Latest
-    );
-
-    if (sourceFile.isDeclarationFile) {
-      return;
-    }
-
+  for (const sourceFile of visit(tree.root)) {
     result = visitor(sourceFile, tree, result);
-  });
+  }
 
   return result;
+}
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        const source = ts.createSourceFile(
+          entry.path,
+          content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        yield source;
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules') {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
 }

--- a/modules/router-store/tsconfig-build.json
+++ b/modules/router-store/tsconfig-build.json
@@ -11,6 +11,7 @@
     "noEmitOnError": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "downlevelIteration": true,
     "outDir": "../../dist/packages/router-store",
     "paths": {
       "@ngrx/store": ["../../dist/packages/store"]

--- a/modules/schematics-core/index.ts
+++ b/modules/schematics-core/index.ts
@@ -33,6 +33,7 @@ export {
   ReplaceChange,
   createReplaceChange,
   createChangeRecorder,
+  commitChanges,
 } from './utility/change';
 
 export { AppConfig, getWorkspace, getWorkspacePath } from './utility/config';

--- a/modules/schematics-core/utility/ast-utils.ts
+++ b/modules/schematics-core/utility/ast-utils.ts
@@ -687,7 +687,7 @@ export function replaceImport(
     })
     .filter(({ hit }) => hit)
     .map(({ specifier, text }) =>
-      createReplaceChange(sourceFile, path, specifier!, text!, importToBe)
+      createReplaceChange(sourceFile, specifier!, text!, importToBe)
     );
 
   return changes;

--- a/modules/schematics-core/utility/change.ts
+++ b/modules/schematics-core/utility/change.ts
@@ -136,12 +136,16 @@ export class ReplaceChange implements Change {
 
 export function createReplaceChange(
   sourceFile: ts.SourceFile,
-  path: Path,
   node: ts.Node,
   oldText: string,
   newText: string
 ): ReplaceChange {
-  return new ReplaceChange(path, node.getStart(sourceFile), oldText, newText);
+  return new ReplaceChange(
+    sourceFile.fileName,
+    node.getStart(sourceFile),
+    oldText,
+    newText
+  );
 }
 
 export function createChangeRecorder(
@@ -161,4 +165,14 @@ export function createChangeRecorder(
     }
   }
   return recorder;
+}
+
+export function commitChanges(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length === 0) {
+    return false;
+  }
+
+  const recorder = createChangeRecorder(tree, path, changes);
+  tree.commitUpdate(recorder);
+  return true;
 }

--- a/modules/schematics-core/utility/visit-utils.ts
+++ b/modules/schematics-core/utility/visit-utils.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { Tree } from '@angular-devkit/schematics';
+import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
   tree: Tree,
@@ -10,24 +10,35 @@ export function visitTSSourceFiles<Result = void>(
   ) => Result | undefined
 ): Result | undefined {
   let result: Result | undefined = undefined;
-
-  tree.visit(path => {
-    if (!path.endsWith('.ts')) {
-      return;
-    }
-
-    const sourceFile = ts.createSourceFile(
-      path,
-      tree.read(path)!.toString(),
-      ts.ScriptTarget.Latest
-    );
-
-    if (sourceFile.isDeclarationFile) {
-      return;
-    }
-
+  for (const sourceFile of visit(tree.root)) {
     result = visitor(sourceFile, tree, result);
-  });
+  }
 
   return result;
+}
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        const source = ts.createSourceFile(
+          entry.path,
+          content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        yield source;
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules') {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
 }

--- a/modules/schematics/schematics-core/index.ts
+++ b/modules/schematics/schematics-core/index.ts
@@ -33,6 +33,7 @@ export {
   ReplaceChange,
   createReplaceChange,
   createChangeRecorder,
+  commitChanges,
 } from './utility/change';
 
 export { AppConfig, getWorkspace, getWorkspacePath } from './utility/config';

--- a/modules/schematics/schematics-core/utility/ast-utils.ts
+++ b/modules/schematics/schematics-core/utility/ast-utils.ts
@@ -687,7 +687,7 @@ export function replaceImport(
     })
     .filter(({ hit }) => hit)
     .map(({ specifier, text }) =>
-      createReplaceChange(sourceFile, path, specifier!, text!, importToBe)
+      createReplaceChange(sourceFile, specifier!, text!, importToBe)
     );
 
   return changes;

--- a/modules/schematics/schematics-core/utility/change.ts
+++ b/modules/schematics/schematics-core/utility/change.ts
@@ -136,12 +136,16 @@ export class ReplaceChange implements Change {
 
 export function createReplaceChange(
   sourceFile: ts.SourceFile,
-  path: Path,
   node: ts.Node,
   oldText: string,
   newText: string
 ): ReplaceChange {
-  return new ReplaceChange(path, node.getStart(sourceFile), oldText, newText);
+  return new ReplaceChange(
+    sourceFile.fileName,
+    node.getStart(sourceFile),
+    oldText,
+    newText
+  );
 }
 
 export function createChangeRecorder(
@@ -161,4 +165,14 @@ export function createChangeRecorder(
     }
   }
   return recorder;
+}
+
+export function commitChanges(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length === 0) {
+    return false;
+  }
+
+  const recorder = createChangeRecorder(tree, path, changes);
+  tree.commitUpdate(recorder);
+  return true;
 }

--- a/modules/schematics/schematics-core/utility/visit-utils.ts
+++ b/modules/schematics/schematics-core/utility/visit-utils.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { Tree } from '@angular-devkit/schematics';
+import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
   tree: Tree,
@@ -10,24 +10,35 @@ export function visitTSSourceFiles<Result = void>(
   ) => Result | undefined
 ): Result | undefined {
   let result: Result | undefined = undefined;
-
-  tree.visit(path => {
-    if (!path.endsWith('.ts')) {
-      return;
-    }
-
-    const sourceFile = ts.createSourceFile(
-      path,
-      tree.read(path)!.toString(),
-      ts.ScriptTarget.Latest
-    );
-
-    if (sourceFile.isDeclarationFile) {
-      return;
-    }
-
+  for (const sourceFile of visit(tree.root)) {
     result = visitor(sourceFile, tree, result);
-  });
+  }
 
   return result;
+}
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        const source = ts.createSourceFile(
+          entry.path,
+          content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        yield source;
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules') {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
 }

--- a/modules/schematics/tsconfig-build.json
+++ b/modules/schematics/tsconfig-build.json
@@ -4,6 +4,7 @@
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
     "moduleResolution": "node",
+    "downlevelIteration": true,
     "outDir": "../../dist/packages/schematics",
     "sourceMap": true,
     "inlineSources": true,

--- a/modules/store-devtools/schematics-core/index.ts
+++ b/modules/store-devtools/schematics-core/index.ts
@@ -33,6 +33,7 @@ export {
   ReplaceChange,
   createReplaceChange,
   createChangeRecorder,
+  commitChanges,
 } from './utility/change';
 
 export { AppConfig, getWorkspace, getWorkspacePath } from './utility/config';

--- a/modules/store-devtools/schematics-core/utility/ast-utils.ts
+++ b/modules/store-devtools/schematics-core/utility/ast-utils.ts
@@ -687,7 +687,7 @@ export function replaceImport(
     })
     .filter(({ hit }) => hit)
     .map(({ specifier, text }) =>
-      createReplaceChange(sourceFile, path, specifier!, text!, importToBe)
+      createReplaceChange(sourceFile, specifier!, text!, importToBe)
     );
 
   return changes;

--- a/modules/store-devtools/schematics-core/utility/change.ts
+++ b/modules/store-devtools/schematics-core/utility/change.ts
@@ -136,12 +136,16 @@ export class ReplaceChange implements Change {
 
 export function createReplaceChange(
   sourceFile: ts.SourceFile,
-  path: Path,
   node: ts.Node,
   oldText: string,
   newText: string
 ): ReplaceChange {
-  return new ReplaceChange(path, node.getStart(sourceFile), oldText, newText);
+  return new ReplaceChange(
+    sourceFile.fileName,
+    node.getStart(sourceFile),
+    oldText,
+    newText
+  );
 }
 
 export function createChangeRecorder(
@@ -161,4 +165,14 @@ export function createChangeRecorder(
     }
   }
   return recorder;
+}
+
+export function commitChanges(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length === 0) {
+    return false;
+  }
+
+  const recorder = createChangeRecorder(tree, path, changes);
+  tree.commitUpdate(recorder);
+  return true;
 }

--- a/modules/store-devtools/schematics-core/utility/visit-utils.ts
+++ b/modules/store-devtools/schematics-core/utility/visit-utils.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { Tree } from '@angular-devkit/schematics';
+import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
   tree: Tree,
@@ -10,24 +10,35 @@ export function visitTSSourceFiles<Result = void>(
   ) => Result | undefined
 ): Result | undefined {
   let result: Result | undefined = undefined;
-
-  tree.visit(path => {
-    if (!path.endsWith('.ts')) {
-      return;
-    }
-
-    const sourceFile = ts.createSourceFile(
-      path,
-      tree.read(path)!.toString(),
-      ts.ScriptTarget.Latest
-    );
-
-    if (sourceFile.isDeclarationFile) {
-      return;
-    }
-
+  for (const sourceFile of visit(tree.root)) {
     result = visitor(sourceFile, tree, result);
-  });
+  }
 
   return result;
+}
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        const source = ts.createSourceFile(
+          entry.path,
+          content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        yield source;
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules') {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
 }

--- a/modules/store-devtools/tsconfig-build.json
+++ b/modules/store-devtools/tsconfig-build.json
@@ -11,6 +11,7 @@
     "noEmitOnError": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "downlevelIteration": true,
     "outDir": "../../dist/packages/store-devtools",
     "paths": {
       "@ngrx/store": ["../../dist/packages/store"]

--- a/modules/store/schematics-core/index.ts
+++ b/modules/store/schematics-core/index.ts
@@ -33,6 +33,7 @@ export {
   ReplaceChange,
   createReplaceChange,
   createChangeRecorder,
+  commitChanges,
 } from './utility/change';
 
 export { AppConfig, getWorkspace, getWorkspacePath } from './utility/config';

--- a/modules/store/schematics-core/utility/ast-utils.ts
+++ b/modules/store/schematics-core/utility/ast-utils.ts
@@ -687,7 +687,7 @@ export function replaceImport(
     })
     .filter(({ hit }) => hit)
     .map(({ specifier, text }) =>
-      createReplaceChange(sourceFile, path, specifier!, text!, importToBe)
+      createReplaceChange(sourceFile, specifier!, text!, importToBe)
     );
 
   return changes;

--- a/modules/store/schematics-core/utility/change.ts
+++ b/modules/store/schematics-core/utility/change.ts
@@ -136,12 +136,16 @@ export class ReplaceChange implements Change {
 
 export function createReplaceChange(
   sourceFile: ts.SourceFile,
-  path: Path,
   node: ts.Node,
   oldText: string,
   newText: string
 ): ReplaceChange {
-  return new ReplaceChange(path, node.getStart(sourceFile), oldText, newText);
+  return new ReplaceChange(
+    sourceFile.fileName,
+    node.getStart(sourceFile),
+    oldText,
+    newText
+  );
 }
 
 export function createChangeRecorder(
@@ -161,4 +165,14 @@ export function createChangeRecorder(
     }
   }
   return recorder;
+}
+
+export function commitChanges(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length === 0) {
+    return false;
+  }
+
+  const recorder = createChangeRecorder(tree, path, changes);
+  tree.commitUpdate(recorder);
+  return true;
 }

--- a/modules/store/schematics-core/utility/visit-utils.ts
+++ b/modules/store/schematics-core/utility/visit-utils.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { Tree } from '@angular-devkit/schematics';
+import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
   tree: Tree,
@@ -10,24 +10,35 @@ export function visitTSSourceFiles<Result = void>(
   ) => Result | undefined
 ): Result | undefined {
   let result: Result | undefined = undefined;
-
-  tree.visit(path => {
-    if (!path.endsWith('.ts')) {
-      return;
-    }
-
-    const sourceFile = ts.createSourceFile(
-      path,
-      tree.read(path)!.toString(),
-      ts.ScriptTarget.Latest
-    );
-
-    if (sourceFile.isDeclarationFile) {
-      return;
-    }
-
+  for (const sourceFile of visit(tree.root)) {
     result = visitor(sourceFile, tree, result);
-  });
+  }
 
   return result;
+}
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        const source = ts.createSourceFile(
+          entry.path,
+          content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        yield source;
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules') {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
 }

--- a/modules/store/tsconfig-build.json
+++ b/modules/store/tsconfig-build.json
@@ -5,6 +5,7 @@
     "stripInternal": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    "downlevelIteration": true,
     "module": "es2015",
     "moduleResolution": "node",
     "outDir": "../../dist/packages/store",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    "downlevelIteration": true,
     "noStrictGenericChecks": true,
     "lib": ["es2016", "dom"],
     "outDir": "../out-tsc/app",


### PR DESCRIPTION
Exclude node_modules
Only commit file updates when there are changes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Performance
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

This PR modifies the v8 migrations.

While running the `ng update` schematics, I noticed these were taking a long time.
Initially I thought this was because we did not exclude `node_modules`, but the main reason was that we committed changes on every ts file.

That's why I extracted the common logic into schematics-core, so we don't have this problem in the future.
