### PR TITLE
feat(store): add refreshState method to mock store

### DIFF
--- a/modules/store/testing/spec/BUILD
+++ b/modules/store/testing/spec/BUILD
@@ -9,6 +9,7 @@ ts_test_library(
         "//modules/store",
         "//modules/store/spec/fixtures",
         "//modules/store/testing",
+        "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],
 )

--- a/modules/store/testing/src/mock_store.ts
+++ b/modules/store/testing/src/mock_store.ts
@@ -36,6 +36,7 @@ export class MockStore<T> extends Store<T> {
   >();
 
   public scannedActions$: Observable<Action>;
+  private lastState: T | undefined;
 
   constructor(
     private state$: MockState<T>,
@@ -47,6 +48,7 @@ export class MockStore<T> extends Store<T> {
     super(state$, actionsObserver, reducerManager);
     this.resetSelectors();
     this.state$.next(this.initialState);
+    this.lastState = this.initialState;
     this.scannedActions$ = actionsObserver.asObservable();
     if (mockSelectors) {
       mockSelectors.forEach(mockSelector => {
@@ -62,6 +64,7 @@ export class MockStore<T> extends Store<T> {
 
   setState(nextState: T): void {
     this.state$.next(nextState);
+    this.lastState = nextState;
   }
 
   overrideSelector<T, Result>(
@@ -108,7 +111,7 @@ export class MockStore<T> extends Store<T> {
   }
 
   select(selector: any, prop?: any) {
-    if (MockStore.selectors.has(selector)) {
+    if (typeof selector === 'string' && MockStore.selectors.has(selector)) {
       return new BehaviorSubject<any>(
         MockStore.selectors.get(selector)
       ).asObservable();
@@ -123,5 +126,12 @@ export class MockStore<T> extends Store<T> {
 
   removeReducer() {
     /* noop */
+  }
+
+  /**
+   * Refreshes the existing state.
+   */
+  refreshState() {
+    this.setState({ ...(this.lastState as T) });
   }
 }

--- a/modules/store/testing/src/mock_store.ts
+++ b/modules/store/testing/src/mock_store.ts
@@ -36,7 +36,7 @@ export class MockStore<T> extends Store<T> {
   >();
 
   public scannedActions$: Observable<Action>;
-  private lastState: T | undefined;
+  private lastState: T;
 
   constructor(
     private state$: MockState<T>,
@@ -47,8 +47,7 @@ export class MockStore<T> extends Store<T> {
   ) {
     super(state$, actionsObserver, reducerManager);
     this.resetSelectors();
-    this.state$.next(this.initialState);
-    this.lastState = this.initialState;
+    this.setState(this.initialState);
     this.scannedActions$ = actionsObserver.asObservable();
     if (mockSelectors) {
       mockSelectors.forEach(mockSelector => {

--- a/modules/store/testing/src/testing.ts
+++ b/modules/store/testing/src/testing.ts
@@ -23,7 +23,7 @@ export function provideMockStore<T = any>(
   return [
     ActionsSubject,
     MockState,
-    { provide: INITIAL_STATE, useValue: config.initialState },
+    { provide: INITIAL_STATE, useValue: config.initialState || {} },
     { provide: MOCK_SELECTORS, useValue: config.selectors },
     { provide: StateObservable, useClass: MockState },
     { provide: ReducerManager, useClass: MockReducerManager },


### PR DESCRIPTION
The MockStore.refreshState() method emits a clone of the existing
state on the state observable, that will cause the selectors to recompute.
This enables multiple calls of setResult for mocked selectors during testing.
Also fixes a bug with store.select not refreshing mocked selectors

Closes #2121

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2121 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
