### PR TITLE
refactor(effects): inline ngrxOnRunEffects type

### DIFF
--- a/modules/effects/src/effect_sources.ts
+++ b/modules/effects/src/effect_sources.ts
@@ -18,7 +18,6 @@ import { mergeEffects } from './effects_resolver';
 import {
   onIdentifyEffectsKey,
   onRunEffectsKey,
-  onRunEffectsFn,
   OnRunEffects,
   onInitEffects,
 } from './lifecycle_hooks';
@@ -30,7 +29,7 @@ export class EffectSources extends Subject<any> {
     super();
   }
 
-  addEffects(effectSourceInstance: any) {
+  addEffects(effectSourceInstance: any): void {
     this.next(effectSourceInstance);
 
     if (
@@ -91,9 +90,9 @@ function resolveEffectSource(
   };
 }
 
-function isOnRunEffects(sourceInstance: {
-  [onRunEffectsKey]?: onRunEffectsFn;
-}): sourceInstance is OnRunEffects {
+function isOnRunEffects(
+  sourceInstance: Partial<OnRunEffects>
+): sourceInstance is OnRunEffects {
   const source = getSourceForInstance(sourceInstance);
 
   return (

--- a/modules/effects/src/lifecycle_hooks.ts
+++ b/modules/effects/src/lifecycle_hooks.ts
@@ -37,10 +37,6 @@ export interface OnIdentifyEffects {
 export const onIdentifyEffectsKey: keyof OnIdentifyEffects =
   'ngrxOnIdentifyEffects';
 
-export type onRunEffectsFn = (
-  resolvedEffects$: Observable<EffectNotification>
-) => Observable<EffectNotification>;
-
 /**
  * @description
  * Interface to control the lifecycle of effects.
@@ -73,7 +69,9 @@ export interface OnRunEffects {
    * @description
    * Method to control the lifecycle of effects.
    */
-  ngrxOnRunEffects: onRunEffectsFn;
+  ngrxOnRunEffects(
+    resolvedEffects$: Observable<EffectNotification>
+  ): Observable<EffectNotification>;
 }
 
 export const onRunEffectsKey: keyof OnRunEffects = 'ngrxOnRunEffects';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

JetBrains WebStorm can not recognize that `ngrxOnRunEffects` is implements `OnRunEffects`
![image](https://user-images.githubusercontent.com/11780854/68178065-1358cf80-ffbd-11e9-8dcc-d23269b63991.png)

## What is the new behavior?

JetBrains WebStorm can recognize that `ngrxOnRunEffects` is implements `OnRunEffects`
![image](https://user-images.githubusercontent.com/11780854/68178043-ff14d280-ffbc-11e9-92d7-c0e1a2838632.png)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
