### PR TITLE
docs: cleanup code sample

### DIFF
--- a/projects/ngrx.io/content/guide/data/entity-metadata.md
+++ b/projects/ngrx.io/content/guide/data/entity-metadata.md
@@ -135,7 +135,7 @@ The demo uses this helper to create hero and villain filters. Here's how the app
  * matches the case-insensitive pattern.
  */
 export function nameAndSayingFilter(entities: Villain[], pattern: string) {
-  return PropsFilterFnFactory < Villain > ['name', 'saying'](guide/data/entities, pattern);
+  return PropsFilterFnFactory < Villain > ['name', 'saying'](entities, pattern);
 }
 ```
 

--- a/projects/ngrx.io/content/guide/data/entity-metadata.md
+++ b/projects/ngrx.io/content/guide/data/entity-metadata.md
@@ -135,7 +135,7 @@ The demo uses this helper to create hero and villain filters. Here's how the app
  * matches the case-insensitive pattern.
  */
 export function nameAndSayingFilter(entities: Villain[], pattern: string) {
-  return PropsFilterFnFactory < Villain > ['name', 'saying'](entities, pattern);
+  return PropsFilterFnFactory<Villain> ['name', 'saying'](entities, pattern);
 }
 ```
 


### PR DESCRIPTION
the string "guide/data" was prefixed to the entities parameter contained within the example code likely due to a search and replace in the documentation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

irrelvant/misleading text within code example  

Closes #

## What is the new behavior?

corrrection of function parameter in example

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
