### PR TITLE
feat(schematics): add createEffect migration

### DIFF
--- a/modules/data/schematics-core/utility/change.ts
+++ b/modules/data/schematics-core/utility/change.ts
@@ -148,6 +148,15 @@ export function createReplaceChange(
   );
 }
 
+export function createRemoveChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  from = node.getStart(sourceFile),
+  to = node.getEnd()
+): RemoveChange {
+  return new RemoveChange(sourceFile.fileName, from, to);
+}
+
 export function createChangeRecorder(
   tree: Tree,
   path: string,

--- a/modules/effects/schematics-core/utility/change.ts
+++ b/modules/effects/schematics-core/utility/change.ts
@@ -148,6 +148,15 @@ export function createReplaceChange(
   );
 }
 
+export function createRemoveChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  from = node.getStart(sourceFile),
+  to = node.getEnd()
+): RemoveChange {
+  return new RemoveChange(sourceFile.fileName, from, to);
+}
+
 export function createChangeRecorder(
   tree: Tree,
   path: string,

--- a/modules/entity/schematics-core/utility/change.ts
+++ b/modules/entity/schematics-core/utility/change.ts
@@ -148,6 +148,15 @@ export function createReplaceChange(
   );
 }
 
+export function createRemoveChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  from = node.getStart(sourceFile),
+  to = node.getEnd()
+): RemoveChange {
+  return new RemoveChange(sourceFile.fileName, from, to);
+}
+
 export function createChangeRecorder(
   tree: Tree,
   path: string,

--- a/modules/router-store/schematics-core/utility/change.ts
+++ b/modules/router-store/schematics-core/utility/change.ts
@@ -148,6 +148,15 @@ export function createReplaceChange(
   );
 }
 
+export function createRemoveChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  from = node.getStart(sourceFile),
+  to = node.getEnd()
+): RemoveChange {
+  return new RemoveChange(sourceFile.fileName, from, to);
+}
+
 export function createChangeRecorder(
   tree: Tree,
   path: string,

--- a/modules/schematics-core/utility/change.ts
+++ b/modules/schematics-core/utility/change.ts
@@ -148,6 +148,15 @@ export function createReplaceChange(
   );
 }
 
