### PR TITLE
feat(effects): improve types for ofType with action creators

### DIFF
--- a/modules/effects/spec/effect_creator.spec.ts
+++ b/modules/effects/spec/effect_creator.spec.ts
@@ -1,69 +1,7 @@
 import { of } from 'rxjs';
-import { expecter } from 'ts-snippet';
 import { createEffect, getCreateEffectMetadata } from '../src/effect_creator';
 
 describe('createEffect()', () => {
-  describe('types', () => {
-    const expectSnippet = expecter(
-      code => `
-        import { Action } from '@ngrx/store';
-        import { createEffect } from '@ngrx/effects';
-        import { of } from 'rxjs';
-        ${code}`,
-      {
-        moduleResolution: 'node',
-        target: 'es2015',
-        baseUrl: '.',
-        experimentalDecorators: true,
-        paths: {
-          '@ngrx/store': ['./modules/store'],
-          '@ngrx/effects': ['./modules/effects'],
-          rxjs: ['../npm/node_modules/rxjs', './node_modules/rxjs'],
-        },
-      }
-    );
-
-    describe('dispatch: true', () => {
-      it('should enforce an Action return value', () => {
-        expectSnippet(`
-          const effect = createEffect(() => of({ type: 'a' }));
-        `).toSucceed();
-
-        expectSnippet(`
-          const effect = createEffect(() => of({ foo: 'a' }));
-        `).toFail(
-          /Type 'Observable<{ foo: string; }>' is not assignable to type 'Observable<Action> | ((...args: any[]) => Observable<Action>)'./
-        );
-      });
-
-      it('should enforce an Action return value when dispatch is provided', () => {
-        expectSnippet(`
-          const effect = createEffect(() => of({ type: 'a' }), { dispatch: true });
-        `).toSucceed();
-
-        expectSnippet(`
-          const effect = createEffect(() => of({ foo: 'a' }), { dispatch: true });
-        `).toFail(
-          /Type 'Observable<{ foo: string; }>' is not assignable to type 'Observable<Action> | ((...args: any[]) => Observable<Action>)'./
-        );
-      });
-    });
-
-    describe('dispatch: false', () => {
-      it('should enforce an Observable return value', () => {
-        expectSnippet(`
-          const effect = createEffect(() => of({ foo: 'a' }), { dispatch: false });
-        `).toSucceed();
-
-        expectSnippet(`
-          const effect = createEffect(() => ({ foo: 'a' }), { dispatch: false });
-        `).toFail(
-          /Type '{ foo: string; }' is not assignable to type 'Observable<unknown> | ((...args: any[]) => Observable<unknown>)'./
-        );
-      });
-    });
-  });
-
   it('should flag the variable with a meta tag', () => {
     const effect = createEffect(() => of({ type: 'a' }));
 

--- a/modules/effects/spec/types/effect_creator.spec.ts
+++ b/modules/effects/spec/types/effect_creator.spec.ts
@@ -1,0 +1,54 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('createEffect()', () => {
+  const expectSnippet = expecter(
+    code => `
+      import { Action } from '@ngrx/store';
+      import { createEffect } from '@ngrx/effects';
+      import { of } from 'rxjs';
+
+      ${code}`,
+    compilerOptions()
+  );
+
+  describe('dispatch: true', () => {
+    it('should enforce an Action return value', () => {
+      expectSnippet(`
+        const effect = createEffect(() => of({ type: 'a' }));
+      `).toSucceed();
+
+      expectSnippet(`
+        const effect = createEffect(() => of({ foo: 'a' }));
+      `).toFail(
+        /Type 'Observable<{ foo: string; }>' is not assignable to type 'Observable<Action> | ((...args: any[]) => Observable<Action>)'./
+      );
+    });
+
+    it('should enforce an Action return value when dispatch is provided', () => {
+      expectSnippet(`
+        const effect = createEffect(() => of({ type: 'a' }), { dispatch: true });
+      `).toSucceed();
+
+      expectSnippet(`
+        const effect = createEffect(() => of({ foo: 'a' }), { dispatch: true });
+      `).toFail(
+        /Type 'Observable<{ foo: string; }>' is not assignable to type 'Observable<Action> | ((...args: any[]) => Observable<Action>)'./
+      );
+    });
+  });
+
+  describe('dispatch: false', () => {
+    it('should enforce an Observable return value', () => {
+      expectSnippet(`
+        const effect = createEffect(() => of({ foo: 'a' }), { dispatch: false });
+      `).toSucceed();
+
+      expectSnippet(`
+        const effect = createEffect(() => ({ foo: 'a' }), { dispatch: false });
+      `).toFail(
+        /Type '{ foo: string; }' is not assignable to type 'Observable<unknown> | ((...args: any[]) => Observable<unknown>)'./
+      );
+    });
+  });
+});

--- a/modules/effects/spec/types/of_type.spec.ts
+++ b/modules/effects/spec/types/of_type.spec.ts
@@ -1,0 +1,184 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('ofType()', () => {
+  describe('action creators', () => {
+    const expectSnippet = expecter(
+      code => `
+      import { Action, createAction, props } from '@ngrx/store';
+      import { Actions, ofType } from '@ngrx/effects';
+      import { of } from 'rxjs';
+
+      const actions$ = {} as Actions;
+
+      ${code}`,
+      compilerOptions()
+    );
+
+    it('should infer correctly', () => {
+      expectSnippet(`
+        const actionA = createAction('Action A');
+        const effect = actions$.pipe(ofType(actionA))
+      `).toInfer('effect', 'Observable<TypedAction<"Action A">>');
+    });
+
+    it('should infer correctly with props', () => {
+      expectSnippet(`
+        const actionA = createAction('Action A', props<{ foo: string }>()});
+        const effect = actions$.pipe(ofType(actionA))
+      `).toInfer(
+        'effect',
+        'Observable<{ foo: string; } & TypedAction<"Action A">>'
+      );
+    });
+
+    it('should infer correctly with function', () => {
+      expectSnippet(`
+        const actionA = createAction('Action A', (foo: string) => ({ foo }));
+        const effect = actions$.pipe(ofType(actionA))
+      `).toInfer(
+        'effect',
+        'Observable<{ foo: string; } & TypedAction<"Action A">>'
+      );
+    });
+
+    it('should infer correctly with multiple actions with 5 actions', () => {
+      expectSnippet(`
+        const actionA = createAction('Action A');
+        const actionB = createAction('Action B');
+        const actionC = createAction('Action C');
+        const actionD = createAction('Action D');
+        const actionE = createAction('Action E');
+
+        const effect = actions$.pipe(ofType(actionA, actionB, actionC, actionD, actionE))
+      `).toInfer(
+        'effect',
+        'Observable<TypedAction<"Action A"> | TypedAction<"Action B"> | TypedAction<"Action C"> | TypedAction<"Action D"> | TypedAction<"Action E">>'
+      );
+    });
+
+    it('should infer correctly with multiple actions (with over 5 actions)', () => {
+      expectSnippet(`
+        const actionA = createAction('Action A');
+        const actionB = createAction('Action B');
+        const actionC = createAction('Action C');
+        const actionD = createAction('Action D');
+        const actionE = createAction('Action E');
+        const actionF = createAction('Action F');
+        const actionG = createAction('Action G');
+
+        const effect = actions$.pipe(ofType(actionA, actionB, actionC, actionD, actionE, actionF, actionG))
+      `).toInfer(
+        'effect',
+        'Observable<TypedAction<"Action A"> | TypedAction<"Action B"> | TypedAction<"Action C"> | TypedAction<"Action D"> | TypedAction<"Action E"> | TypedAction<"Action F"> | TypedAction<"Action G">>'
+      );
+    });
+  });
+
+  describe('strings with typed Actions', () => {
+    const expectSnippet = expecter(
+      code => `
+      import { Action } from '@ngrx/store';
+      import { Actions, ofType } from '@ngrx/effects';
+      import { of } from 'rxjs';
+
+      const ACTION_A = 'ACTION A'
+      const ACTION_B = 'ACTION B'
+      const ACTION_C = 'ACTION C'
+      const ACTION_D = 'ACTION D'
+      const ACTION_E = 'ACTION E'
+      const ACTION_F = 'ACTION F'
+
+      interface ActionA { type: typeof ACTION_A };
+      interface ActionB { type: typeof ACTION_B };
+      interface ActionC { type: typeof ACTION_C };
+      interface ActionD { type: typeof ACTION_D };
+      interface ActionE { type: typeof ACTION_E };
+      interface ActionF { type: typeof ACTION_F };
+
+      ${code}`,
+      compilerOptions()
+    );
+
+    it('should infer correctly', () => {
+      expectSnippet(`
+        const actions$ = {} as Actions<ActionA>;
+        const effect = actions$.pipe(ofType(ACTION_A))
+      `).toInfer('effect', 'Observable<ActionA>');
+    });
+
+    it('should infer correctly with multiple actions (up to 5 actions)', () => {
+      expectSnippet(`
+        const actions$ = {} as Actions<ActionA | ActionB | ActionC | ActionD | ActionE>;
+        const effect = actions$.pipe(ofType(ACTION_A, ACTION_B, ACTION_C, ACTION_D, ACTION_E))
+      `).toInfer(
+        'effect',
+        'Observable<ActionA | ActionB | ActionC | ActionD | ActionE>'
+      );
+    });
+
+    it('should infer to Action when more than 5 actions', () => {
+      expectSnippet(`
+        const actions$ = {} as Actions<ActionA | ActionB | ActionC | ActionD | ActionE | ActionF>;
+        const effect = actions$.pipe(ofType(ACTION_A, ACTION_B, ACTION_C, ACTION_D, ACTION_E, ACTION_F))
+      `).toInfer('effect', 'Observable<Action>');
+    });
+
+    it('should infer to never when the action is not in Actions', () => {
+      expectSnippet(`
+        const actions$ = {} as Actions<ActionA>;
+        const effect = actions$.pipe(ofType(ACTION_B))
+      `).toInfer('effect', 'Observable<never>');
+    });
+  });
+
+  describe('strings ofType generic', () => {
+    const expectSnippet = expecter(
+      code => `
+      import { Action } from '@ngrx/store';
+      import { Actions, ofType } from '@ngrx/effects';
+      import { of } from 'rxjs';
+
+      const ACTION_A = 'ACTION A'
+      const ACTION_B = 'ACTION B'
+      const ACTION_C = 'ACTION C'
+      const ACTION_D = 'ACTION D'
+      const ACTION_E = 'ACTION E'
+      const ACTION_F = 'ACTION F'
+
+      interface ActionA { type: typeof ACTION_A };
+      interface ActionB { type: typeof ACTION_B };
+      interface ActionC { type: typeof ACTION_C };
+      interface ActionD { type: typeof ACTION_D };
+      interface ActionE { type: typeof ACTION_E };
+      interface ActionF { type: typeof ACTION_F };
+
+      ${code}`,
+      compilerOptions()
+    );
+
+    it('should infer correctly', () => {
+      expectSnippet(`
+        const actions$ = {} as Actions;
+        const effect = actions$.pipe(ofType<ActionA>(ACTION_A))
+      `).toInfer('effect', 'Observable<ActionA>');
+    });
+
+    it('should infer correctly with multiple actions (with over 5 actions)', () => {
+      expectSnippet(`
+        const actions$ = {} as Actions;
+        const effect = actions$.pipe(ofType<ActionA | ActionB | ActionC | ActionD | ActionE | ActionF>(ACTION_A, ACTION_B, ACTION_C, ACTION_D, ACTION_E, ACTION_F))
+      `).toInfer(
+        'effect',
+        'Observable<ActionA | ActionB | ActionC | ActionD | ActionE | ActionF>'
+      );
+    });
+
+    it('should infer to the generic even if the generic is wrong', () => {
+      expectSnippet(`
+        const actions$ = {} as Actions;
+        const effect = actions$.pipe(ofType<ActionA>(ACTION_B))
+      `).toInfer('effect', 'Observable<ActionA>');
+    });
+  });
+});

--- a/modules/effects/spec/types/of_type.spec.ts
+++ b/modules/effects/spec/types/of_type.spec.ts
@@ -42,21 +42,6 @@ describe('ofType()', () => {
       );
     });
 
-    it('should infer correctly with multiple actions with 5 actions', () => {
-      expectSnippet(`
-        const actionA = createAction('Action A');
-        const actionB = createAction('Action B');
-        const actionC = createAction('Action C');
-        const actionD = createAction('Action D');
-        const actionE = createAction('Action E');
-
-        const effect = actions$.pipe(ofType(actionA, actionB, actionC, actionD, actionE))
-      `).toInfer(
-        'effect',
-        'Observable<TypedAction<"Action A"> | TypedAction<"Action B"> | TypedAction<"Action C"> | TypedAction<"Action D"> | TypedAction<"Action E">>'
-      );
-    });
-
     it('should infer correctly with multiple actions (with over 5 actions)', () => {
       expectSnippet(`
         const actionA = createAction('Action A');

--- a/modules/effects/spec/types/utils.ts
+++ b/modules/effects/spec/types/utils.ts
@@ -1,0 +1,11 @@
+export const compilerOptions = () => ({
+  moduleResolution: 'node',
+  target: 'es2015',
+  baseUrl: '.',
+  experimentalDecorators: true,
+  paths: {
+    '@ngrx/store': ['./modules/store'],
+    '@ngrx/effects': ['./modules/effects'],
+    rxjs: ['../npm/node_modules/rxjs', './node_modules/rxjs'],
+  },
+});

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -26,12 +26,6 @@ export class Actions<V = Action> extends Observable<V> {
   }
 }
 
-// Module-private helper type
-type ActionExtractor<
-  T extends string | AC,
-  AC extends ActionCreator<string, Creator>,
-  E
-> = T extends string ? E : ReturnType<Extract<T, AC>>;
 /**
  * 'ofType' filters an Observable of Actions into an observable of the actions
  * whose type strings are passed to it.
@@ -54,50 +48,47 @@ type ActionExtractor<
  * 'Observable<never>'. In such cases one has to manually set the generic type
  * like `actions.ofType<AdditionAction>('add')`.
  */
+
 export function ofType<
-  E extends Extract<U, { type: T1 }>,
-  AC extends ActionCreator<string, Creator>,
-  T1 extends string | AC,
+  AC extends ActionCreator<string, Creator>[],
   U extends Action = Action,
-  V = T1 extends string ? E : ReturnType<Extract<T1, AC>>
+  V = ReturnType<AC[number]>
+>(...allowedTypes: AC): OperatorFunction<U, V>;
+
+export function ofType<
+  V extends Extract<U, { type: T1 }>,
+  T1 extends string = string,
+  U extends Action = Action
 >(t1: T1): OperatorFunction<U, V>;
 export function ofType<
-  E extends Extract<U, { type: T1 | T2 }>,
-  AC extends ActionCreator<string, Creator>,
-  T1 extends string | AC,
-  T2 extends string | AC,
-  U extends Action = Action,
-  V = ActionExtractor<T1 | T2, AC, E>
+  V extends Extract<U, { type: T1 | T2 }>,
+  T1 extends string = string,
+  T2 extends string = string,
+  U extends Action = Action
 >(t1: T1, t2: T2): OperatorFunction<U, V>;
 export function ofType<
-  E extends Extract<U, { type: T1 | T2 | T3 }>,
-  AC extends ActionCreator<string, Creator>,
-  T1 extends string | AC,
-  T2 extends string | AC,
-  T3 extends string | AC,
-  U extends Action = Action,
-  V = ActionExtractor<T1 | T2 | T3, AC, E>
+  V extends Extract<U, { type: T1 | T2 | T3 }>,
+  T1 extends string = string,
+  T2 extends string = string,
+  T3 extends string = string,
+  U extends Action = Action
 >(t1: T1, t2: T2, t3: T3): OperatorFunction<U, V>;
 export function ofType<
-  E extends Extract<U, { type: T1 | T2 | T3 | T4 }>,
-  AC extends ActionCreator<string, Creator>,
-  T1 extends string | AC,
-  T2 extends string | AC,
-  T3 extends string | AC,
-  T4 extends string | AC,
-  U extends Action = Action,
-  V = ActionExtractor<T1 | T2 | T3 | T4, AC, E>
+  V extends Extract<U, { type: T1 | T2 | T3 | T4 }>,
+  T1 extends string = string,
+  T2 extends string = string,
+  T3 extends string = string,
+  T4 extends string = string,
+  U extends Action = Action
 >(t1: T1, t2: T2, t3: T3, t4: T4): OperatorFunction<U, V>;
 export function ofType<
-  E extends Extract<U, { type: T1 | T2 | T3 | T4 | T5 }>,
-  AC extends ActionCreator<string, Creator>,
-  T1 extends string | AC,
-  T2 extends string | AC,
-  T3 extends string | AC,
-  T4 extends string | AC,
-  T5 extends string | AC,
-  U extends Action = Action,
-  V = ActionExtractor<T1 | T2 | T3 | T4 | T5, AC, E>
+  V extends Extract<U, { type: T1 | T2 | T3 | T4 | T5 }>,
+  T1 extends string = string,
+  T2 extends string = string,
+  T3 extends string = string,
+  T4 extends string = string,
+  T5 extends string = string,
+  U extends Action = Action
 >(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5): OperatorFunction<U, V>;
 /**
  * Fallback for more than 5 arguments.
@@ -108,8 +99,9 @@ export function ofType<
  * arguments, to preserve backwards compatibility with old versions of ngrx.
  */
 export function ofType<V extends Action>(
-  ...allowedTypes: Array<string | ActionCreator<string, Creator>>
+  ...allowedTypes: string[]
 ): OperatorFunction<Action, V>;
+
 export function ofType(
   ...allowedTypes: Array<string | ActionCreator<string, Creator>>
 ): OperatorFunction<Action, Action> {

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -26,6 +26,12 @@ export class Actions<V = Action> extends Observable<V> {
   }
 }
 
+// Module-private helper type
+type ActionExtractor<
+  T extends string | AC,
+  AC extends ActionCreator<string, Creator>,
+  E
+> = T extends string ? E : ReturnType<Extract<T, AC>>;
 /**
  * 'ofType' filters an Observable of Actions into an observable of the actions
  * whose type strings are passed to it.
@@ -48,7 +54,6 @@ export class Actions<V = Action> extends Observable<V> {
  * 'Observable<never>'. In such cases one has to manually set the generic type
  * like `actions.ofType<AdditionAction>('add')`.
  */
-
 export function ofType<
   AC extends ActionCreator<string, Creator>[],
   U extends Action = Action,
@@ -56,39 +61,49 @@ export function ofType<
 >(...allowedTypes: AC): OperatorFunction<U, V>;
 
 export function ofType<
-  V extends Extract<U, { type: T1 }>,
-  T1 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  U extends Action = Action,
+  V = T1 extends string ? E : ReturnType<Extract<T1, AC>>
 >(t1: T1): OperatorFunction<U, V>;
 export function ofType<
-  V extends Extract<U, { type: T1 | T2 }>,
-  T1 extends string = string,
-  T2 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 | T2 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  T2 extends string | AC,
+  U extends Action = Action,
+  V = ActionExtractor<T1 | T2, AC, E>
 >(t1: T1, t2: T2): OperatorFunction<U, V>;
 export function ofType<
-  V extends Extract<U, { type: T1 | T2 | T3 }>,
-  T1 extends string = string,
-  T2 extends string = string,
-  T3 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 | T2 | T3 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  T2 extends string | AC,
+  T3 extends string | AC,
+  U extends Action = Action,
+  V = ActionExtractor<T1 | T2 | T3, AC, E>
 >(t1: T1, t2: T2, t3: T3): OperatorFunction<U, V>;
 export function ofType<
-  V extends Extract<U, { type: T1 | T2 | T3 | T4 }>,
-  T1 extends string = string,
-  T2 extends string = string,
-  T3 extends string = string,
-  T4 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 | T2 | T3 | T4 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  T2 extends string | AC,
+  T3 extends string | AC,
+  T4 extends string | AC,
+  U extends Action = Action,
+  V = ActionExtractor<T1 | T2 | T3 | T4, AC, E>
 >(t1: T1, t2: T2, t3: T3, t4: T4): OperatorFunction<U, V>;
 export function ofType<
-  V extends Extract<U, { type: T1 | T2 | T3 | T4 | T5 }>,
-  T1 extends string = string,
-  T2 extends string = string,
-  T3 extends string = string,
-  T4 extends string = string,
-  T5 extends string = string,
-  U extends Action = Action
+  E extends Extract<U, { type: T1 | T2 | T3 | T4 | T5 }>,
+  AC extends ActionCreator<string, Creator>,
+  T1 extends string | AC,
+  T2 extends string | AC,
+  T3 extends string | AC,
+  T4 extends string | AC,
+  T5 extends string | AC,
+  U extends Action = Action,
+  V = ActionExtractor<T1 | T2 | T3 | T4 | T5, AC, E>
 >(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5): OperatorFunction<U, V>;
 /**
  * Fallback for more than 5 arguments.
@@ -99,9 +114,8 @@ export function ofType<
  * arguments, to preserve backwards compatibility with old versions of ngrx.
  */
 export function ofType<V extends Action>(
-  ...allowedTypes: string[]
+  ...allowedTypes: Array<string | ActionCreator<string, Creator>>
 ): OperatorFunction<Action, V>;
-
 export function ofType(
   ...allowedTypes: Array<string | ActionCreator<string, Creator>>
 ): OperatorFunction<Action, Action> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Today, I had the case where I needed to support more than 5 actions inside an effect, but the types only allow up to 5 actions.

## What is the new behavior?

I'm proposing a change where we could support an unrestricted amount of actions.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

/cc @alex-okrushko 
