### PR TITLE
docs: add missing @Injectable() decorator

### DIFF
--- a/projects/ngrx.io/content/guide/data/entity-metadata.md
+++ b/projects/ngrx.io/content/guide/data/entity-metadata.md
@@ -227,6 +227,7 @@ If the property you want to add comes from `backend`, you will need some additio
 Create a new class `AdditionalPersistenceResultHandler` that `extends DefaultPersistenceResultHandler` and overwrite the [handleSuccess](https://github.com/ngrx/platform/blob/master/modules/data/src/dataservices/persistence-result-handler.service.ts) method, the purpose is to parse the data received from `DataService`, retrieve the additional property, and then save this to the `action.payload`. Here is an example.
 
 ```typescript
+@Injectable()
 export class AdditionalPropertyPersistenceResultHandler extends DefaultPersistenceResultHandler {
   handleSuccess(originalAction: EntityAction): (data: any) => Action {
     const actionHandler = super.handleSuccess(originalAction);
@@ -249,6 +250,7 @@ export class AdditionalPropertyPersistenceResultHandler extends DefaultPersisten
 Following the prior step, we have added the additional property to the `action.payload`. Up next we need to set it to the instance of EntityCollection in the `reducer`. In order to accomplish that, we need to create an `AdditionalEntityCollectionReducerMethods` that `extends EntityCollectionReducerMethods`. In addition, we will need to overwrite the method to match your `action`. For example, if the additional property `foo` is only available in `queryMany action(triggered by EntityCollectionService.getWithQuery)`, we can follow this approach.
 
 ```typescript
+@Injectable()
 export class AdditionalEntityCollectionReducerMethods<T> extends EntityCollectionReducerMethods<T> {
   constructor(public entityName: string, public definition: EntityDefinition<T>) {
     super(entityName, definition);


### PR DESCRIPTION
The dependencies (e.g. Logger, EntityActionFactory, ...,) for `AdditionalEntityCollectionReducerMethods` and `AdditionalPropertyPersistenceResultHandler` cannot be inject when `@Injectable()` is missing.

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```