+export function createRemoveChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  from = node.getStart(sourceFile),
+  to = node.getEnd()
+): RemoveChange {
+  return new RemoveChange(sourceFile.fileName, from, to);
+}
+
 export function createChangeRecorder(
   tree: Tree,
   path: string,

--- a/modules/schematics/BUILD
+++ b/modules/schematics/BUILD
@@ -63,6 +63,7 @@ ts_test_library(
     deps = [
         ":schematics",
         "//modules/schematics-core",
+        "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",
         "@npm//@schematics/angular",
     ],

--- a/modules/schematics/collection.json
+++ b/modules/schematics/collection.json
@@ -22,6 +22,13 @@
       "description": "Add side effect class"
     },
 
+    "create-effect-migration": {
+      "aliases": ["cefm"],
+      "factory": "./src/create-effect-migration",
+      "schema": "./src/create-effect-migration/schema.json",
+      "description": "Migrated usages of @Effect() to createEffect()"
+    },
+
     "entity": {
       "aliases": ["en"],
       "factory": "./src/entity",

--- a/modules/schematics/schematics-core/utility/change.ts
+++ b/modules/schematics/schematics-core/utility/change.ts
@@ -148,6 +148,15 @@ export function createReplaceChange(
   );
 }
 
+export function createRemoveChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  from = node.getStart(sourceFile),
+  to = node.getEnd()
+): RemoveChange {
+  return new RemoveChange(sourceFile.fileName, from, to);
+}
+
 export function createChangeRecorder(
   tree: Tree,
   path: string,

--- a/modules/schematics/src/create-effect-migration/index.spec.ts
+++ b/modules/schematics/src/create-effect-migration/index.spec.ts
@@ -166,9 +166,43 @@ describe('Creator migration', async () => {
 
   it('should not import createEffect if already imported', async () => {
     const input = tags.stripIndent`
-      import { Actions, ofType, createEffect } from '@ngrx/effects';
+      import { Actions, Effect, createEffect, ofType } from '@ngrx/effects';
       @Injectable()
       export class SomeEffectsClass {
+        @Effect()
+        logout$ = this.actions$.pipe(
+          ofType('LOGOUT'),
+          map(() => ({ type: 'LOGGED_OUT' }))
+        );
+        constructor(private actions$: Actions) {}
+      }
+    `;
+
+    const output = tags.stripIndent`
+      import { Actions, createEffect, ofType } from '@ngrx/effects';
+      @Injectable()
+      export class SomeEffectsClass {
+      **
+        logout$ = createEffect(() => this.actions$.pipe(
+          ofType('LOGOUT'),
+          map(() => ({ type: 'LOGGED_OUT' }))
+        ));
+        constructor(private actions$: Actions) {}
+      }
+    `;
+
+    await runTest(input, output);
+  });
+
+  it('should not run the schematic if the createEffect syntax is already used', async () => {
+    const input = tags.stripIndent`
+      import { Actions, createEffect, ofType } from '@ngrx/effects';
+      @Injectable()
+      export class SomeEffectsClass {
+        logout$ = createEffect(() => this.actions$.pipe(
+          ofType('LOGOUT'),
+          map(() => ({ type: 'LOGGED_OUT' }))
+        ));
         constructor(private actions$: Actions) {}
       }
     `;

--- a/modules/schematics/src/create-effect-migration/index.spec.ts
+++ b/modules/schematics/src/create-effect-migration/index.spec.ts
@@ -1,0 +1,193 @@
+import { tags } from '@angular-devkit/core';
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { createWorkspace } from '../../../schematics-core/testing';
+
+describe('Creator migration', async () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@ngrx/schematics',
+    path.join(__dirname, '../../collection.json')
+  );
+
+  let appTree: UnitTestTree;
+
+  beforeEach(async () => {
+    appTree = await createWorkspace(schematicRunner, appTree);
+  });
+
+  it('should use createEffect for non-dispatching effects', async () => {
+    const input = tags.stripIndent`
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+        @Effect()
+        foo$ = this.actions$.pipe(
+          ofType<LoginAction>(AuthActions.login),
+          tap(action => console.log(action))
+        );
+      }
+    `;
+
+    const output = tags.stripIndent`
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+      **
+        foo$ = createEffect(() => this.actions$.pipe(
+          ofType<LoginAction>(AuthActions.login),
+          tap(action => console.log(action))
+        ));
+      }
+    `;
+
+    await runTest(input, output);
+  });
+
+  it('should use createEffect for non-dispatching effects', async () => {
+    const input = tags.stripIndent`
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+        @Effect({ dispatch: false })
+        bar$ = this.actions$.pipe(
+          ofType(AuthActions.login, AuthActions.logout),
+          tap(action => console.log(action))
+        );
+      }
+    `;
+
+    const output = tags.stripIndent`
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+      **
+        bar$ = createEffect(() => this.actions$.pipe(
+          ofType(AuthActions.login, AuthActions.logout),
+          tap(action => console.log(action))
+        ), { dispatch: false });
+      }
+    `;
+
+    await runTest(input, output);
+  });
+
+  it('should use createEffect for effects as functions', async () => {
+    const input = tags.stripIndent`
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+        @Effect()
+        baz$ = ({ debounce = 300, scheduler = asyncScheduler } = {}) => this.actions$.pipe(
+          ofType(login),
+          tap(action => console.log(action))
+        );
+      }
+    `;
+
+    const output = tags.stripIndent`
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+      **
+        baz$ = createEffect(() => ({ debounce = 300, scheduler = asyncScheduler } = {}) => this.actions$.pipe(
+          ofType(login),
+          tap(action => console.log(action))
+        ));
+      }
+    `;
+
+    await runTest(input, output);
+  });
+
+  it('should stay off of other decorators', async () => {
+    const input = tags.stripIndent`
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+        @Effect()
+        @Log()
+        login$ = this.actions$.pipe(
+          ofType('LOGIN'),
+          map(() => ({ type: 'LOGGED_IN' }))
+        );
+        @Log()
+        @Effect()
+        logout$ = this.actions$.pipe(
+          ofType('LOGOUT'),
+          map(() => ({ type: 'LOGGED_OUT' }))
+        );
+      }
+    `;
+
+    const output = tags.stripIndent`
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+      **
+        @Log()
+        login$ = createEffect(() => this.actions$.pipe(
+          ofType('LOGIN'),
+          map(() => ({ type: 'LOGGED_IN' }))
+        ));
+        @Log()
+      **
+        logout$ = createEffect(() => this.actions$.pipe(
+          ofType('LOGOUT'),
+          map(() => ({ type: 'LOGGED_OUT' }))
+        ));
+      }
+    `;
+
+    await runTest(input, output);
+  });
+
+  it('should import createEffect', async () => {
+    const input = tags.stripIndent`
+      import { Actions, ofType, Effect } from '@ngrx/effects';
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+      }
+    `;
+
+    const output = tags.stripIndent`
+      import { Actions, ofType, createEffect } from '@ngrx/effects';
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+      }
+    `;
+
+    await runTest(input, output);
+  });
+
+  it('should not import createEffect if already imported', async () => {
+    const input = tags.stripIndent`
+      import { Actions, ofType, createEffect } from '@ngrx/effects';
+      @Injectable()
+      export class SomeEffectsClass {
+        constructor(private actions$: Actions) {}
+      }
+    `;
+
+    await runTest(input, input);
+  });
+
+  async function runTest(input: string, expected: string) {
+    const options = {};
+    const effectPath = '/some.effects.ts';
+    appTree.create(effectPath, input);
+
+    const tree = await schematicRunner
+      .runSchematicAsync('create-effect-migration', options, appTree)
+      .toPromise();
+
+    const actual = tree.readContent(effectPath);
+
+    // ** for indentation because empty lines are formatted on auto-save
+    expect(actual).toBe(expected.replace(/\*\*/g, '  '));
+  }
+});

--- a/modules/schematics/src/create-effect-migration/index.ts
+++ b/modules/schematics/src/create-effect-migration/index.ts
@@ -1,0 +1,128 @@
+import * as ts from 'typescript';
+import { Path } from '@angular-devkit/core';
+import { Tree, Rule, chain } from '@angular-devkit/schematics';
+import {
+  InsertChange,
+  RemoveChange,
+  replaceImport,
+  commitChanges,
+} from '@ngrx/schematics/schematics-core';
+
+export function migrateToCreators(): Rule {
+  return (host: Tree) =>
+    host.visit(path => {
+      if (!path.endsWith('.ts')) {
+        return;
+      }
+
+      const sourceFile = ts.createSourceFile(
+        path,
+        host.read(path)!.toString(),
+        ts.ScriptTarget.Latest
+      );
+
+      if (sourceFile.isDeclarationFile) {
+        return;
+      }
+
+      const effectsPerClass = sourceFile.statements
+        .filter(ts.isClassDeclaration)
+        .map(clas =>
+          clas.members
+            .filter(ts.isPropertyDeclaration)
+            .filter(
+              property =>
+                property.decorators &&
+                property.decorators.some(isEffectDecorator)
+            )
+        );
+
+      const effects = effectsPerClass.reduce(
+        (acc, effects) => acc.concat(effects),
+        []
+      );
+
+      const createEffectsChanges = replaceEffectDecorators(host, path, effects);
+      const importChanges = replaceImport(
+        sourceFile,
+        path,
+        '@ngrx/effects',
+        'Effect',
+        'createEffect'
+      );
+
+      return commitChanges(host, sourceFile.fileName, [
+        ...importChanges,
+        ...createEffectsChanges,
+      ]);
+    });
+}
+
+function replaceEffectDecorators(
+  host: Tree,
+  path: Path,
+  effects: ts.PropertyDeclaration[]
+) {
+  const inserts = effects
+    .filter(effect => !!effect.initializer)
+    .map(effect => {
+      const decorator = (effect.decorators || []).find(isEffectDecorator)!;
+      const effectArguments = getDispatchProperties(host, path, decorator);
+      const end = effectArguments ? `, ${effectArguments})` : ')';
+
+      return [
+        new InsertChange(path, effect.initializer!.pos, ' createEffect(() =>'),
+        new InsertChange(path, effect.initializer!.end, end),
+      ];
+    })
+    .reduce((acc, inserts) => acc.concat(inserts), []);
+
+  const removes = effects
+    .map(effect => effect.decorators)
+    .filter(decorators => decorators)
+    .map(decorators => {
+      const effectDecorators = decorators!.filter(isEffectDecorator);
+      return effectDecorators.map(decorator => {
+        return new RemoveChange(
+          path,
+          decorator.expression.pos - 1, // also get the @ sign
+          decorator.expression.end
+        );
+      });
+    })
+    .reduce((acc, removes) => acc.concat(removes), []);
+
+  return [...inserts, ...removes];
+}
+
+function isEffectDecorator(decorator: ts.Decorator) {
+  return (
+    ts.isCallExpression(decorator.expression) &&
+    ts.isIdentifier(decorator.expression.expression) &&
+    decorator.expression.expression.text === 'Effect'
+  );
+}
+
+function getDispatchProperties(
+  host: Tree,
+  path: Path,
+  decorator: ts.Decorator
+) {
+  if (!decorator.expression || !ts.isCallExpression(decorator.expression)) {
+    return '';
+  }
+
+  // just copy the effect properties
+  const content = host.read(path)!.toString('utf8');
+  const args = content
+    .substring(
+      decorator.expression.arguments.pos,
+      decorator.expression.arguments.end
+    )
+    .trim();
+  return args;
+}
+
+export default function(): Rule {
+  return chain([migrateToCreators()]);
+}

--- a/modules/schematics/src/create-effect-migration/schema.json
+++ b/modules/schematics/src/create-effect-migration/schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsNgRxCreateEffectMigration",
+  "title": "NgRx Effect Migration from @Effect to createEffect",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/modules/schematics/src/create-effect-migration/schema.ts
+++ b/modules/schematics/src/create-effect-migration/schema.ts
@@ -1,0 +1,1 @@
+export interface Schema {}

--- a/modules/store-devtools/schematics-core/utility/change.ts
+++ b/modules/store-devtools/schematics-core/utility/change.ts
@@ -148,6 +148,15 @@ export function createReplaceChange(
   );
 }
 
+export function createRemoveChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  from = node.getStart(sourceFile),
+  to = node.getEnd()
+): RemoveChange {
+  return new RemoveChange(sourceFile.fileName, from, to);
+}
+
 export function createChangeRecorder(
   tree: Tree,
   path: string,

--- a/modules/store/schematics-core/utility/change.ts
+++ b/modules/store/schematics-core/utility/change.ts
@@ -148,6 +148,15 @@ export function createReplaceChange(
   );
 }
 
+export function createRemoveChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  from = node.getStart(sourceFile),
+  to = node.getEnd()
+): RemoveChange {
+  return new RemoveChange(sourceFile.fileName, from, to);
+}
+
 export function createChangeRecorder(
   tree: Tree,
   path: string,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

This PR adds a new schematic `create-effect-migration` to migrate from the `@Effect()` decorator to the `createEffect()` function.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
