### PR TITLE
docs: fix typo in exported reducer function examples

### DIFF
--- a/projects/ngrx.io/content/guide/entity/adapter.md
+++ b/projects/ngrx.io/content/guide/entity/adapter.md
@@ -72,7 +72,7 @@ export const initialState: State = adapter.getInitialState({
 
 const userReducer = createReducer(initialState);
 
-export function reducer(state: State | undefined: action: Action) {
+export function reducer(state: State | undefined, action: Action) {
   return userReducer(state, action);
 }
 </code-example>
@@ -183,7 +183,7 @@ const userReducer = createReducer(
   })
 );
 
-export function reducer(state: State | undefined: action: Action) {
+export function reducer(state: State | undefined, action: Action) {
   return userReducer(state, action);
 }
 

--- a/projects/ngrx.io/content/guide/entity/recipes/additional-state-properties.md
+++ b/projects/ngrx.io/content/guide/entity/recipes/additional-state-properties.md
@@ -66,7 +66,7 @@ export const userReducer = createReducer(
   })
 );
 
-export function reducer(state: State | undefined: action: Action) {
+export function reducer(state: State | undefined, action: Action) {
   return userReducer(state, action);
 }
 </code-example>

--- a/projects/ngrx.io/content/guide/store/reducers.md
+++ b/projects/ngrx.io/content/guide/store/reducers.md
@@ -75,7 +75,7 @@ const scoreboardReducer = createReducer(
   on(ScoreboardPageActions.resetScore, state => ({ home: 0, away: 0 }))
 );
 
-export function reducer(state: State | undefined: action: Action) {
+export function reducer(state: State | undefined, action: Action) {
   return scoreboardReducer(state, action);
 }
 </code-example>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current exported reducer function documentation has a typo. It uses a colon to separate the `state` and `action` arguments instead of a comma.

## What is the new behavior?
Typo has been fixed.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
