### PR TITLE
fix(store): improve types for string selectors

### DIFF
--- a/modules/data/spec/selectors/entity-selectors$.spec.ts
+++ b/modules/data/spec/selectors/entity-selectors$.spec.ts
@@ -102,7 +102,7 @@ describe('EntitySelectors$', () => {
 
       // listen for changes to the hero collection
       store
-        .select<HeroCollection>(ENTITY_CACHE_NAME, 'Hero')
+        .select<HeroCollection>(ENTITY_CACHE_NAME as any, 'Hero')
         .subscribe((c: HeroCollection) => (collection = c));
     });
 

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -199,7 +199,7 @@ export class StoreRouterConnectingModule {
   private setUpStoreStateListener(): void {
     this.store
       .pipe(
-        select(this.stateKey),
+        select(this.stateKey as any),
         withLatestFrom(this.store)
       )
       .subscribe(([routerStoreState, storeState]) => {

--- a/modules/store/spec/action_creator.spec.ts
+++ b/modules/store/spec/action_creator.spec.ts
@@ -1,5 +1,4 @@
 import { createAction, props, union } from '@ngrx/store';
-import { expecter } from 'ts-snippet';
 
 describe('Action Creators', () => {
   let originalTimeout: number;
@@ -12,17 +11,6 @@ describe('Action Creators', () => {
   afterEach(() => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
   });
-
-  const expectSnippet = expecter(
-    code => `
-  // path goes from root
-  import {createAction, props, union} from './modules/store/src/action_creator';
-    ${code}`,
-    {
-      moduleResolution: 'node',
-      target: 'es2015',
-    }
-  );
 
   describe('createAction', () => {
     it('should create an action', () => {
@@ -53,45 +41,6 @@ describe('Action Creators', () => {
       const text = JSON.stringify(fooAction);
 
       expect(JSON.parse(text)).toEqual({ type: 'FOO', foo: 42 });
-    });
-
-    it('should enforce ctor parameters', () => {
-      expectSnippet(`
-        const foo = createAction('FOO', (foo: number) => ({ foo }));
-        const fooAction = foo('42');
-    `).toFail(/not assignable to parameter of type 'number'/);
-    });
-
-    it('should enforce action property types', () => {
-      expectSnippet(`
-          const foo = createAction('FOO', (foo: number) => ({ foo }));
-          const fooAction = foo(42);
-          const value: string = fooAction.foo;
-      `).toFail(/'number' is not assignable to type 'string'/);
-    });
-
-    it('should enforce action property names', () => {
-      expectSnippet(`
-          const foo = createAction('FOO', (foo: number) => ({ foo }));
-          const fooAction = foo(42);
-          const value = fooAction.bar;
-      `).toFail(/'bar' does not exist on type/);
-    });
-
-    it('should not allow type property', () => {
-      expectSnippet(`
-            const foo = createAction('FOO', (type: string) => ({type}));
-        `).toFail(
-        /Type '{ type: string; }' is not assignable to type '"type property is not allowed in action creators"'/
-      );
-    });
-
-    it('should not allow ararys', () => {
-      expectSnippet(`
-          const foo = createAction('FOO', () => [ ]);
-        `).toFail(
-        /Type 'any\[]' is not assignable to type '"arrays are not allowed in action creators"'/
-      );
     });
   });
 
@@ -133,45 +82,6 @@ describe('Action Creators', () => {
       const text = JSON.stringify(fooAction);
 
       expect(JSON.parse(text)).toEqual({ foo: 42, type: 'FOO' });
-    });
-
-    it('should enforce ctor parameters', () => {
-      expectSnippet(`
-            const foo = createAction('FOO', props<{ foo: number }>());
-            const fooAction = foo({ foo: '42' });
-        `).toFail(/'string' is not assignable to type 'number'/);
-    });
-
-    it('should enforce action property types', () => {
-      expectSnippet(`
-            const foo = createAction('FOO', props<{ foo: number }>());
-            const fooAction = foo({ foo: 42 });
-            const value: string = fooAction.foo;
-        `).toFail(/'number' is not assignable to type 'string'/);
-    });
-
-    it('should enforce action property names', () => {
-      expectSnippet(`
-            const foo = createAction('FOO', props<{ foo: number }>());
-            const fooAction = foo({ foo: 42 });
-            const value = fooAction.bar;
-        `).toFail(/'bar' does not exist on type/);
-    });
-
-    it('should not allow type property', () => {
-      expectSnippet(`
-          const foo = createAction('FOO', props<{ type: number }>());
-        `).toFail(
-        /Argument of type '"type property is not allowed in action creators"' is not assignable to parameter of type/
-      );
-    });
-
-    it('should not allow ararys', () => {
-      expectSnippet(`
-          const foo = createAction('FOO', props<[]>());
-        `).toFail(
-        /Argument of type '"arrays are not allowed in action creators"' is not assignable to parameter of type/
-      );
     });
   });
 });

--- a/modules/store/spec/reducer_creator.spec.ts
+++ b/modules/store/spec/reducer_creator.spec.ts
@@ -1,38 +1,11 @@
 import { on, createReducer, createAction, props, union } from '@ngrx/store';
-import { expecter } from 'ts-snippet';
 
 describe('classes/reducer', function(): void {
-  const expectSnippet = expecter(
-    code => `
-// path goes from root
-import {createAction, props} from './modules/store/src/action_creator';
-import {on} from './modules/store/src/reducer_creator';
-  ${code}`,
-    {
-      moduleResolution: 'node',
-      target: 'es2015',
-    }
-  );
-
   describe('base', () => {
     const bar = createAction('[foobar] BAR', props<{ bar: number }>());
     const foo = createAction('[foobar] FOO', props<{ foo: number }>());
 
     describe('on', () => {
-      it('should enforce action property types', () => {
-        expectSnippet(`
-                    const foo = createAction('FOO', props<{ foo: number }>());
-                    on(foo, (state, action) => { const foo: string = action.foo; return state; });
-                `).toFail(/'number' is not assignable to type 'string'/);
-      });
-
-      it('should enforce action property names', () => {
-        expectSnippet(`
-                    const foo = createAction('FOO', props<{ foo: number }>());
-                    on(foo, (state, action) => { const bar: string = action.bar; return state; });
-                `).toFail(/'bar' does not exist on type/);
-      });
-
       it('should support reducers with multiple actions', () => {
         const both = union({ bar, foo });
         const func = (state: {}, action: typeof both) => ({});

--- a/modules/store/spec/types/action_creator.spec.ts
+++ b/modules/store/spec/types/action_creator.spec.ts
@@ -1,17 +1,14 @@
 import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
 
 describe('createAction()', () => {
   const expectSnippet = expecter(
     code => `
-      // path goes from root
-      import {createAction, props, union} from './modules/store';
+      import {createAction, props, union} from '@ngrx/store';
 
       ${code}
     `,
-    {
-      moduleResolution: 'node',
-      target: 'es2015',
-    }
+    compilerOptions()
   );
 
   describe('with props', () => {

--- a/modules/store/spec/types/action_creator.spec.ts
+++ b/modules/store/spec/types/action_creator.spec.ts
@@ -1,0 +1,98 @@
+import { expecter } from 'ts-snippet';
+
+describe('createAction()', () => {
+  const expectSnippet = expecter(
+    code => `
+      // path goes from root
+      import {createAction, props, union} from './modules/store';
+
+      ${code}
+    `,
+    {
+      moduleResolution: 'node',
+      target: 'es2015',
+    }
+  );
+
+  describe('with props', () => {
+    it('should enforce ctor parameters', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<{ foo: number }>());
+        const fooAction = foo({ foo: '42' });
+      `).toFail(/'string' is not assignable to type 'number'/);
+    });
+
+    it('should enforce action property types', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<{ foo: number }>());
+        const fooAction = foo({ foo: 42 });
+        const value: string = fooAction.foo;
+      `).toFail(/'number' is not assignable to type 'string'/);
+    });
+
+    it('should enforce action property names', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<{ foo: number }>());
+        const fooAction = foo({ foo: 42 });
+        const value = fooAction.bar;
+      `).toFail(/'bar' does not exist on type/);
+    });
+
+    it('should not allow type property', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<{ type: number }>());
+      `).toFail(
+        /Argument of type '"type property is not allowed in action creators"' is not assignable to parameter of type/
+      );
+    });
+
+    it('should not allow ararys', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<[]>());
+      `).toFail(
+        /Argument of type '"arrays are not allowed in action creators"' is not assignable to parameter of type/
+      );
+    });
+  });
+
+  describe('with function', () => {
+    it('should enforce ctor parameters', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', (foo: number) => ({ foo }));
+        const fooAction = foo('42');
+      `).toFail(/not assignable to parameter of type 'number'/);
+    });
+
+    it('should enforce action property types', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', (foo: number) => ({ foo }));
+        const fooAction = foo(42);
+        const value: string = fooAction.foo;
+      `).toFail(/'number' is not assignable to type 'string'/);
+    });
+
+    it('should enforce action property names', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', (foo: number) => ({ foo }));
+        const fooAction = foo(42);
+        const value = fooAction.bar;
+      `).toFail(/'bar' does not exist on type/);
+    });
+
+    it('should not allow type property', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', (type: string) => ({type}));
+      `).toFail(
+        /Type '{ type: string; }' is not assignable to type '"type property is not allowed in action creators"'/
+      );
+    });
+
+    it('should not allow arrays', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', () => [ ]);
+      `).toFail(
+        /Type 'any\[]' is not assignable to type '"arrays are not allowed in action creators"'/
+      );
+    });
+  });
+});

--- a/modules/store/spec/types/reducer_creator.spec.ts
+++ b/modules/store/spec/types/reducer_creator.spec.ts
@@ -1,0 +1,32 @@
+import { expecter } from 'ts-snippet';
+
+describe('createReducer()', () => {
+  const expectSnippet = expecter(
+    code => `
+      // path goes from root
+      import {createAction, props, on} from './modules/store';
+
+      ${code}
+    `,
+    {
+      moduleResolution: 'node',
+      target: 'es2015',
+    }
+  );
+
+  describe('on()', () => {
+    it('should enforce action property types', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<{ foo: number }>());
+        on(foo, (state, action) => { const foo: string = action.foo; return state; });
+      `).toFail(/'number' is not assignable to type 'string'/);
+    });
+
+    it('should enforce action property names', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<{ foo: number }>());
+        on(foo, (state, action) => { const bar: string = action.bar; return state; });
+      `).toFail(/'bar' does not exist on type/);
+    });
+  });
+});

--- a/modules/store/spec/types/reducer_creator.spec.ts
+++ b/modules/store/spec/types/reducer_creator.spec.ts
@@ -1,17 +1,14 @@
 import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
 
 describe('createReducer()', () => {
   const expectSnippet = expecter(
     code => `
-      // path goes from root
-      import {createAction, props, on} from './modules/store';
+      import {createAction, props, on} from '@ngrx/store';
 
       ${code}
     `,
-    {
-      moduleResolution: 'node',
-      target: 'es2015',
-    }
+    compilerOptions()
   );
 
   describe('on()', () => {

--- a/modules/store/spec/types/select.spec.ts
+++ b/modules/store/spec/types/select.spec.ts
@@ -1,10 +1,10 @@
 import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
 
 describe('select()', () => {
   const expectSnippet = expecter(
     code => `
-      // path goes from root
-      import { Store, select, createSelector, createFeatureSelector } from './modules/store';
+      import { Store, select, createSelector, createFeatureSelector } '@ngrx/store';
 
       interface State { foo: { bar: { baz: [] } } };
       const store = {} as Store<State>;
@@ -13,10 +13,7 @@ describe('select()', () => {
 
       ${code}
     `,
-    {
-      moduleResolution: 'node',
-      target: 'es2015',
-    }
+    compilerOptions()
   );
 
   describe('as property', () => {

--- a/modules/store/spec/types/select.spec.ts
+++ b/modules/store/spec/types/select.spec.ts
@@ -1,0 +1,164 @@
+import { expecter } from 'ts-snippet';
+
+describe('select()', () => {
+  const expectSnippet = expecter(
+    code => `
+      // path goes from root
+      import { Store, select, createSelector, createFeatureSelector } from './modules/store';
+
+      interface State { foo: { bar: { baz: [] } } };
+      const store = {} as Store<State>;
+      const fooSelector = createFeatureSelector<State, State['foo']>('foo')
+      const barSelector = createSelector(fooSelector, s => s.bar)
+
+      ${code}
+    `,
+    {
+      moduleResolution: 'node',
+      target: 'es2015',
+    }
+  );
+
+  describe('as property', () => {
+    describe('with strings', () => {
+      it('should enforce that properties exists on state (root)', () => {
+        expectSnippet(`const selector = store.select('mia');`).toFail(
+          /Argument of type '"mia"' is not assignable to parameter of type '"foo"'/
+        );
+      });
+
+      it('should enforce that properties exists on state (nested)', () => {
+        expectSnippet(
+          `const selector = store.select('foo', 'bar', 'mia');`
+        ).toFail(
+          /Argument of type '"mia"' is not assignable to parameter of type '"baz"'/
+        );
+      });
+
+      it('should infer correctly (root)', () => {
+        expectSnippet(`const selector = store.select('foo');`).toInfer(
+          'selector',
+          'Observable<{ bar: { baz: []; }; }>'
+        );
+      });
+
+      it('should infer correctly (nested)', () => {
+        expectSnippet(`const selector = store.select('foo', 'bar');`).toInfer(
+          'selector',
+          'Observable<{ baz: []; }>'
+        );
+      });
+    });
+
+    describe('with functions', () => {
+      it('should enforce that properties exists on state (root)', () => {
+        expectSnippet(`const selector = store.select(s => s.mia);`).toFail(
+          /Property 'mia' does not exist on type 'State'/
+        );
+      });
+
+      it('should enforce that properties exists on state (nested)', () => {
+        expectSnippet(
+          `const selector = store.select(s => s.foo.bar.mia);`
+        ).toFail(/Property 'mia' does not exist on type '\{ baz: \[\]; \}'/);
+      });
+
+      it('should infer correctly (root)', () => {
+        expectSnippet(`const selector = store.select(s => s.foo);`).toInfer(
+          'selector',
+          'Observable<{ bar: { baz: []; }; }>'
+        );
+      });
+
+      it('should infer correctly (nested)', () => {
+        expectSnippet(`const selector = store.select(s => s.foo.bar);`).toInfer(
+          'selector',
+          'Observable<{ baz: []; }>'
+        );
+      });
+    });
+
+    describe('with selectors', () => {
+      it('should infer correctly', () => {
+        expectSnippet(`const selector = store.select(fooSelector);`).toInfer(
+          'selector',
+          'Observable<{ bar: { baz: []; }; }>'
+        );
+
+        expectSnippet(`const selector = store.select(barSelector);`).toInfer(
+          'selector',
+          'Observable<{ baz: []; }>'
+        );
+      });
+    });
+  });
+
+  describe('as operator', () => {
+    describe('with strings', () => {
+      it('should enforce that properties exists on state (root)', () => {
+        expectSnippet(`const selector = store.pipe(select('mia'));`).toFail(
+          /Argument of type '"mia"' is not assignable to parameter of type '"foo"'/
+        );
+      });
+
+      it('should enforce that properties exists on state (nested)', () => {
+        expectSnippet(
+          `const selector = store.pipe(select('foo', 'bar', 'mia'));`
+        ).toFail(
+          /Argument of type '"mia"' is not assignable to parameter of type '"baz"'/
+        );
+      });
+
+      it('should infer correctly (root)', () => {
+        expectSnippet(`const selector = store.pipe(select('foo'));`).toInfer(
+          'selector',
+          'Observable<{ bar: { baz: []; }; }>'
+        );
+      });
+
+      it('should infer correctly (nested)', () => {
+        expectSnippet(
+          `const selector = store.pipe(select('foo', 'bar'));`
+        ).toInfer('selector', 'Observable<{ baz: []; }>');
+      });
+    });
+
+    describe('with functions', () => {
+      it('should enforce that properties exists on state (root)', () => {
+        expectSnippet(
+          `const selector = store.pipe(select(s => s.mia));`
+        ).toFail(/Property 'mia' does not exist on type 'State'/);
+      });
+
+      it('should enforce that properties exists on state (nested)', () => {
+        expectSnippet(
+          `const selector = store.pipe(select(s => s.foo.bar.mia));`
+        ).toFail(/Property 'mia' does not exist on type '\{ baz: \[\]; \}'/);
+      });
+
+      it('should infer correctly (root)', () => {
+        expectSnippet(
+          `const selector = store.pipe(select(s => s.foo));`
+        ).toInfer('selector', 'Observable<{ bar: { baz: []; }; }>');
+      });
+
+      it('should infer correctly (nested)', () => {
+        expectSnippet(
+          `const selector = store.pipe(select(s => s.foo.bar));`
+        ).toInfer('selector', 'Observable<{ baz: []; }>');
+      });
+    });
+
+    describe('with selectors', () => {
+      it('should infer correctly', () => {
+        expectSnippet(
+          `const selector = store.pipe(select(fooSelector));`
+        ).toInfer('selector', 'Observable<{ bar: { baz: []; }; }>');
+
+        expectSnippet(
+          `const selector = store.pipe(select(barSelector));`
+        ).toInfer('selector', 'Observable<{ baz: []; }>');
+      });
+    });
+  });
+});

--- a/modules/store/spec/types/utils.ts
+++ b/modules/store/spec/types/utils.ts
@@ -1,0 +1,8 @@
+export const compilerOptions = () => ({
+  moduleResolution: 'node',
+  target: 'es2015',
+  baseUrl: '.',
+  paths: {
+    '@ngrx/store': ['./modules/store'],
+  },
+});

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -62,16 +62,28 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
     key5: e,
     key6: f
   ): Observable<T[a][b][c][d][e][f]>;
-  /**
-   * This overload is used to support spread operator with
-   * fixed length tuples type in typescript 2.7
-   */
-  select<K = any>(...paths: string[]): Observable<K>;
-  select<Props = any>(
-    pathOrMapFn: ((state: T, props?: Props) => any) | string,
+  select<
+    a extends keyof T,
+    b extends keyof T[a],
+    c extends keyof T[a][b],
+    d extends keyof T[a][b][c],
+    e extends keyof T[a][b][c][d],
+    f extends keyof T[a][b][c][d][e],
+    K = any
+  >(
+    key1: a,
+    key2: b,
+    key3: c,
+    key4: d,
+    key5: e,
+    key6: f,
+    ...paths: string[]
+  ): Observable<K>;
+  select<Props = any, K = any>(
+    pathOrMapFn: ((state: T, props?: Props) => K) | string,
     ...paths: string[]
   ): Observable<any> {
-    return select.call(null, pathOrMapFn, ...paths)(this);
+    return (select as any).call(null, pathOrMapFn, ...paths)(this);
   }
 
   lift<R>(operator: Operator<T, R>): Store<R> {
@@ -116,8 +128,7 @@ export function select<T, Props, K>(
   props?: Props
 ): (source$: Observable<T>) => Observable<K>;
 export function select<T, a extends keyof T>(
-  key: a,
-  props: null
+  key: a
 ): (source$: Observable<T>) => Observable<T[a]>;
 export function select<T, a extends keyof T, b extends keyof T[a]>(
   key1: a,
@@ -175,17 +186,27 @@ export function select<
   key5: e,
   key6: f
 ): (source$: Observable<T>) => Observable<T[a][b][c][d][e][f]>;
-/**
- * This overload is used to support spread operator with
- * fixed length tuples type in typescript 2.7
- */
-export function select<T, Props = any, K = any>(
-  propsOrPath: Props,
+export function select<
+  T,
+  a extends keyof T,
+  b extends keyof T[a],
+  c extends keyof T[a][b],
+  d extends keyof T[a][b][c],
+  e extends keyof T[a][b][c][d],
+  f extends keyof T[a][b][c][d][e],
+  K = any
+>(
+  key1: a,
+  key2: b,
+  key3: c,
+  key4: d,
+  key5: e,
+  key6: f,
   ...paths: string[]
 ): (source$: Observable<T>) => Observable<K>;
 export function select<T, Props, K>(
   pathOrMapFn: ((state: T, props?: Props) => any) | string,
-  propsOrPath: Props | string,
+  propsOrPath?: Props | string,
   ...paths: string[]
 ) {
   return function selectOperator(source$: Observable<T>): Observable<K> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

The string selectors don't have the correct types:

- Does not infer correctly, it will always(?) infer to `any`

```
books = this.store.select('books')
```

- Are not type safe

```
books = this.store.select('books', 'notExistingState')
```

## What is the new behavior?

The new behavior will  infer correctly and will throw errors if the state property is missing.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Similar PRs:

- https://github.com/ngrx/platform/pull/2170
- https://github.com/ngrx/platform/pull/2074

/cc @alex-okrushko 
