### PR TITLE
fix(effects): dispatch init action once

### DIFF
--- a/modules/effects/spec/effect_sources.spec.ts
+++ b/modules/effects/spec/effect_sources.spec.ts
@@ -1,8 +1,16 @@
 import { ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { cold, hot, getTestScheduler } from 'jasmine-marbles';
-import { concat, NEVER, Observable, of, throwError, timer } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  concat,
+  NEVER,
+  Observable,
+  of,
+  throwError,
+  timer,
+  Subject,
+} from 'rxjs';
+import { map, mapTo } from 'rxjs/operators';
 
 import {
   Effect,
@@ -10,9 +18,11 @@ import {
   OnIdentifyEffects,
   OnInitEffects,
   createEffect,
+  Actions,
 } from '../';
 import { EffectsRunner } from '../src/effects_runner';
 import { Store } from '@ngrx/store';
+import { ofType } from '../src';
 
 describe('EffectSources', () => {
   let mockErrorReporter: ErrorHandler;
@@ -59,6 +69,37 @@ describe('EffectSources', () => {
     const store = TestBed.get(Store);
 
     effectSources.addEffects(new EffectWithInitAction());
+
+    expect(store.dispatch).toHaveBeenCalledTimes(1);
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: '[EffectWithInitAction] Init',
+    });
+  });
+
+  it('should dispatch an action on ngrxOnInitEffects after being registered (class has effects)', () => {
+    class EffectWithInitActionAndEffects implements OnInitEffects {
+      effectOne = createEffect(() => {
+        return this.actions$.pipe(
+          ofType('Action 1'),
+          mapTo({ type: 'Action 1 Response' })
+        );
+      });
+      effectTwo = createEffect(() => {
+        return this.actions$.pipe(
+          ofType('Action 2'),
+          mapTo({ type: 'Action 2 Response' })
+        );
+      });
+
+      ngrxOnInitEffects() {
+        return { type: '[EffectWithInitAction] Init' };
+      }
+
+      constructor(private actions$: Actions) {}
+    }
+    const store = TestBed.get(Store);
+
+    effectSources.addEffects(new EffectWithInitActionAndEffects(new Subject()));
 
     expect(store.dispatch).toHaveBeenCalledTimes(1);
     expect(store.dispatch).toHaveBeenCalledWith({

--- a/modules/effects/spec/effect_sources.spec.ts
+++ b/modules/effects/spec/effect_sources.spec.ts
@@ -11,6 +11,7 @@ import {
   OnInitEffects,
   createEffect,
 } from '../';
+import { EffectsRunner } from '../src/effects_runner';
 import { Store } from '@ngrx/store';
 
 describe('EffectSources', () => {
@@ -21,6 +22,7 @@ describe('EffectSources', () => {
     TestBed.configureTestingModule({
       providers: [
         EffectSources,
+        EffectsRunner,
         {
           provide: Store,
           useValue: {
@@ -29,6 +31,9 @@ describe('EffectSources', () => {
         },
       ],
     });
+
+    const effectsRunner = TestBed.get(EffectsRunner);
+    effectsRunner.start();
 
     mockErrorReporter = TestBed.get(ErrorHandler);
     effectSources = TestBed.get(EffectSources);
@@ -52,7 +57,6 @@ describe('EffectSources', () => {
       }
     }
     const store = TestBed.get(Store);
-    effectSources.toActions().subscribe();
 
     effectSources.addEffects(new EffectWithInitAction());
 
@@ -69,7 +73,6 @@ describe('EffectSources', () => {
       }
     }
     const store = TestBed.get(Store);
-    effectSources.toActions().subscribe();
 
     effectSources.addEffects(new EffectWithInitAction());
     effectSources.addEffects(new EffectWithInitAction());
@@ -92,7 +95,6 @@ describe('EffectSources', () => {
       }
     }
     const store = TestBed.get(Store);
-    effectSources.toActions().subscribe();
 
     effectSources.addEffects(new EffectWithInitAction());
     effectSources.addEffects(new EffectWithInitAction());

--- a/modules/effects/spec/integration.spec.ts
+++ b/modules/effects/spec/integration.spec.ts
@@ -49,7 +49,7 @@ describe('NgRx Effects Integration spec', () => {
   });
 
   it('should dispatch init actions in the correct order', () => {
-    expect(dispatch.calls.count()).toBe(7);
+    expect(dispatch.calls.count()).toBe(6);
 
     // All of the root effects init actions are dispatched first
     expect(dispatch.calls.argsFor(0)).toEqual([
@@ -71,11 +71,6 @@ describe('NgRx Effects Integration spec', () => {
     ]);
 
     expect(dispatch.calls.argsFor(5)).toEqual([
-      { type: '[FeatEffectWithIdentifierAndInitAction]: INIT' },
-    ]);
-
-    // While the effect has the same identifier the init effect action is still being dispatched
-    expect(dispatch.calls.argsFor(6)).toEqual([
       { type: '[FeatEffectWithIdentifierAndInitAction]: INIT' },
     ]);
   });

--- a/modules/effects/src/effect_sources.ts
+++ b/modules/effects/src/effect_sources.ts
@@ -8,6 +8,7 @@ import {
   groupBy,
   map,
   mergeMap,
+  tap,
 } from 'rxjs/operators';
 
 import {
@@ -31,13 +32,6 @@ export class EffectSources extends Subject<any> {
 
   addEffects(effectSourceInstance: any): void {
     this.next(effectSourceInstance);
-
-    if (
-      onInitEffects in effectSourceInstance &&
-      typeof effectSourceInstance[onInitEffects] === 'function'
-    ) {
-      this.store.dispatch(effectSourceInstance[onInitEffects]());
-    }
   }
 
   /**
@@ -46,7 +40,21 @@ export class EffectSources extends Subject<any> {
   toActions(): Observable<Action> {
     return this.pipe(
       groupBy(getSourceForInstance),
-      mergeMap(source$ => source$.pipe(groupBy(effectsInstance))),
+      mergeMap(source$ => {
+        return source$.pipe(
+          groupBy(effectsInstance),
+          tap(() => {
+            if (
+              onInitEffects in source$.key &&
+              typeof source$.key[onInitEffects] === 'function'
+            ) {
+              this.store.dispatch(
+                source$.key[onInitEffects].bind(source$.key)()
+              );
+            }
+          })
+        );
+      }),
       mergeMap(source$ =>
         source$.pipe(
           exhaustMap(resolveEffectSource(this.errorHandler)),

--- a/modules/effects/src/effect_sources.ts
+++ b/modules/effects/src/effect_sources.ts
@@ -48,9 +48,7 @@ export class EffectSources extends Subject<any> {
               onInitEffects in source$.key &&
               typeof source$.key[onInitEffects] === 'function'
             ) {
-              this.store.dispatch(
-                source$.key[onInitEffects].bind(source$.key)()
-              );
+              this.store.dispatch(source$.key.ngrxOnInitEffects());
             }
           })
         );


### PR DESCRIPTION


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2106

## What is the new behavior?

See the breaking change section below

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGE

Before
When the effect class was registered, the init action would be dispatched.
If the effect was provided in multiple lazy loaded modules, the init action would be dispatched for every module.

After
The init action is only dispatched once
The init action is now dispatched based on the identifier of the effect (via ngrxOnIdentifyEffects)
