### PR TITLE
docs: removed unnecessary 'Effect' decorator import and replaced it w…

### DIFF
--- a/projects/ngrx.io/content/guide/effects/index.md
+++ b/projects/ngrx.io/content/guide/effects/index.md
@@ -104,7 +104,7 @@ To show how you handle loading movies from the example above, let's look at `Mov
 
 <code-example header="movie.effects.ts">
 import { Injectable } from '@angular/core';
-import { Actions, Effect, ofType } from '@ngrx/effects';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { EMPTY } from 'rxjs';
 import { map, mergeMap, catchError } from 'rxjs/operators';
 import { MoviesService } from './movies.service';
@@ -150,7 +150,7 @@ Effects are built on top of observable streams provided by RxJS. Effects are lis
 
 <code-example header="movie.effects.ts">
 import { Injectable } from '@angular/core';
-import { Actions, Effect, ofType } from '@ngrx/effects';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
 import { map, mergeMap, catchError } from 'rxjs/operators';
 import { MoviesService } from './movies.service';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

In the 'Writing Effects' and 'Handling Errors' code samples (in [effects](https://ngrx.io/guide/effects) documentation page), the 'Effect' decorator is unnecessary and the 'createEffect' function, which is required, is missing.

## What is the new behavior?

The code samples are now correctly importing the required 'createEffect' function instead of the unused 'Effect' decorator.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
