### PR TITLE
docs(store): add note to use resetSelectors to prevent cross-test state bleeding

### DIFF
--- a/projects/ngrx.io/content/examples/testing-store/src/app/auth-guard.service.spec.ts
+++ b/projects/ngrx.io/content/examples/testing-store/src/app/auth-guard.service.spec.ts
@@ -34,4 +34,6 @@ describe('Auth Guard', () => {
 
     expect(guard.canActivate()).toBeObservable(expected);
   });
+
+  afterAll(() => store.resetSelectors());
 });

--- a/projects/ngrx.io/content/guide/store/testing.md
+++ b/projects/ngrx.io/content/guide/store/testing.md
@@ -74,6 +74,12 @@ Usage:
 
 In this example, we mock the `getLoggedIn` selector by using `overrideSelector`, passing in the `getLoggedIn` selector with a default mocked return value of `false`.  In the second test, we use `setResult()` to update the mock selector to return `true`.
 
+<div class="alert is-helpful">
+
+**Note:** You should reset overridden selectors using `resetSelectors()` to prevent other tests from using the overridden selector value.  This is shown in the above example.
+
+</div>
+
 Try the <live-example name="testing-store"></live-example>.
 
 ### Integration Testing

--- a/projects/ngrx.io/content/guide/store/testing.md
+++ b/projects/ngrx.io/content/guide/store/testing.md
@@ -76,7 +76,7 @@ In this example, we mock the `getLoggedIn` selector by using `overrideSelector`,
 
 <div class="alert is-helpful">
 
-**Note:** You should reset overridden selectors using `resetSelectors()` to prevent other tests from using the overridden selector value.  This is shown in the above example.
+**Note:** Reset overridden selectors using the `MockStore.resetSelectors()` method to prevent other tests from using the overridden selector value.  This is shown in the above example.
 
 </div>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2044

## What is the new behavior?

Show a workaround to prevent cross-test state bleeding using `afterAll` + `resetSelectors`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

