### PR TITLE
refactor(store): give createReducer generic action

### DIFF
--- a/modules/store/src/reducer_creator.ts
+++ b/modules/store/src/reducer_creator.ts
@@ -225,18 +225,18 @@ export function on(
  * }
  * ```
  */
-export function createReducer<S>(
+export function createReducer<S, A extends Action = Action>(
   initialState: S,
   ...ons: On<S>[]
-): ActionReducer<S> {
-  const map = new Map<string, ActionReducer<S>>();
+): ActionReducer<S, A> {
+  const map = new Map<string, ActionReducer<S, A>>();
   for (let on of ons) {
     for (let type of on.types) {
       map.set(type, on.reducer);
     }
   }
 
-  return function(state: S = initialState, action: Action): S {
+  return function(state: S = initialState, action: A): S {
     const reducer = map.get(action.type);
     return reducer ? reducer(state, action) : state;
   };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, createReducer requires that entities be of the Action type, but we have a use case that requires custom action types.

## What is the new behavior?

This just makes createReducer generic, allowing for other types to be passed in.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
