### PR TITLE
refactor(schematics): migrate from styleext to style

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -101,7 +101,7 @@
       "flat": true,
       "spec": false,
       "prefix": "bc",
-      "styleext": "css"
+      "style": "css"
     },
     "@schematics/angular:directive": {
       "prefix": "bc"

--- a/modules/schematics/src/container/index.spec.ts
+++ b/modules/schematics/src/container/index.spec.ts
@@ -21,7 +21,7 @@ describe('Container Schematic', () => {
     inlineStyle: false,
     inlineTemplate: false,
     changeDetection: 'Default',
-    styleext: 'css',
+    style: 'css',
     spec: true,
     module: undefined,
     export: false,

--- a/modules/schematics/src/container/schema.json
+++ b/modules/schematics/src/container/schema.json
@@ -55,8 +55,9 @@
       "description": "The prefix to apply to generated selectors.",
       "alias": "p"
     },
-    "styleext": {
-      "description": "The file extension to be used for style files.",
+    "style": {
+      "description":
+        "The file extension or preprocessor to use for style files.",
       "type": "string",
       "default": "css"
     },

--- a/modules/schematics/src/container/schema.ts
+++ b/modules/schematics/src/container/schema.ts
@@ -32,9 +32,9 @@ export interface Schema {
    */
   prefix?: string;
   /**
-   * The file extension to be used for style files.
+   * The file extension or preprocessor to use for style files.
    */
-  styleext?: string;
+  style?: string;
   /**
    * Specifies if a spec file is generated.
    */

--- a/projects/ngrx.io/angular.json
+++ b/projects/ngrx.io/angular.json
@@ -173,7 +173,7 @@
     "@schematics/angular:component": {
       "inlineStyle": true,
       "prefix": "aio",
-      "styleext": "scss"
+      "style": "scss"
     },
     "@schematics/angular:directive": {
       "prefix": "aio"

--- a/projects/ngrx.io/content/guide/schematics/container.md
+++ b/projects/ngrx.io/content/guide/schematics/container.md
@@ -55,7 +55,7 @@ If you want to generate a container with an scss file, add `@ngrx/schematics:con
 ```json
 "schematics": {
   "@ngrx/schematics:container": {
-    "styleext": "scss"
+    "style": "scss"
   }
 }
 ```

--- a/projects/ngrx.io/content/guide/schematics/index.md
+++ b/projects/ngrx.io/content/guide/schematics/index.md
@@ -56,7 +56,7 @@ The `@ngrx/schematics` extend the default `@schematics/angular` collection. If y
 ```json
 "schematics": {
   "@ngrx/schematics:component": {
-    "styleext": "scss"
+    "style": "scss"
   }
 }
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Migration from `styleext` to `style`
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When setting the `style` you can do this by `ng set default.styleext`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2248 

## What is the new behavior?
With these changes, we are inline with the Angular CLI and you need the following command for setting the style `ng set default.style`

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
