### PR TITLE
feat(store): add clearResult to reset a mock selector

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -7,6 +7,7 @@ export type MemoizedProjection = {
   memoized: AnyFn;
   reset: () => void;
   setResult: (result?: any) => void;
+  clearResult: () => void;
 };
 
 export type MemoizeFn = (t: AnyFn) => MemoizedProjection;
@@ -23,6 +24,7 @@ export interface MemoizedSelector<
   release(): void;
   projector: ProjectorFn;
   setResult: (result?: Result) => void;
+  clearResult: () => void;
 }
 
 export interface MemoizedSelectorWithProps<
@@ -34,6 +36,7 @@ export interface MemoizedSelectorWithProps<
   release(): void;
   projector: ProjectorFn;
   setResult: (result?: Result) => void;
+  clearResult: () => void;
 }
 
 export function isEqualCheck(a: any, b: any): boolean {
@@ -76,13 +79,17 @@ export function defaultMemoize(
   }
 
   function setResult(result: any = undefined) {
-    overrideResult = result;
+    overrideResult = { result };
+  }
+
+  function clearResult() {
+    overrideResult = undefined;
   }
 
   // tslint:disable-next-line:no-any anything could be the result.
   function memoized(): any {
     if (overrideResult !== undefined) {
-      return overrideResult;
+      return overrideResult.result;
     }
 
     if (!lastArguments) {
@@ -107,7 +114,7 @@ export function defaultMemoize(
     return newResult;
   }
 
-  return { memoized, reset, setResult };
+  return { memoized, reset, setResult, clearResult };
 }
 
 export function createSelector<State, S1, Result>(
@@ -590,6 +597,7 @@ export function createSelectorFactory(
       release,
       projector: memoizedProjector.memoized,
       setResult: memoizedState.setResult,
+      clearResult: memoizedState.clearResult,
     });
   };
 }

--- a/modules/store/testing/src/mock_store.ts
+++ b/modules/store/testing/src/mock_store.ts
@@ -102,7 +102,7 @@ export class MockStore<T> extends Store<T> {
     MockStore.selectors.forEach((_, selector) => {
       if (typeof selector !== 'string') {
         selector.release();
-        selector.setResult();
+        selector.clearResult();
       }
     });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Calling `mockSelector.setValue(undefined)`, does a reset the mocked selector. 

Closes #2244

## What is the new behavior?

Calling `mockSelector.setValue(undefined)`, sets the result to `undefined`.
To reset a mock selector, use `mockSelector.clearResult()`. 

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

```
BREAKING CHANGE:

BEFORE:

Using `mockSelector.setResult(undefined)` resulted in clearing the
return value.

AFTER:

Using `mockSelector.setResult(undefined)` will set the return value of
the selector to `undefined`.
To reset the mock selector, use `mockSelector.clearResult()`.
```