### PR TITLE
feat(data): pass tag to EntityDataService

### DIFF
--- a/modules/data/src/dataservices/interfaces.ts
+++ b/modules/data/src/dataservices/interfaces.ts
@@ -4,13 +4,19 @@ import { Update } from '@ngrx/entity';
 /** A service that performs REST-like HTTP data operations for an entity collection */
 export interface EntityCollectionDataService<T> {
   readonly name: string;
-  add(entity: T): Observable<T>;
-  delete(id: number | string): Observable<number | string>;
-  getAll(): Observable<T[]>;
-  getById(id: any): Observable<T>;
-  getWithQuery(params: QueryParams | string): Observable<T[]>;
-  update(update: Update<T>): Observable<T>;
-  upsert(entity: T): Observable<T>;
+  add(entity: T, options?: EntityDataServiceOptions): Observable<T>;
+  delete(
+    id: number | string,
+    options?: EntityDataServiceOptions
+  ): Observable<number | string>;
+  getAll(options?: EntityDataServiceOptions): Observable<T[]>;
+  getById(id: any, options?: EntityDataServiceOptions): Observable<T>;
+  getWithQuery(
+    params: QueryParams | string,
+    options?: EntityDataServiceOptions
+  ): Observable<T[]>;
+  update(update: Update<T>, options?: EntityDataServiceOptions): Observable<T>;
+  upsert(entity: T, options?: EntityDataServiceOptions): Observable<T>;
 }
 
 export type HttpMethods = 'DELETE' | 'GET' | 'POST' | 'PUT';
@@ -29,4 +35,12 @@ export interface RequestData {
  */
 export interface QueryParams {
   [name: string]: string | string[];
+}
+
+/**
+ * The EntityDataServiceOptions interface contains a tag property
+ * which is from the EntityActionOptions.tag
+ */
+export interface EntityDataServiceOptions {
+  tag?: string;
 }

--- a/modules/data/src/effects/entity-effects.ts
+++ b/modules/data/src/effects/entity-effects.ts
@@ -111,28 +111,29 @@ export class EntityEffects {
   }
 
   private callDataService(action: EntityAction) {
-    const { entityName, entityOp, data } = action.payload;
+    const { entityName, entityOp, data, tag } = action.payload;
     const service = this.dataService.getService(entityName);
+    const options = { tag };
     switch (entityOp) {
       case EntityOp.QUERY_ALL:
       case EntityOp.QUERY_LOAD:
-        return service.getAll();
+        return service.getAll(options);
 
       case EntityOp.QUERY_BY_KEY:
-        return service.getById(data);
+        return service.getById(data, options);
 
       case EntityOp.QUERY_MANY:
-        return service.getWithQuery(data);
+        return service.getWithQuery(data, options);
 
       case EntityOp.SAVE_ADD_ONE:
-        return service.add(data);
+        return service.add(data, options);
 
       case EntityOp.SAVE_DELETE_ONE:
-        return service.delete(data);
+        return service.delete(data, options);
 
       case EntityOp.SAVE_UPDATE_ONE:
         const { id, changes } = data as Update<any>; // data must be Update<T>
-        return service.update(data).pipe(
+        return service.update(data, options).pipe(
           map(updatedEntity => {
             // Return an Update<T> with updated entity data.
             // If server returned entity data, merge with the changes that were sent
@@ -150,7 +151,7 @@ export class EntityEffects {
         );
 
       case EntityOp.SAVE_UPSERT_ONE:
-        return service.upsert(data).pipe(
+        return service.upsert(data, options).pipe(
           map(upsertedEntity => {
             const hasData =
               upsertedEntity && Object.keys(upsertedEntity).length > 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Now, `EntityDataService` can only accept `Entity` as parameter, the `tag` from `EntityCollectionService` is missing, we may need this `tag` in some use cases.

For example, Sometimes you may want to dispatch to different backend endpoints in the same operation of the EntityDataService, for example, let's say in frontend, we need to get `most downloaded items` and `most starred items`, if the backend provides a unified endpoint, we can just overwrite the `getWithQuery` operation, but if the backend provides two endpoints, we still want to use `getWithQuery` mechanism, in this case, we can use `tag`.
## What is the new behavior?

In the case I describe above, we can implement the `CustomDataService` like this,

```typescript
export class HeroDataService extends DefaultDataService&lt;Hero&gt; {
  getWithQuery(params: string | QueryParams, options?: EntityDataServiceOptions): Observable&lt;Hero[]&gt; {
    let data$;
    if (options && options.tag) {
      if (options.tag === 'MOST_DOWNLOADED') {
        data$ = getData('${serverUrl}/mostdownloaded');
      } else if (options.tag === 'MOST_STARRED') {
        data$ = getData('${serverUrl}/moststarred');
      }
    }
    if (!data$) {
      data$ = super.getWithQuery(params);
    }
    return data$.pipe(map(heroes => heroes.map(hero => this.mapHero(hero))));
  }
}
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

