### PR TITLE
feat(schematics): add x-prompt messages

### DIFF
--- a/modules/schematics/src/action/schema.json
+++ b/modules/schematics/src/action/schema.json
@@ -10,7 +10,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the action?"
     },
     "path": {
       "type": "string",
@@ -44,14 +45,16 @@
       "default": false,
       "description":
         "Specifies if api success and failure actions should be generated.",
-      "aliases": ["a"]
+      "aliases": ["a"],
+      "x-prompt": "Should we generate success and failure actions?"
     },
     "creators": {
       "type": "boolean",
       "default": false,
       "description":
         "Specifies whether to use creator functions for handling actions and reducers.",
-      "aliases": ["c"]
+      "aliases": ["c"],
+      "x-prompt": "Do you want to use the create function?"
     }
   },
   "required": []

--- a/modules/schematics/src/container/schema.json
+++ b/modules/schematics/src/container/schema.json
@@ -21,7 +21,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the container component?"
     },
     "inlineStyle": {
       "description": "Specifies if the style will be in the ts file.",

--- a/modules/schematics/src/effect/schema.json
+++ b/modules/schematics/src/effect/schema.json
@@ -10,7 +10,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the Effect?"
     },
     "path": {
       "type": "string",
@@ -38,7 +39,8 @@
       "default": "",
       "description": "Allows specification of the declaring module.",
       "alias": "m",
-      "subtype": "filepath"
+      "subtype": "filepath",
+      "x-prompt": "To which module (path) should the effect be registered in?"
     },
     "root": {
       "type": "boolean",
@@ -62,14 +64,16 @@
       "default": false,
       "description":
         "Specifies if effect has api success and failure actions wired up",
-      "aliases": ["a"]
+      "aliases": ["a"],
+      "x-prompt": "Should we wire up success and failure actions?"
     },
     "creators": {
       "type": "boolean",
       "default": false,
       "description":
         "Specifies whether to use creator functions for handling actions, reducers, and effects.",
-      "aliases": ["c"]
+      "aliases": ["c"],
+      "x-prompt": "Do you want to use the create function?"
     },
     "minimal": {
       "type": "boolean",

--- a/modules/schematics/src/entity/schema.json
+++ b/modules/schematics/src/entity/schema.json
@@ -10,7 +10,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the entity?"
     },
     "path": {
       "type": "string",
@@ -55,7 +56,8 @@
       "default": false,
       "description":
         "Specifies whether to use creator functions for handling actions and reducers.",
-      "aliases": ["c"]
+      "aliases": ["c"],
+      "x-prompt": "Do you want to use the create function?"
     }
   },
   "required": []

--- a/modules/schematics/src/feature/schema.json
+++ b/modules/schematics/src/feature/schema.json
@@ -21,7 +21,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the feature?"
     },
     "flat": {
       "type": "boolean",
@@ -55,14 +56,16 @@
       "default": false,
       "description":
         "Specifies if api success and failure actions, reducer, and effects should be generated as part of this feature.",
-      "aliases": ["a"]
+      "aliases": ["a"],
+      "x-prompt": "Should we generate and wire success and failure actions?"
     },
     "creators": {
       "type": "boolean",
       "default": false,
       "description":
         "Specifies if the actions, reducers, and effects should be created using creator functions",
-      "aliases": ["c"]
+      "aliases": ["c"],
+      "x-prompt": "Do you want to use the create functions?"
     }
   },
   "required": []

--- a/modules/schematics/src/reducer/schema.json
+++ b/modules/schematics/src/reducer/schema.json
@@ -10,7 +10,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the reducer?"
     },
     "path": {
       "type": "string",
@@ -59,14 +60,16 @@
       "default": false,
       "description":
         "Specifies if api success and failure actions should be added to the reducer",
-      "aliases": ["a"]
+      "aliases": ["a"],
+      "x-prompt": "Should we add success and failure actions to the reducer?"
     },
     "creators": {
       "type": "boolean",
       "default": false,
       "description":
         "Specifies whether to use creator functions for handling actions and reducers.",
-      "aliases": ["c"]
+      "aliases": ["c"],
+      "x-prompt": "Do you want to use the create function?"
     }
   },
   "required": []

--- a/modules/schematics/src/store/schema.json
+++ b/modules/schematics/src/store/schema.json
@@ -10,7 +10,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the state?"
     },
     "path": {
       "type": "string",
@@ -38,7 +39,8 @@
       "default": "",
       "description": "Allows specification of the declaring module.",
       "alias": "m",
-      "subtype": "filepath"
+      "subtype": "filepath",
+      "x-prompt": "To which module (path) should the state be registered in?"
     },
     "statePath": {
       "type": "string",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Devs need to remember the command or look in the docs to know how to use the schematics.

## What is the new behavior?

This PR adds an `x-prompt` for the required fields, or for the fields that I think can benefit from having an `x-prompt`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

To be honest, I always forget the flags I have to pass to use the schematics.
I'm open for suggestions, if the message should be modified, or if a message needs to be added or removed.

We could also do the same for the `ng-add` schematics if we agree this PR adds value.
I have only tested the `store` schematics locally and I'm assuming since it worked, the rest should also work.