### PR TITLE
fix(store): immutability check IE compatibility

### DIFF
--- a/modules/store/src/meta-reducers/immutability_reducer.ts
+++ b/modules/store/src/meta-reducers/immutability_reducer.ts
@@ -20,16 +20,20 @@ function freeze(target: any) {
   const targetIsFunction = isFunction(target);
 
   Object.getOwnPropertyNames(target).forEach(prop => {
-    const propValue = target[prop];
     if (
       hasOwnProperty(target, prop) &&
       (targetIsFunction
         ? prop !== 'caller' && prop !== 'callee' && prop !== 'arguments'
-        : true) &&
-      (isObjectLike(propValue) || isFunction(propValue)) &&
-      !Object.isFrozen(propValue)
+        : true)
     ) {
-      freeze(propValue);
+      const propValue = target[prop];
+
+      if (
+        (isObjectLike(propValue) || isFunction(propValue)) &&
+        !Object.isFrozen(propValue)
+      ) {
+        freeze(propValue);
+      }
     }
   });
 


### PR DESCRIPTION
IE errors when attempting to access the `caller` property of a function,
so rearrange the freeze function to check for this first.

Fixes #1991

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)

This shouldn't change the logic, so I think it should be covered by the existing tests?

- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
```

## What is the current behavior?

If a store state object contains a function, the immutability check's freeze function will fail in IE. This is a known issue that [also affected ngrx-store-freeze for a while](https://github.com/brandonroberts/ngrx-store-freeze/issues/7) and necessitated switching to [deep-freeze-strict](https://www.npmjs.com/package/deep-freeze-strict) 

It looks like whoever wrote the freeze function referenced deep-freeze-strict's code but perhaps didn't realise why the check for certain properties on a function were there, and so rearranged things in a way that broke it.

Closes #1991 

## What is the new behavior?

The `freeze` function now delays accessing the property until after the check.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
