### PR TITLE
feat(selectors):  deep-cached selectors

### DIFF
--- a/modules/store/src/cache/cache.util.ts
+++ b/modules/store/src/cache/cache.util.ts
@@ -1,0 +1,89 @@
+import { MemoizedSelector, MemoizedSelectorWithProps } from '@ngrx/store';
+import { LruCache } from 'modules/store/src/cache/lru.cache';
+import { FifoCache } from 'modules/store/src/cache/fifo.cache';
+
+export function validateCacheSize(cacheSize: number) {
+  if (cacheSize === undefined) {
+    throw new Error('Missing the required property "cacheSize".');
+  }
+  if (!Number.isInteger(cacheSize) || cacheSize <= 0) {
+    throw new Error(
+      'The "cacheSize" property must be a positive integer value.'
+    );
+  }
+}
+
+export const DEFAULT_CACHE_SIZE = 20;
+
+export function createUnboundedCache<
+  Props,
+  Cache extends
+    | MemoizedSelector<any, any>
+    | MemoizedSelectorWithProps<any, any, any>
+>(): SelectorCache<Cache> {
+  return new Map<Props, Cache>();
+}
+
+export enum CacheStrategy {
+  UNBOUNDED,
+  FIFO,
+  LRU,
+}
+
+export type KeySelector = (...args: any[]) => any;
+
+export interface CacheConfig<Props = any> {
+  maxSize?: number;
+  strategy?: CacheStrategy;
+  keySelector?: string | KeySelector;
+}
+
+export interface SelectorCache<
+  Cache extends
+    | MemoizedSelector<any, any>
+    | MemoizedSelectorWithProps<any, any, any>
+> {
+  get(key: any): Cache | undefined;
+
+  set(key: any, value: Cache): void;
+
+  delete(key: any): void;
+
+  clear(): void;
+}
+
+export function createCache<
+  Props,
+  Cache extends
+    | MemoizedSelector<any, any>
+    | MemoizedSelectorWithProps<any, any, any>
+>(cacheConfig: CacheConfig<Props> = {}): SelectorCache<Cache> {
+  switch (cacheConfig.strategy) {
+    case CacheStrategy.FIFO:
+      return new FifoCache<Props, Cache>(cacheConfig.maxSize);
+      break;
+    case CacheStrategy.LRU:
+      return new LruCache<Props, Cache>(cacheConfig.maxSize);
+      break;
+    case CacheStrategy.UNBOUNDED:
+    default:
+      return createUnboundedCache<Props, Cache>();
+  }
+}
+
+export const defaultKeySelector = (props: any) => props;
+
+export function createKeySelector<Props>(
+  cacheConfig: CacheConfig<Props>
+): KeySelector {
+  if (!cacheConfig.keySelector) return defaultKeySelector;
+  else {
+    if (typeof cacheConfig.keySelector === 'string') {
+      return (prop: any) => prop[cacheConfig.keySelector as keyof Props];
+    } else if (typeof cacheConfig.keySelector === 'function') {
+      return cacheConfig.keySelector;
+    } else {
+      throw new Error('keySelector must be a string or function');
+    }
+  }
+}

--- a/modules/store/src/cache/fifo.cache.ts
+++ b/modules/store/src/cache/fifo.cache.ts
@@ -1,0 +1,39 @@
+import {
+  DEFAULT_CACHE_SIZE,
+  SelectorCache,
+  validateCacheSize,
+} from 'modules/store/src/cache/cache.util';
+import { MemoizedSelector, MemoizedSelectorWithProps } from '@ngrx/store';
+
+export class FifoCache<
+  Props,
+  Cache extends
+    | MemoizedSelector<any, any>
+    | MemoizedSelectorWithProps<any, any, any>
+> implements SelectorCache<Cache> {
+  private cache = new Map<Props, Cache>();
+
+  constructor(private readonly cacheSize: number = DEFAULT_CACHE_SIZE) {
+    validateCacheSize(cacheSize);
+  }
+
+  set(key: Props, selectorFn: Cache) {
+    this.cache.set(key, selectorFn);
+    if (this.cache.size > this.cacheSize) {
+      const earliest = this.cache.keys().next().value;
+      this.delete(earliest);
+    }
+  }
+
+  get(key: Props) {
+    return this.cache.get(key);
+  }
+
+  delete(key: Props) {
+    this.cache.delete(key);
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+}

--- a/modules/store/src/cache/lru.cache.ts
+++ b/modules/store/src/cache/lru.cache.ts
@@ -1,0 +1,47 @@
+import { MemoizedSelector, MemoizedSelectorWithProps } from '@ngrx/store';
+import {
+  DEFAULT_CACHE_SIZE,
+  SelectorCache,
+  validateCacheSize,
+} from 'modules/store/src/cache/cache.util';
+
+export class LruCache<
+  Props,
+  Cache extends
+    | MemoizedSelector<any, any>
+    | MemoizedSelectorWithProps<any, any, any>
+> implements SelectorCache<Cache> {
+  private cache: Map<Props, Cache> = new Map();
+
+  constructor(private readonly cacheSize: number = DEFAULT_CACHE_SIZE) {
+    validateCacheSize(cacheSize);
+  }
+
+  set(key: Props, selectorFn: Cache) {
+    this.cache.set(key, selectorFn);
+
+    if (this.cache.size > this.cacheSize) {
+      const earliest = this.cache.keys().next().value;
+      this.delete(earliest);
+    }
+  }
+
+  get(key: Props) {
+    const value = this.cache.get(key);
+
+    // Register cache hit
+    if (this.cache.has(key)) {
+      this.delete(key);
+      this.cache.set(key, value as Cache);
+    }
+    return value;
+  }
+
+  delete(key: Props) {
+    this.cache.delete(key);
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+}

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -34,6 +34,8 @@ export {
   MemoizedSelectorWithProps,
   resultMemoize,
   DefaultProjectorFn,
+  createSelectorFactoryWithCache,
+  SelectorFactoryWithParam,
 } from './selector';
 export { State, StateObservable, reduceState } from './state';
 export {

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -35,6 +35,7 @@ export {
   resultMemoize,
   DefaultProjectorFn,
   createSelectorFactoryWithCache,
+  createCachedSelector,
   SelectorFactoryWithParam,
 } from './selector';
 export { State, StateObservable, reduceState } from './state';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
selectors with props are only cached when the props are equal by reference.
all underlying selectors are "dropped" if the prop is changed.
"deep-caching" allows selector function to cache its previous calls to underlaying selectors/projection when the props are re-used.
 
Closes #2104

## What is the new behavior?
2 proposed APIs are added here which provide the above functionality.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

* *I will rebase and update this PR by comments and directions - 
 I am still looking for feedback and suggestions on how to improving the typing/tests and obviously still need to write docs**