### PR TITLE
fix(data): allow ChangeSetItemFactory to update entities with number ids

### DIFF
--- a/modules/data/src/actions/entity-cache-change-set.ts
+++ b/modules/data/src/actions/entity-cache-change-set.ts
@@ -85,7 +85,7 @@ export class ChangeSetItemFactory {
   }
 
   /** Create the ChangeSetUpdate for Updates of entities of the given entity type */
-  update<T extends { id: string }>(
+  update<T extends { id: string | number }>(
     entityName: string,
     updates: Update<T> | Update<T>[]
   ): ChangeSetUpdate<T> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`ChangeSetItemFactory.update` only allows for entities with `string` type IDs

Closes #1988 

## What is the new behavior?

`ChangeSetItemFactory.update` allows for entities with `string` or `number` type IDs, to match with `Update<T>`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
