### PR TITLE
feat(effects): createEffect returns specific type for dispatch false

### DIFF
--- a/modules/effects/spec/types/effect_creator.spec.ts
+++ b/modules/effects/spec/types/effect_creator.spec.ts
@@ -47,7 +47,7 @@ describe('createEffect()', () => {
       expectSnippet(`
         const effect = createEffect(() => ({ foo: 'a' }), { dispatch: false });
       `).toFail(
-        /Type '{ foo: string; }' is not assignable to type 'Observable<unknown> | ((...args: any[]) => Observable<unknown>)'./
+        /Type '{ foo: string; }' is not assignable to type 'Observable<{}> | ((...args: any[]) => Observable<{}>)'./
       );
     });
   });

--- a/modules/effects/src/effect_creator.ts
+++ b/modules/effects/src/effect_creator.ts
@@ -8,10 +8,8 @@ interface CreateEffectMetadata {
   [CREATE_EFFECT_METADATA_KEY]: EffectConfig;
 }
 
-type DispatchType<T> = T extends { dispatch: infer U } ? U : unknown;
-type ObservableReturnType<T> = T extends false
-  ? Observable<unknown>
-  : Observable<Action>;
+type DispatchType<T> = T extends { dispatch: infer U } ? U : true;
+type ObservableType<T, OriginalType> = T extends false ? OriginalType : Action;
 /**
  * @description
  * Creates an effect from an `Observable` and an `EffectConfig`.
@@ -46,9 +44,9 @@ type ObservableReturnType<T> = T extends false
  */
 export function createEffect<
   C extends EffectConfig,
-  T extends DispatchType<C>,
-  O extends ObservableReturnType<T>,
-  R extends O | ((...args: any[]) => O)
+  DT extends DispatchType<C>,
+  OT extends ObservableType<DT, OT>,
+  R extends Observable<OT> | ((...args: any[]) => Observable<OT>)
 >(source: () => R, config?: Partial<C>): R & CreateEffectMetadata {
   const effect = source();
   const value: EffectConfig = {

--- a/modules/effects/src/models.ts
+++ b/modules/effects/src/models.ts
@@ -13,7 +13,7 @@ export interface EffectConfig {
   resubscribeOnError?: boolean;
 }
 
-export const DEFAULT_EFFECT_CONFIG: Required<EffectConfig> = {
+export const DEFAULT_EFFECT_CONFIG: Readonly<Required<EffectConfig>> = {
   dispatch: true,
   resubscribeOnError: true,
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

based of https://github.com/ngrx/platform/pull/2194

`createEffect` with `{dispatch: false}` now returns whatever Observable type is actually returned (instead of `unknown`).

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`createEffect` with `{dispatch: false}` returns  `Observable<unknown>`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

`createEffect` with `{dispatch: false}` returns  `Observable<SpecificType>`.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

Somewhat. If anyone was relying that `Observable<unknown>` is returned. However, `Observable<SpecificType>` can be always widened to `Observable<unknown>` so it shouldn't really break anything.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
