### PR TITLE
feat(store): add verbose error message for unprovided feature state in development mode

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -1,4 +1,5 @@
 import { Selector, SelectorWithProps } from './models';
+import { isDevMode } from '@angular/core';
 
 export type AnyFn = (...args: any[]) => any;
 
@@ -274,6 +275,7 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
     Selector<State, S1>,
     Selector<State, S2>,
     Selector<State, S3>,
+
     Selector<State, S4>,
     Selector<State, S5>,
     Selector<State, S6>
@@ -601,8 +603,19 @@ export function createFeatureSelector<T, V>(
 export function createFeatureSelector(
   featureName: any
 ): MemoizedSelector<any, any> {
-  return createSelector(
-    (state: any) => state[featureName],
-    (featureState: any) => featureState
-  );
+  return createSelector((state: any) => {
+    const featureState = state[featureName];
+    if (isDevMode() && featureState === undefined) {
+      console.error(
+        `The feature name \"${featureName}\" does ` +
+          'not exist in the state, therefore createFeatureSelector ' +
+          'cannot access it.  Be sure it is imported in a loaded module ' +
+          `using StoreModule.forRoot('${featureName}', ...) or ` +
+          `StoreModule.forFeature('${featureName}', ...).  If the default ` +
+          'state is intended to be undefined, as is the case with router ' +
+          'state, this development-only error message can be ignored.'
+      );
+    }
+    return featureState;
+  }, (featureState: any) => featureState);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [n/a] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1897 

## What is the new behavior?

Verbose error message when the developer attemps to access a selector without first registering the state in a module.

In the example-app, if we try to get something from books state on the login page:
```ts
export class LoginPageComponent implements OnInit {
  // ...
  constructor(private store: Store<fromAuth.State>, private bookStore: Store<fromBooks.State>) {
    bookStore.pipe(select(fromBooks.getAllBooks)).subscribe(val => console.log(val));
  }
  // ...
}
```
We get an error that accompanies the javascript "undefined" error that will help alert users to this common mistake:
<img width="693" alt="Screen Shot 2019-08-21 at 12 24 31 AM" src="https://user-images.githubusercontent.com/3779096/63402824-c34d7200-c3aa-11e9-9a5d-612c11b7a14d.png">


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
