### PR TITLE
fix(data): set action input as Action type instead of EntityAction

### DIFF
--- a/modules/data/spec/actions/entity-action-operators.spec.ts
+++ b/modules/data/spec/actions/entity-action-operators.spec.ts
@@ -3,7 +3,6 @@ import { Action } from '@ngrx/store';
 import { Subject } from 'rxjs';
 
 import {
-  EntityAction,
   EntityActionFactory,
   EntityOp,
   ofEntityType,
@@ -21,7 +20,9 @@ describe('EntityAction Operators', () => {
   const entityActionFactory = new EntityActionFactory();
 
   let results: any[];
-  let actions: Subject<EntityAction>;
+
+  // in a real-world application, actions can contains any type of action
+  let actions: Subject<Action>;
 
   const testActions = {
     foo: <Action>{ type: 'Foo' },
@@ -43,7 +44,7 @@ describe('EntityAction Operators', () => {
   }
 
   beforeEach(() => {
-    actions = new Subject<EntityAction>();
+    actions = new Subject<Action>();
     results = [];
   });
 

--- a/modules/data/src/actions/entity-action-operators.ts
+++ b/modules/data/src/actions/entity-action-operators.ts
@@ -4,6 +4,7 @@ import { filter } from 'rxjs/operators';
 import { EntityAction } from './entity-action';
 import { EntityOp } from './entity-op';
 import { flattenArgs } from '../utils/utilities';
+import { Action } from '@ngrx/store';
 
 /**
  * Select actions concerning one of the allowed Entity operations
@@ -18,29 +19,29 @@ import { flattenArgs } from '../utils/utilities';
  */
 export function ofEntityOp<T extends EntityAction>(
   allowedOps: string[] | EntityOp[]
-): OperatorFunction<EntityAction, T>;
+): OperatorFunction<Action, T>;
 export function ofEntityOp<T extends EntityAction>(
   ...allowedOps: (string | EntityOp)[]
-): OperatorFunction<EntityAction, T>;
+): OperatorFunction<Action, T>;
 export function ofEntityOp<T extends EntityAction>(
   ...allowedEntityOps: any[]
-): OperatorFunction<EntityAction, T> {
+): OperatorFunction<Action, T> {
   const ops: string[] = flattenArgs(allowedEntityOps);
   switch (ops.length) {
     case 0:
       return filter(
-        (action: EntityAction): action is T =>
+        (action: any): action is T =>
           action.payload && action.payload.entityOp != null
       );
     case 1:
       const op = ops[0];
       return filter(
-        (action: EntityAction): action is T =>
+        (action: any): action is T =>
           action.payload && op === action.payload.entityOp
       );
     default:
       return filter(
-        (action: EntityAction): action is T => {
+        (action: any): action is T => {
           const entityOp = action.payload && action.payload.entityOp;
           return entityOp && ops.some(o => o === entityOp);
         }
@@ -62,29 +63,29 @@ export function ofEntityOp<T extends EntityAction>(
  */
 export function ofEntityType<T extends EntityAction>(
   allowedEntityNames?: string[]
-): OperatorFunction<EntityAction, T>;
+): OperatorFunction<Action, T>;
 export function ofEntityType<T extends EntityAction>(
   ...allowedEntityNames: string[]
-): OperatorFunction<EntityAction, T>;
+): OperatorFunction<Action, T>;
 export function ofEntityType<T extends EntityAction>(
   ...allowedEntityNames: any[]
-): OperatorFunction<EntityAction, T> {
+): OperatorFunction<Action, T> {
   const names: string[] = flattenArgs(allowedEntityNames);
   switch (names.length) {
     case 0:
       return filter(
-        (action: EntityAction): action is T =>
+        (action: any): action is T =>
           action.payload && action.payload.entityName != null
       );
     case 1:
       const name = names[0];
       return filter(
-        (action: EntityAction): action is T =>
+        (action: any): action is T =>
           action.payload && name === action.payload.entityName
       );
     default:
       return filter(
-        (action: EntityAction): action is T => {
+        (action: any): action is T => {
           const entityName = action.payload && action.payload.entityName;
           return !!entityName && names.some(n => n === entityName);
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

In a real-world application, you create effects and filter the `actions$` which is of type `Action` using `ofType` operator. But using the `ofEntityType` (and `ofEntityOp`), the `EntityAction` type is enforced so that using these operators with `actions$` is impossible... 

## What is the new behavior?

Updated the `OperatorFunction<EntityAction, T>` to `OperatorFunction<Action, T>` to fix the problem.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
