### PR TITLE
fix(store): add missing StoreConfig and RootStoreConfig exports

### DIFF
--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -47,5 +47,7 @@ export {
   StoreModule,
   StoreRootModule,
   StoreFeatureModule,
+  RootStoreConfig,
+  StoreConfig,
 } from './store_module';
 export { on, createReducer } from './reducer_creator';


### PR DESCRIPTION
These were missing from `modules/store/src/index.ts`.

Closes ngrx/platform#2007

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`@ngrx/store` does not export the `StoreConfig` and `RootStoreConfig` interfaces from `modules/store/src.index.ts`, which it should per the NgRx guide.

Closes #2007

## What is the new behavior?
`@ngrx/store` now exports the `StoreConfig` and `RootStoreConfig` modules per [Using Dependency Injection -> Injecting Feature Config](https://ngrx.io/guide/store/recipes/injecting#injecting-feature-config)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information