### PR TITLE
docs(store): update advanced selector example

### DIFF
--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -346,5 +346,3 @@ Finally, the component will subscribe to the store, telling the number of state 
 // Subscribe to the store using the custom pipeable operator
 store.pipe(selectLastStateTransitions(3)).subscribe(/* .. */);
 </code-example>
-
-See the [advanced example live in action in a Stackblitz](https://stackblitz.com/edit/angular-ngrx-effects-1rj88y?file=app%2Fstore%2Ffoo.ts)

--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -333,7 +333,7 @@ export const selectLastStateTransitions = (count: number) => {
     select(selectProjectedValues),
     // Combines the last `count` state values in array
     scan((acc, curr) => {
-      return [ curr, acc[0], acc[1] ].filter(val => val !== undefined);
+      return [ curr, acc[0], acc[1] ].filter(val => val !== undefined).slice(0,count);
     }, [] as {foo: number; bar: string}[]) // XX: Explicit type hint for the array.
                                           // Equivalent to what is emitted by the selector
   );

--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -333,7 +333,7 @@ export const selectLastStateTransitions = (count: number) => {
     select(selectProjectedValues),
     // Combines the last `count` state values in array
     scan((acc, curr) => {
-      return [ curr, acc[0], acc[1] ].filter(val => val !== undefined).slice(0,count);
+      return [ curr, ...acc ].filter((val, index) => index < count && val !== undefined)
     }, [] as {foo: number; bar: string}[]) // XX: Explicit type hint for the array.
                                           // Equivalent to what is emitted by the selector
   );


### PR DESCRIPTION
The selectLastStateTransitions example should use the count parameter.

closes #2102

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The advanced selector example doesn't use the count parameter as explained in #2102 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Closes #2102 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
