### PR TITLE
Fix disallow arrays in action creators

### DIFF
--- a/modules/store/spec/action_creator.spec.ts
+++ b/modules/store/spec/action_creator.spec.ts
@@ -77,6 +77,7 @@ describe('Action Creators', () => {
           const value = fooAction.bar;
       `).toFail(/'bar' does not exist on type/);
     });
+
     it('should not allow type property', () => {
       expectSnippet(`
             const foo = createAction('FOO', (type: string) => ({type}));

--- a/modules/store/spec/action_creator.spec.ts
+++ b/modules/store/spec/action_creator.spec.ts
@@ -84,6 +84,14 @@ describe('Action Creators', () => {
         /Type '{ type: string; }' is not assignable to type '"type property is not allowed in action creators"/
       );
     });
+
+    it('should not allow ararys', () => {
+      expectSnippet(`
+          const foo = createAction('FOO', () => [ ]);
+        `).toFail(
+        /Type 'any\[]' is not assignable to type '"arrays are not allowed in action creators"'/
+      );
+    });
   });
 
   describe('empty', () => {
@@ -155,6 +163,14 @@ describe('Action Creators', () => {
           const foo = createAction('FOO', props<{ type: number }>());
         `).toFail(
         /Argument of type '"type property is not allowed in action creators"' is not assignable to parameter of type/
+      );
+    });
+
+    it('should not allow ararys', () => {
+      expectSnippet(`
+          const foo = createAction('FOO', props<[]>());
+        `).toFail(
+        /Argument of type '"arrays are not allowed in action creators"' is not assignable to parameter of type/
       );
     });
   });

--- a/modules/store/spec/action_creator.spec.ts
+++ b/modules/store/spec/action_creator.spec.ts
@@ -159,7 +159,6 @@ describe('Action Creators', () => {
     });
 
     it('should not allow type property', () => {
-      const foo = createAction('FOO', props<{ type: number }>() as any);
       expectSnippet(`
           const foo = createAction('FOO', props<{ type: number }>());
         `).toFail(

--- a/modules/store/spec/action_creator.spec.ts
+++ b/modules/store/spec/action_creator.spec.ts
@@ -82,7 +82,7 @@ describe('Action Creators', () => {
       expectSnippet(`
             const foo = createAction('FOO', (type: string) => ({type}));
         `).toFail(
-        /Type '{ type: string; }' is not assignable to type '"type property is not allowed in action creators"/
+        /Type '{ type: string; }' is not assignable to type '"type property is not allowed in action creators"'/
       );
     });
 

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -4,7 +4,7 @@ import {
   TypedAction,
   FunctionWithParametersType,
   PropsReturnType,
-  DisallowTypeProperty,
+  DisallowArraysAndTypeProperty,
 } from './models';
 
 // Action creators taken from ts-action library and modified a bit to better
@@ -23,7 +23,7 @@ export function createAction<
   R extends object
 >(
   type: T,
-  creator: Creator<P, DisallowTypeProperty<R>>
+  creator: Creator<P, DisallowArraysAndTypeProperty<R>>
 ): FunctionWithParametersType<P, R & TypedAction<T>> & TypedAction<T>;
 /**
  * @description

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -53,9 +53,13 @@ export type SelectorWithProps<State, Props, Result> = (
   props: Props
 ) => Result;
 
-export type DisallowTypeProperty<T> = T extends { type: any }
-  ? TypePropertyIsNotAllowed
-  : T;
+export const arraysAreNotAllowedMsg =
+  'arrays are not allowed in action creators';
+type ArraysAreNotAllowed = typeof arraysAreNotAllowedMsg;
+
+export type DisallowArraysAndTypeProperty<T> = T extends any[]
+  ? ArraysAreNotAllowed
+  : T extends { type: any } ? TypePropertyIsNotAllowed : T;
 
 export const typePropertyIsNotAllowedMsg =
   'type property is not allowed in action creators';
@@ -67,13 +71,17 @@ type TypePropertyIsNotAllowed = typeof typePropertyIsNotAllowedMsg;
 export type Creator<
   P extends any[] = any[],
   R extends object = object
-> = R extends { type: any }
-  ? TypePropertyIsNotAllowed
-  : FunctionWithParametersType<P, R>;
+> = R extends any[]
+  ? ArraysAreNotAllowed
+  : R extends { type: any }
+    ? TypePropertyIsNotAllowed
+    : FunctionWithParametersType<P, R>;
 
-export type PropsReturnType<T extends object> = T extends { type: any }
-  ? TypePropertyIsNotAllowed
-  : { _as: 'props'; _p: T };
+export type PropsReturnType<T extends object> = T extends any[]
+  ? ArraysAreNotAllowed
+  : T extends { type: any }
+    ? TypePropertyIsNotAllowed
+    : { _as: 'props'; _p: T };
 
 /**
  * See `Creator`.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

I think it is debatable whether this is a bugfix or a feature.

```
[-] Bugfix
[-] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I noticed that the new `createAction()` function has a clever type definition which prevents it from being used with a props object shaped like this `{ type: any }`.  Since an array is also an object in JavaScript it can still be used like this:

```typescript
const myAction = createAction('MY_ACTION_TYPE', (x: string) => [ x ]);
const myOtherAction = createAction('MY_ACTION_TYPE', props<[ string ]>());
```

Of course this becomes a little odd when the resulting function is used to create an actual action:

```
myAction('hello');
```

TypeScript thinks it has the type `string[] & TypedAction<"MY_ACTION_TYPE">` but in reality it is an object with the following shape: `{ 0: hello, type: 'MY_ACTION_TYPE' }`.

## What is the new behavior?

A similar technique to the one which prevents `{ type: any }` is used to prevent arrays which means `createAction('MY_ACTION_TYPE', props<[]>())` will not compile anymore.

## Does this PR introduce a breaking change?

Technically this is a breaking change. But it will only break code which used `createAction()` in an unintended way.

```
[ -] Yes
[ -] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Please let me know if there is anything I need to change before this can be merged. And in case you think this is not necessary at all feel free to close it.

I also cleaned up the test suite of the action creator a little bit by removing an unused line of code and by inserting a missing blank line and a missing quote. Please let me know if I should better exclude those changes from this pull request.
