### PR TITLE
fix(store): added noop for addFeature in MockReducerManager

### DIFF
--- a/modules/store/testing/src/mock_reducer_manager.ts
+++ b/modules/store/testing/src/mock_reducer_manager.ts
@@ -9,4 +9,12 @@ export class MockReducerManager extends BehaviorSubject<
   constructor() {
     super(() => undefined);
   }
+  
+  addFeature(feature: any) {
+    /* noop */
+  }
+
+  addFeatures(feature: any) {
+    /* noop */
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

It is currently not possible to use _provideMockStore_ if the component has a dependency to a module which uses forFeature imports.

```
StoreModule.forFeature('feature', FeatureReducer),
EffectsModule.forFeature([FeatureEffects]),
```

Currently crashes with:
`
TypeError: reducerManager.addFeatures is not a function
 `

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2263

## What is the new behavior?

Added noop for _addFeature_.
## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
