### PR TITLE
style(schematics): remove whitespace from effects template

### DIFF
--- a/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
+++ b/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
@@ -50,7 +50,7 @@ export class <%= classify(name) %>Effects {
 <% if (feature && !creators) { %>
   constructor(private actions$: Actions<<%= classify(name) %>Actions>) {}
 <% } else if (feature && creators) { %>
-  constructor(private actions$: Actions) {}  
+  constructor(private actions$: Actions) {}
 <% } else { %>
   constructor(private actions$: Actions) {}
 <% } %>


### PR DESCRIPTION
Generating an effect with the old template lead to TSLint warnings due to unnecessary whitespace

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Documentation has been added / updated (for bug fixes / features)~~

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Generated effects TS files have two whitespaces after the constructor brackets with `--creators`. This makes TSLint trigger the `no-trailing-whitespace` rule.


## What is the new behavior?

Removed the whitespace

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
