### PR TITLE
docs: add roboto font weights to support md's bold

### DIFF
--- a/projects/ngrx.io/src/index.html
+++ b/projects/ngrx.io/src/index.html
@@ -23,6 +23,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Droid+Sans+Mono" rel="stylesheet">
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
   <!-- -->
 
   <link rel="manifest" href="pwa-manifest.json">

--- a/projects/ngrx.io/src/styles/0-base/_typography.scss
+++ b/projects/ngrx.io/src/styles/0-base/_typography.scss
@@ -106,7 +106,7 @@ aio-shell.page-home .app-toolbar a {
 }
 
 strong {
-  font-weight: 500;
+  font-weight: $bold-font-weight;
 }
 
 table {

--- a/projects/ngrx.io/src/styles/_constants.scss
+++ b/projects/ngrx.io/src/styles/_constants.scss
@@ -1,6 +1,7 @@
 // TYPOGRAPHY
 $main-font: "Roboto","Helvetica Neue Light","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
 $code-font: "Droid Sans Mono", monospace;
+$bold-font-weight: 600;
 
 // Z-LAYER
 $layer-1: 1;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit

## PR Type
added 

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
markdown `**` bold feature generates into `<strong></strong>` element, which set the font weights of the content between to "500".
currently, the docs are missing roboto's 500 weight so the bold content doesn't look bold.

## What is the new behavior?
content wrapped by `**` looks bolder.
