### PR TITLE
docs(store): update meta-reducers injection guide

### DIFF
--- a/projects/ngrx.io/content/guide/store/recipes/injecting.md
+++ b/projects/ngrx.io/content/guide/store/recipes/injecting.md
@@ -56,8 +56,35 @@ export class FeatureModule {}
 
 ## Injecting Meta-Reducers
 
-To inject 'middleware' meta reducers, use the `META_REDUCERS` injection token exported in
+To inject an initial set of meta-reducers, use the `USER_PROVIDED_META_REDUCERS` injection token exported in
 the Store API and a `Provider` to register the meta reducers through dependency
+injection.
+
+<code-example header="app.module.ts">
+import { MetaReducer, USER_PROVIDED_META_REDUCERS } from '@ngrx/store';
+import { SomeService } from './some.service';
+import * as fromRoot from './reducers';
+
+export function getMetaReducers(
+  some: SomeService
+): MetaReducer&lt;fromRoot.State&gt;[] {
+  // return initial meta reducers;
+}
+
+@NgModule({
+  providers: [
+    {
+      provide: USER_PROVIDED_META_REDUCERS,
+      deps: [SomeService],
+      useFactory: getMetaReducers
+    },
+  ],
+})
+export class AppModule {}
+</code-example>
+
+To inject 'middleware' meta reducers, use the `META_REDUCERS` injection token exported in
+the Store API and a `Provider` for every meta-reducer to register through dependency
 injection.
 
 <code-example header="app.module.ts">


### PR DESCRIPTION
Closes #2129

* Add example for usage of `USER_PROVIDED_META_REDUCERS` token

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

See #2129
For some reason the doc file was patched already to exemplify the correct usage of `META_REDUCERS` but ngrx.io displays an old version of the guide. See #2110

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
