### PR TITLE
fix/feat(store): createReducer: on should not be overwritten

### DIFF
--- a/modules/store/spec/reducer_creator.spec.ts
+++ b/modules/store/spec/reducer_creator.spec.ts
@@ -86,6 +86,23 @@ import {on} from './modules/store/src/reducer_creator';
         state = fooBarReducer(state, bar({ bar: 54 }));
         expect(state).toEqual(['[foobar] FOO', '[foobar] BAR']);
       });
+
+      it('should support "on"s to have identical action types', () => {
+        const increase = createAction('[COUNTER] increase');
+
+        const counterReducer = createReducer(
+          0,
+          on(increase, state => state + 1),
+          on(increase, state => state + 1)
+        );
+
+        expect(typeof counterReducer).toEqual('function');
+
+        let state = 5;
+
+        state = counterReducer(state, increase());
+        expect(state).toEqual(7);
+      });
     });
   });
 });


### PR DESCRIPTION
createReducer should allow ons to take actions of same type and excute all ons to match the action dispatched

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
If the following is configured and initial state is 0, if `increase` action is dispatched, the next state is 2, because the the second `on` has same action type as the first `on`, and the first `on` is overwritten.
```
const increase = createAction('[COUNTER] INCREASE');
createReducer(0, on(increase, state = state + 1), on(increase, state = state + 2))
```

(Indirectly) Closes #1956 

## What is the new behavior?
In `createReducer`, `on` should not overwrite previous `on`s if they have the same action types.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
