### PR TITLE
feat(store): enable immutability checks by default

### DIFF
--- a/modules/store/schematics/ng-add/index.spec.ts
+++ b/modules/store/schematics/ng-add/index.spec.ts
@@ -130,17 +130,4 @@ describe('Store ng-add Schematic', () => {
 
     expect(content).toMatch(/export interface AppState {/);
   });
-
-  it('should not add runtime checks by default', () => {
-    const options = {
-      ...defaultOptions,
-      module: 'app.module.ts',
-      minimal: true,
-    };
-
-    const tree = schematicRunner.runSchematic('ng-add', options, appTree);
-    const content = tree.readContent(`${projectPath}/src/app/app.module.ts`);
-
-    expect(content).toMatch(/StoreModule.forRoot\(\{\}, \{\}\)/);
-  });
 });

--- a/modules/store/schematics/ng-add/index.spec.ts
+++ b/modules/store/schematics/ng-add/index.spec.ts
@@ -131,14 +131,16 @@ describe('Store ng-add Schematic', () => {
     expect(content).toMatch(/export interface AppState {/);
   });
 
-  it('should add runtime checks by default', () => {
-    const options = { ...defaultOptions, module: 'app.module.ts' };
+  it('should not add runtime checks by default', () => {
+    const options = {
+      ...defaultOptions,
+      module: 'app.module.ts',
+      minimal: true,
+    };
 
     const tree = schematicRunner.runSchematic('ng-add', options, appTree);
     const content = tree.readContent(`${projectPath}/src/app/app.module.ts`);
 
-    expect(content).toMatch(/runtimeChecks: {/);
-    expect(content).toMatch(/strictStateImmutability: true,/);
-    expect(content).toMatch(/strictActionImmutability: true/);
+    expect(content).toMatch(/StoreModule.forRoot\(\{\}, \{\}\)/);
   });
 });

--- a/modules/store/schematics/ng-add/index.ts
+++ b/modules/store/schematics/ng-add/index.ts
@@ -8,7 +8,6 @@ import {
   branchAndMerge,
   chain,
   mergeWith,
-  template,
   url,
   noop,
   move,
@@ -59,18 +58,9 @@ function addImportToNgModule(options: RootStoreOptions): Rule {
     const storeModuleReducers = options.minimal ? `{}` : `reducers`;
 
     const storeModuleConfig = options.minimal
-      ? `{
-      runtimeChecks: {
-        strictStateImmutability: true,
-        strictActionImmutability: true
-      }
-    }`
+      ? `{}`
       : `{
-      metaReducers,
-      runtimeChecks: {
-        strictStateImmutability: true,
-        strictActionImmutability: true
-      }
+      metaReducers
     }`;
     const storeModuleSetup = `StoreModule.forRoot(${storeModuleReducers}, ${storeModuleConfig})`;
 

--- a/modules/store/spec/runtime_checks.spec.ts
+++ b/modules/store/spec/runtime_checks.spec.ts
@@ -7,7 +7,34 @@ import * as metaReducers from '../src/meta-reducers';
 
 describe('Runtime checks:', () => {
   describe('createActiveRuntimeChecks:', () => {
-    it('should disable all checks by default', () => {
+    it('should enable immutability checks by default', () => {
+      expect(createActiveRuntimeChecks()).toEqual({
+        strictStateSerializability: false,
+        strictActionSerializability: false,
+        strictActionImmutability: true,
+        strictStateImmutability: true,
+      });
+    });
+
+    it('should allow the user to override the config', () => {
+      expect(
+        createActiveRuntimeChecks({
+          strictStateSerializability: true,
+          strictActionSerializability: true,
+          strictActionImmutability: false,
+          strictStateImmutability: false,
+        })
+      ).toEqual({
+        strictStateSerializability: true,
+        strictActionSerializability: true,
+        strictActionImmutability: false,
+        strictStateImmutability: false,
+      });
+    });
+
+    it('should disable runtime checks in production by default', () => {
+      spyOn(ngCore, 'isDevMode').and.returnValue(false);
+
       expect(createActiveRuntimeChecks()).toEqual({
         strictStateSerializability: false,
         strictActionSerializability: false,
@@ -16,51 +43,15 @@ describe('Runtime checks:', () => {
       });
     });
 
-    it('should log a warning in dev mode when no configuration is provided', () => {
-      const spy = spyOn(console, 'warn');
-
-      createActiveRuntimeChecks();
-
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('should not log a warning in dev mode when configuration is provided', () => {
-      const spy = spyOn(console, 'warn');
-
-      createActiveRuntimeChecks({});
-
-      expect(spy).not.toHaveBeenCalled();
-    });
-
-    it('should not log a warning when not dev mode when no configuration is provided', () => {
+    it('should disable runtime checks in production even if opted in to enable', () => {
       spyOn(ngCore, 'isDevMode').and.returnValue(false);
-      const spy = spyOn(console, 'warn');
 
-      createActiveRuntimeChecks();
-
-      expect(spy).not.toHaveBeenCalled();
-    });
-
-    it('should allow the user to override the config', () => {
       expect(
         createActiveRuntimeChecks({
           strictStateSerializability: true,
           strictActionSerializability: true,
-          strictActionImmutability: true,
-          strictStateImmutability: true,
         })
       ).toEqual({
-        strictStateSerializability: true,
-        strictActionSerializability: true,
-        strictActionImmutability: true,
-        strictStateImmutability: true,
-      });
-    });
-
-    it('should disable runtime checks in production', () => {
-      spyOn(ngCore, 'isDevMode').and.returnValue(false);
-
-      expect(createActiveRuntimeChecks()).toEqual({
         strictStateSerializability: false,
         strictActionSerializability: false,
         strictActionImmutability: false,
@@ -114,7 +105,7 @@ describe('Runtime checks:', () => {
       expect(serializationCheckMetaReducerSpy).not.toHaveBeenCalled();
     });
 
-    it('should not create a meta reducer without config', () => {
+    it('should create immutability meta reducer without config', () => {
       const serializationCheckMetaReducerSpy = spyOn(
         metaReducers,
         'serializationCheckMetaReducer'
@@ -136,7 +127,7 @@ describe('Runtime checks:', () => {
 
       const _store = TestBed.get<Store<any>>(Store);
       expect(serializationCheckMetaReducerSpy).not.toHaveBeenCalled();
-      expect(immutabilityCheckMetaReducerSpy).not.toHaveBeenCalled();
+      expect(immutabilityCheckMetaReducerSpy).toHaveBeenCalled();
     });
   });
 

--- a/modules/store/src/runtime_checks.ts
+++ b/modules/store/src/runtime_checks.ts
@@ -15,16 +15,11 @@ export function createActiveRuntimeChecks(
   runtimeChecks?: Partial<RuntimeChecks>
 ): RuntimeChecks {
   if (isDevMode()) {
-    if (runtimeChecks === undefined) {
-      console.warn(
-        '@ngrx/store: runtime checks are currently opt-in but will be the default in the next major version with the possibility to opt-out, see https://ngrx.io/guide/migration/v8 for more information.'
-      );
-    }
     return {
       strictStateSerializability: false,
       strictActionSerializability: false,
-      strictStateImmutability: false,
-      strictActionImmutability: false,
+      strictStateImmutability: true,
+      strictActionImmutability: true,
       ...runtimeChecks,
     };
   }


### PR DESCRIPTION
Closes #2217

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Store runtime immutability checks are being enabled by default with this change

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently immutability checks are opt in.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2217

## What is the new behavior?
If state or action is mutated then there will be a run time exception thrown by default now. In order to opt out user will need to pass immutability checks set to false.

## Does this PR introduce a breaking change?

```
[x] Yes
[] No
```

BREAKING CHANGE

Before
Immutability checks are opt-in.

After
Immutability checks are enabled by default. If state or action is mutated then there will be a run time exception thrown.