### PR TITLE
refactor(data): use createEffect function instead of decorator

### DIFF
--- a/modules/data/spec/entity-data.module.spec.ts
+++ b/modules/data/spec/entity-data.module.spec.ts
@@ -6,7 +6,7 @@ import {
   Store,
   StoreModule,
 } from '@ngrx/store';
-import { Actions, Effect, EffectsModule } from '@ngrx/effects';
+import { Actions, EffectsModule, createEffect } from '@ngrx/effects';
 
 // Not using marble testing
 import { TestBed } from '@angular/core/testing';
@@ -35,11 +35,12 @@ const EC_METAREDUCER_TOKEN = new InjectionToken<
 
 @Injectable()
 class TestEntityEffects {
-  @Effect()
-  test$: Observable<Action> = this.actions.pipe(
-    // tap(action => console.log('test$ effect', action)),
-    ofEntityOp(persistOps),
-    map(this.testHook)
+  test$: Observable<Action> = createEffect(() =>
+    this.actions.pipe(
+      // tap(action => console.log('test$ effect', action)),
+      ofEntityOp(persistOps),
+      map(this.testHook)
+    )
   );
 
   testHook(action: EntityAction) {

--- a/modules/data/src/effects/entity-cache-effects.ts
+++ b/modules/data/src/effects/entity-cache-effects.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { Action } from '@ngrx/store';
-import { Actions, Effect, ofType } from '@ngrx/effects';
+import { Actions, ofType, createEffect } from '@ngrx/effects';
 
 import {
   asyncScheduler,
@@ -63,18 +63,22 @@ export class EntityCacheEffects {
   /**
    * Observable of SAVE_ENTITIES_CANCEL actions with non-null correlation ids
    */
-  @Effect({ dispatch: false })
-  saveEntitiesCancel$: Observable<SaveEntitiesCancel> = this.actions.pipe(
-    ofType(EntityCacheAction.SAVE_ENTITIES_CANCEL),
-    filter((a: SaveEntitiesCancel) => a.payload.correlationId != null)
+  saveEntitiesCancel$: Observable<SaveEntitiesCancel> = createEffect(
+    () =>
+      this.actions.pipe(
+        ofType(EntityCacheAction.SAVE_ENTITIES_CANCEL),
+        filter((a: SaveEntitiesCancel) => a.payload.correlationId != null)
+      ),
+    { dispatch: false }
   );
 
-  @Effect()
   // Concurrent persistence requests considered unsafe.
   // `mergeMap` allows for concurrent requests which may return in any order
-  saveEntities$: Observable<Action> = this.actions.pipe(
-    ofType(EntityCacheAction.SAVE_ENTITIES),
-    mergeMap((action: SaveEntities) => this.saveEntities(action))
+  saveEntities$: Observable<Action> = createEffect(() =>
+    this.actions.pipe(
+      ofType(EntityCacheAction.SAVE_ENTITIES),
+      mergeMap((action: SaveEntities) => this.saveEntities(action))
+    )
   );
 
   /**

--- a/modules/data/src/effects/entity-effects.ts
+++ b/modules/data/src/effects/entity-effects.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { Action } from '@ngrx/store';
-import { Actions, Effect } from '@ngrx/effects';
+import { Actions, createEffect } from '@ngrx/effects';
 import { Update } from '@ngrx/entity';
 
 import { asyncScheduler, Observable, of, race, SchedulerLike } from 'rxjs';
@@ -36,18 +36,22 @@ export class EntityEffects {
   /**
    * Observable of non-null cancellation correlation ids from CANCEL_PERSIST actions
    */
-  @Effect({ dispatch: false })
-  cancel$: Observable<any> = this.actions.pipe(
-    ofEntityOp(EntityOp.CANCEL_PERSIST),
-    map((action: EntityAction) => action.payload.correlationId),
-    filter(id => id != null)
+  cancel$: Observable<any> = createEffect(
+    () =>
+      this.actions.pipe(
+        ofEntityOp(EntityOp.CANCEL_PERSIST),
+        map((action: EntityAction) => action.payload.correlationId),
+        filter(id => id != null)
+      ),
+    { dispatch: false }
   );
 
-  @Effect()
   // `mergeMap` allows for concurrent requests which may return in any order
-  persist$: Observable<Action> = this.actions.pipe(
-    ofEntityOp(persistOps),
-    mergeMap(action => this.persist(action))
+  persist$: Observable<Action> = createEffect(() =>
+    this.actions.pipe(
+      ofEntityOp(persistOps),
+      mergeMap(action => this.persist(action))
+    )
   );
 
   constructor(

--- a/modules/data/src/entity-data.module.ts
+++ b/modules/data/src/entity-data.module.ts
@@ -110,7 +110,7 @@ export class EntityDataModule {
   }
 
   /**
-   * Add another class instance that contains @Effect methods.
+   * Add another class instance that contains effects.
    * @param effectSourceInstance a class instance that implements effects.
    * Warning: undocumented @ngrx/effects API
    */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

## What is the new behavior?

Using `createEffect` instead of `@Effect` in the source code of `@ngrx/data`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
