### PR TITLE
fix(effects): resubscribe every time and error occurs (#2023)

### DIFF
--- a/modules/effects/spec/effect_sources.spec.ts
+++ b/modules/effects/spec/effect_sources.spec.ts
@@ -248,9 +248,9 @@ describe('EffectSources', () => {
       it('should resubscribe on error by default', () => {
         class Eff {
           @Effect()
-          b$ = hot('a--b--c--d').pipe(
+          b$ = hot('a--e--b--e--c--e--d').pipe(
             map(v => {
-              if (v == 'b') throw new Error('An Error');
+              if (v == 'e') throw new Error('An Error');
               return v;
             })
           );
@@ -258,8 +258,8 @@ describe('EffectSources', () => {
 
         const sources$ = of(new Eff());
 
-        //                       👇 'b' is ignored.
-        const expected = cold('a-----c--d');
+        //                       👇'e' is ignored.
+        const expected = cold('a-----b-----c-----d');
 
         expect(toActions(sources$)).toBeObservable(expected);
       });

--- a/modules/effects/src/effects_resolver.ts
+++ b/modules/effects/src/effects_resolver.ts
@@ -24,14 +24,19 @@ export function mergeEffects(
           ? sourceInstance[propertyName]()
           : sourceInstance[propertyName];
 
+      const resubscribeInCaseOfError = (
+        observable$: Observable<any>
+      ): Observable<any> =>
+        observable$.pipe(
+          catchError(error => {
+            if (errorHandler) errorHandler.handleError(error);
+            // Return observable that produces this particular effect
+            return resubscribeInCaseOfError(observable$);
+          })
+        );
+
       const resubscribable$ = resubscribeOnError
-        ? observable$.pipe(
-            catchError(error => {
-              if (errorHandler) errorHandler.handleError(error);
-              // Return observable that produces this particular effect
-              return observable$;
-            })
-          )
+        ? resubscribeInCaseOfError(observable$)
         : observable$;
 
       if (dispatch === false) {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2023

## What is the new behavior?

The effects will resubscribe every time an error occurs in the stream.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
