### PR TITLE
docs(data): improve DefaultDataServiceConfig root parameter docs

### DIFF
--- a/modules/data/src/dataservices/default-data-service-config.ts
+++ b/modules/data/src/dataservices/default-data-service-config.ts
@@ -5,7 +5,10 @@ import { HttpUrlGenerator, EntityHttpResourceUrls } from './http-url-generator';
  * such as the `DefaultDataService<T>`.
  */
 export abstract class DefaultDataServiceConfig {
-  /** root path of the web api (default: 'api') */
+  /**
+   * root path of the web api.  may also include protocol, domain, and port
+   * for remote api, e.g.: `'https://api-domain.com:8000/api/v1'` (default: 'api')
+   */
   root?: string;
   /**
    * Known entity HttpResourceUrls.

--- a/projects/ngrx.io/content/guide/data/entity-dataservice.md
+++ b/projects/ngrx.io/content/guide/data/entity-dataservice.md
@@ -101,7 +101,7 @@ The shared configuration values are almost always specific to the application an
 The NgRx Data library defines a `DefaultDataServiceConfig` for 
 conveying shared configuration to an entity collection data service.
 
-The most important configuration property, `root`, returns the _root_ of every web api URL, the parts that come before the entity resource name. If you are using a remote API, this value can include the protocol, domain, port, and root path, e.g.: `'https://my-api-domain.com:8000/api/v1'`.
+The most important configuration property, `root`, returns the _root_ of every web api URL, the parts that come before the entity resource name. If you are using a remote API, this value can include the protocol, domain, port, and root path, such as `https://my-api-domain.com:8000/api/v1`.
 
 For a `DefaultDataService<T>`, the default value is `'api'`, which results in URLs such as `api/heroes`.
 

--- a/projects/ngrx.io/content/guide/data/entity-dataservice.md
+++ b/projects/ngrx.io/content/guide/data/entity-dataservice.md
@@ -101,7 +101,7 @@ The shared configuration values are almost always specific to the application an
 The NgRx Data library defines a `DefaultDataServiceConfig` for 
 conveying shared configuration to an entity collection data service.
 
-The most important configuration property, `root`, returns the _root_ of every web api URL, the parts that come before the entity resource name.
+The most important configuration property, `root`, returns the _root_ of every web api URL, the parts that come before the entity resource name. If you are using a remote API, this value can include the protocol, domain, port, and root path, e.g.: `'https://my-api-domain.com:8000/api/v1'`.
 
 For a `DefaultDataService<T>`, the default value is `'api'`, which results in URLs such as `api/heroes`.
 
@@ -121,7 +121,7 @@ First, create a custom configuration object of type `DefaultDataServiceConfig` :
 
 ```typescript
 const defaultDataServiceConfig: DefaultDataServiceConfig = {
-  root: 'api',
+  root: 'https://my-api-domain.com:8000/api/v1',
   timeout: 3000, // request timeout
 }
 ```


### PR DESCRIPTION
add more details for the DefaultDataServiceConfig api docs and Entity Dataservice
doc page.  specifically, added details and examples for providing a remote api to
the DefaultDataServiceConfig root parameter.  Current docs do not include this
information, and it this makes it clear how one would use a remote api, which is
a very common use case.

Closes #2071

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
No indication in the docs on how to set a remote API url.  The way the root parameter is described currently, implies that it is a root path, separate from the URL, which is not the case.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2071 

## What is the new behavior?
Documentation now provides more detailed information and an example of how to set a remote API server domain/port.  Updates were made to both the `DefaultDataServiceConfig API` page, and the `Architecture --> Entity Dataservices` page.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
