### PR TITLE
docs: update store recipes to clarify proper use of META_REDUCER token in libs

### DIFF
--- a/projects/ngrx.io/content/guide/store/recipes/injecting.md
+++ b/projects/ngrx.io/content/guide/store/recipes/injecting.md
@@ -77,11 +77,22 @@ export function getMetaReducers(
       provide: META_REDUCERS,
       deps: [SomeService],
       useFactory: getMetaReducers,
+      multi: true,
     },
   ],
 })
 export class AppModule {}
 </code-example>
+
+<div class="alert is-important">
+
+Careful attention should be called to the use of the `multi` 
+property in the provider here for `META_REDUCERS`. As this injection token may be utilized 
+by many libraries concurrently, specifying `multi: true` is critical to ensuring that all 
+library meta reducers are applied to any project that consumes multiple NgRx libraries with 
+registered meta reducers.
+
+</div>
 
 
 ## Injecting Feature Config


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Current documentation for store/recipes/injecting.md for META_REDUCERS injection token is incomplete. While attempting to add a meta reducer from a library I am implementing, the question arose about whether the use of `multi: true` was appropriate when using the META_REDUCERS token. 

Current documentation, as well as current third party library implementations, do NOT make use of `multi` at all. Lack of use of `multi: true` presents a problem when multiple third-party @ngrx libraries are used simultaneously, as it would most likely be "last in wins" for whichever META_REDUCER was actually added to the set of meta reducers applied during runtime. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

After verification with Wes Grimes and checking of the @ngrx/store source code, it was determined that use of `multi: true` on all providers in third-party libraries that use the `META_REDUCERS` injection token from @ngrx is indeed appropriate and necessary.

Documentation now specifies multi use in both code example and warns of potential consequences of improper use in third party libraries. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The hope is that this documentation change will ensure proper usage of the `META_REDUCERS` token for all library implementors who find the proper recipes documentation. Further evangelization of proper use of the `META_REDUCERS` token for library implementors is recommended, as other libraries as well as code examples in existing articles do not use `multi: true` and could lead to improper runtime behavior in the presence of multiple libraries that use the `META_REDUCERS` injection token. 
