### PR TITLE
fix(store): ensure type-safety of select()

### DIFF
--- a/modules/store/spec/fixtures/sub.ts
+++ b/modules/store/spec/fixtures/sub.ts
@@ -1,0 +1,12 @@
+export const SUB_PROPERTY = 'SUB_PROPERTY';
+
+export function subReducer(state = {}, { type, payload }: any) {
+  switch (type) {
+    case SUB_PROPERTY:
+      const newState = state ? { ...state } : { property: undefined };
+      newState.property = payload;
+      return newState;
+    default:
+      return state;
+  }
+}

--- a/modules/store/spec/store.spec.ts
+++ b/modules/store/spec/store.spec.ts
@@ -23,12 +23,17 @@ import {
 } from './fixtures/counter';
 import Spy = jasmine.Spy;
 import { take } from 'rxjs/operators';
+import { SUB_PROPERTY, subReducer } from './fixtures/sub';
+import { Observable } from 'rxjs';
 
 interface TestAppSchema {
   counter1: number;
   counter2: number;
   counter3: number;
   counter4?: number;
+  sub?: {
+    property: number;
+  };
 }
 
 describe('ngRx Store', () => {
@@ -43,6 +48,7 @@ describe('ngRx Store', () => {
       counter1: counterReducer,
       counter2: counterReducer,
       counter3: counterReducer,
+      sub: subReducer,
     };
 
     TestBed.configureTestingModule({
@@ -56,12 +62,12 @@ describe('ngRx Store', () => {
   describe('initial state', () => {
     it('should handle an initial state object', (done: any) => {
       setup();
-      testStoreValue({ counter1: 0, counter2: 1, counter3: 0 }, done);
+      testStoreValue({ counter1: 0, counter2: 1, counter3: 0, sub: {} }, done);
     });
 
     it('should handle an initial state function', (done: any) => {
       setup(() => ({ counter1: 0, counter2: 5 }));
-      testStoreValue({ counter1: 0, counter2: 5, counter3: 0 }, done);
+      testStoreValue({ counter1: 0, counter2: 5, counter3: 0, sub: {} }, done);
     });
 
     it('should keep initial state values when state is partially initialized', (done: DoneFn) => {
@@ -203,6 +209,27 @@ describe('ngRx Store', () => {
       const counter1Values = { i: 0, v: 1, w: 2, x: 1, y: 0, z: 1 };
 
       expect(counterStateWithString).toBeObservable(
+        hot(stateSequence, counter1Values)
+      );
+    });
+
+    it('should let you select state with a sub-property key name', () => {
+      const counterSteps = hot('--a', {
+        a: { type: SUB_PROPERTY, payload: 55 },
+      });
+
+      counterSteps.subscribe(action => store.dispatch(action));
+
+      const subPropertyStateWithString: Observable<number> = store.pipe(
+        select('sub', 'property')
+      );
+      // uncommenting the next line should result in a compilation error
+      // const subProperty2StateWithString: boolean = store.pipe(select('sub', 'nonExistentProperty'));
+
+      const stateSequence = 'i-v';
+      const counter1Values = { i: undefined, v: 55 };
+
+      expect(subPropertyStateWithString).toBeObservable(
         hot(stateSequence, counter1Values)
       );
     });

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -62,16 +62,29 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
     key5: e,
     key6: f
   ): Observable<T[a][b][c][d][e][f]>;
-  /**
-   * This overload is used to support spread operator with
-   * fixed length tuples type in typescript 2.7
-   */
-  select<K = any>(...paths: string[]): Observable<K>;
-  select<Props = any>(
-    pathOrMapFn: ((state: T, props?: Props) => any) | string,
+  select<
+    T,
+    a extends keyof T,
+    b extends keyof T[a],
+    c extends keyof T[a][b],
+    d extends keyof T[a][b][c],
+    e extends keyof T[a][b][c][d],
+    f extends keyof T[a][b][c][d][e],
+    K = any
+  >(
+    key1: a,
+    key2: b,
+    key3: c,
+    key4: d,
+    key5: e,
+    key6: f,
+    ...paths: string[]
+  ): Observable<K>;
+  select<T, Props = any>(
+    pathOrMapFn: ((state: T, props?: Props) => any) | keyof T,
     ...paths: string[]
   ): Observable<any> {
-    return select.call(null, pathOrMapFn, ...paths)(this);
+    return select.apply(null, arguments as any)(this);
   }
 
   lift<R>(operator: Operator<T, R>): Store<R> {
@@ -175,16 +188,26 @@ export function select<
   key5: e,
   key6: f
 ): (source$: Observable<T>) => Observable<T[a][b][c][d][e][f]>;
-/**
- * This overload is used to support spread operator with
- * fixed length tuples type in typescript 2.7
- */
-export function select<T, Props = any, K = any>(
-  propsOrPath: Props,
+export function select<
+  T,
+  a extends keyof T,
+  b extends keyof T[a],
+  c extends keyof T[a][b],
+  d extends keyof T[a][b][c],
+  e extends keyof T[a][b][c][d],
+  f extends keyof T[a][b][c][d][e],
+  K = any
+>(
+  key1: a,
+  key2: b,
+  key3: c,
+  key4: d,
+  key5: e,
+  key6: f,
   ...paths: string[]
 ): (source$: Observable<T>) => Observable<K>;
 export function select<T, Props, K>(
-  pathOrMapFn: ((state: T, props?: Props) => any) | string,
+  pathOrMapFn: ((state: T, props?: Props) => any) | keyof T,
   propsOrPath: Props | string,
   ...paths: string[]
 ) {


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
With e.g. 
```typescript
interface State {
  sub: {
    property: number;
  }
}
```
the invokation of `select()` is allowed with any list of strings (e.g. `select('sub', 'property')`), even if the properties do not exist in the `State` defined, e.g. 
```typescript
select('sub', 'somethingElse')
```

Closes #2070

## What is the new behavior?
The string path parts passed to `select()` must be a key of `State`.
```typescript
select('sub', 'property')
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

any non-type-safe invokation of `select()` will throw a compilation error, e.g. `store.pipe(select('sub', 'nonExistentProperty')` will fail if `nonExistentProperty` is not a key of `sub.nonExistentProperty` is not a valid property of the `State`
This also applies to fixed-length tuple types e.g. `[string, string]`, which can be circumvented with a better typing e.g.
```typescript
type MyPath<T, a extends keyof T = keyof T, b extends keyof T[a] = keyof T[a]> = [a, b];
const path: MyPath<State> = ['sub', 'property'];
```

## Other information
