### PR TITLE
feat(schematics): update creators to the default

### DIFF
--- a/modules/schematics/src/action/index.spec.ts
+++ b/modules/schematics/src/action/index.spec.ts
@@ -76,10 +76,12 @@ describe('Action Schematic', () => {
   });
 
   describe('action classes', () => {
+    const actionClassesDefaultOptions = { ...defaultOptions, creators: false };
+
     it('should create an enum named "Foo"', () => {
       const tree = schematicRunner.runSchematic(
         'action',
-        defaultOptions,
+        actionClassesDefaultOptions,
         appTree
       );
       const fileContent = tree.readContent(
@@ -92,7 +94,7 @@ describe('Action Schematic', () => {
     it('should create a class based on the provided name', () => {
       const tree = schematicRunner.runSchematic(
         'action',
-        defaultOptions,
+        actionClassesDefaultOptions,
         appTree
       );
       const fileContent = tree.readContent(
@@ -105,7 +107,7 @@ describe('Action Schematic', () => {
     it('should create the union type based on the provided name', () => {
       const tree = schematicRunner.runSchematic(
         'action',
-        defaultOptions,
+        actionClassesDefaultOptions,
         appTree
       );
       const fileContent = tree.readContent(
@@ -116,7 +118,7 @@ describe('Action Schematic', () => {
     });
 
     it('should create spec class with right imports', () => {
-      const options = { ...defaultOptions, spec: true };
+      const options = { ...actionClassesDefaultOptions, spec: true };
       const tree = schematicRunner.runSchematic('action', options, appTree);
       const fileContent = tree.readContent(
         `${projectPath}/src/app/foo.actions.spec.ts`
@@ -127,12 +129,12 @@ describe('Action Schematic', () => {
   });
 
   describe('action creators', () => {
-    const creatorOptions = { ...defaultOptions, creators: true };
+    const creatorDefaultOptions = { ...defaultOptions };
 
     it('should create a const for the action creator', () => {
       const tree = schematicRunner.runSchematic(
         'action',
-        creatorOptions,
+        creatorDefaultOptions,
         appTree
       );
       const fileContent = tree.readContent(
@@ -146,7 +148,7 @@ describe('Action Schematic', () => {
     it('should create success/error actions when the api flag is set', () => {
       const tree = schematicRunner.runSchematic(
         'action',
-        { ...creatorOptions, api: true },
+        { ...creatorDefaultOptions, api: true },
         appTree
       );
       const fileContent = tree.readContent(
@@ -161,71 +163,74 @@ describe('Action Schematic', () => {
     });
   });
 
-  it('should group within an "actions" folder if group is set', () => {
-    const tree = schematicRunner.runSchematic(
-      'action',
-      {
-        ...defaultOptions,
-        group: true,
-      },
-      appTree
-    );
-    expect(
-      tree.files.indexOf(`${projectPath}/src/app/actions/foo.actions.ts`)
-    ).toBeGreaterThanOrEqual(0);
-  });
+  describe('api', () => {
+    it('should group within an "actions" folder if group is set', () => {
+      const tree = schematicRunner.runSchematic(
+        'action',
+        {
+          ...defaultOptions,
+          group: true,
+        },
+        appTree
+      );
+      expect(
+        tree.files.indexOf(`${projectPath}/src/app/actions/foo.actions.ts`)
+      ).toBeGreaterThanOrEqual(0);
+    });
 
-  it('should create a success class based on the provided name, given api', () => {
-    const tree = schematicRunner.runSchematic(
-      'action',
-      {
-        ...defaultOptions,
-        api: true,
-      },
-      appTree
-    );
-    const fileContent = tree.readContent(
-      `${projectPath}/src/app/foo.actions.ts`
-    );
+    it('should create a success class based on the provided name, given api', () => {
+      const tree = schematicRunner.runSchematic(
+        'action',
+        {
+          ...defaultOptions,
+          api: true,
+        },
+        appTree
+      );
+      const fileContent = tree.readContent(
+        `${projectPath}/src/app/foo.actions.ts`
+      );
 
-    expect(fileContent).toMatch(
-      /export class LoadFoosSuccess implements Action/
-    );
-  });
+      expect(fileContent).toMatch(
+        /export const loadFoosSuccess = createAction\(\r?\n?\s*'\[Foo\] Load Foos Success'\r?\n?\s*,/
+      );
+    });
 
-  it('should create a failure class based on the provided name, given api', () => {
-    const tree = schematicRunner.runSchematic(
-      'action',
-      {
-        ...defaultOptions,
-        api: true,
-      },
-      appTree
-    );
-    const fileContent = tree.readContent(
-      `${projectPath}/src/app/foo.actions.ts`
-    );
+    it('should create a failure class based on the provided name, given api', () => {
+      const tree = schematicRunner.runSchematic(
+        'action',
+        {
+          ...defaultOptions,
+          api: true,
+        },
+        appTree
+      );
+      const fileContent = tree.readContent(
+        `${projectPath}/src/app/foo.actions.ts`
+      );
 
-    expect(fileContent).toMatch(
-      /export class LoadFoosFailure implements Action/
-    );
-  });
+      expect(fileContent).toMatch(
+        /export const loadFoosFailure = createAction\(\r?\n?\s*'\[Foo\] Load Foos Failure'\r?\n?\s*,/
+      );
+    });
 
-  it('should create the union type with success and failure based on the provided name, given api', () => {
-    const tree = schematicRunner.runSchematic(
-      'action',
-      {
-        ...defaultOptions,
-        api: true,
-      },
-      appTree
-    );
-    const fileContent = tree.readContent(
-      `${projectPath}/src/app/foo.actions.ts`
-    );
+    it('should create the union type with success and failure based on the provided name, given api and creators false', () => {
+      const tree = schematicRunner.runSchematic(
+        'action',
+        {
+          ...defaultOptions,
+          api: true,
+          creators: false,
+        },
+        appTree
+      );
+      const fileContent = tree.readContent(
+        `${projectPath}/src/app/foo.actions.ts`
+      );
 
-    expect(fileContent).toMatch(
-      /export type FooActions = LoadFoos \| LoadFoosSuccess \| LoadFoosFailure/
-    );
+      expect(fileContent).toMatch(
+        /export type FooActions = LoadFoos \| LoadFoosSuccess \| LoadFoosFailure/
+      );
+    });
   });
 });

--- a/modules/schematics/src/action/schema.json
+++ b/modules/schematics/src/action/schema.json
@@ -50,7 +50,7 @@
     },
     "creators": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description":
         "Specifies whether to use creator functions for handling actions and reducers.",
       "aliases": ["c"],

--- a/modules/schematics/src/effect/schema.json
+++ b/modules/schematics/src/effect/schema.json
@@ -69,7 +69,7 @@
     },
     "creators": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description":
         "Specifies whether to use creator functions for handling actions, reducers, and effects.",
       "aliases": ["c"],

--- a/modules/schematics/src/entity/schema.json
+++ b/modules/schematics/src/entity/schema.json
@@ -53,7 +53,7 @@
     },
     "creators": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description":
         "Specifies whether to use creator functions for handling actions and reducers.",
       "aliases": ["c"],

--- a/modules/schematics/src/feature/index.spec.ts
+++ b/modules/schematics/src/feature/index.spec.ts
@@ -138,17 +138,18 @@ describe('Feature Schematic', () => {
     );
 
     expect(moduleFileContent).toMatch(
-      /import { FooEffects } from '\.\/foo\/effects\/foo.effects';/
+      /import { FooEffects } from '.\/foo\/effects\/foo.effects';/
     );
     expect(moduleFileContent).toMatch(
-      /import \* as fromFoo from '\.\/foo\/reducers\/foo.reducer';/
+      /import \* as fromFoo from '.\/foo\/reducers\/foo.reducer';/
     );
   });
 
-  it('should have all three api actions in actions type union if api flag enabled', () => {
+  it('should have all three api actions in actions type union if api flag enabled and creators=false', () => {
     const options = {
       ...defaultOptions,
       api: true,
+      creators: false,
     };
 
     const tree = schematicRunner.runSchematic('feature', options, appTree);
@@ -173,26 +174,27 @@ describe('Feature Schematic', () => {
     );
 
     expect(fileContent).toMatch(
-      /import { Actions, Effect, ofType } from '@ngrx\/effects';/
+      /import { Actions, createEffect, ofType } from '@ngrx\/effects';/
     );
     expect(fileContent).toMatch(
       /import { catchError, map, concatMap } from 'rxjs\/operators';/
     );
     expect(fileContent).toMatch(/import { EMPTY, of } from 'rxjs';/);
     expect(fileContent).toMatch(
-      /import { LoadFoosFailure, LoadFoosSuccess, FooActionTypes, FooActions } from '\.\/foo.actions';/
+      /import \* as FooActions from '.\/foo.actions';/
     );
 
     expect(fileContent).toMatch(/export class FooEffects/);
-    expect(fileContent).toMatch(/loadFoos\$ = this\.actions\$.pipe\(/);
-    expect(fileContent).toMatch(/ofType\(FooActionTypes\.LoadFoos\),/);
+    expect(fileContent).toMatch(/loadFoos\$ = createEffect\(\(\) => {/);
+    expect(fileContent).toMatch(/return this.actions\$.pipe\(/);
+    expect(fileContent).toMatch(/ofType\(FooActions.loadFoos\),/);
     expect(fileContent).toMatch(/concatMap\(\(\) =>/);
-    expect(fileContent).toMatch(/EMPTY\.pipe\(/);
+    expect(fileContent).toMatch(/EMPTY.pipe\(/);
     expect(fileContent).toMatch(
-      /map\(data => new LoadFoosSuccess\({ data }\)\),/
+      /map\(data => FooActions.loadFoosSuccess\({ data }\)\),/
     );
     expect(fileContent).toMatch(
-      /catchError\(error => of\(new LoadFoosFailure\({ error }\)\)\)\)/
+      /catchError\(error => of\(FooActions.loadFoosFailure\({ error }\)\)\)\)/
     );
   });
 
@@ -207,7 +209,12 @@ describe('Feature Schematic', () => {
       `${projectPath}/src/app/foo.reducer.ts`
     );
 
-    expect(fileContent).toMatch(/case FooActionTypes\.LoadFoosSuccess/);
-    expect(fileContent).toMatch(/case FooActionTypes\.LoadFoosFailure/);
+    expect(fileContent).toMatch(/on\(FooActions.loadFoos, state => state\),/);
+    expect(fileContent).toMatch(
+      /on\(FooActions.loadFoosSuccess, \(state, action\) => state\),/
+    );
+    expect(fileContent).toMatch(
+      /on\(FooActions.loadFoosFailure, \(state, action\) => state\),/
+    );
   });
 });

--- a/modules/schematics/src/feature/schema.json
+++ b/modules/schematics/src/feature/schema.json
@@ -61,7 +61,7 @@
     },
     "creators": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description":
         "Specifies if the actions, reducers, and effects should be created using creator functions",
       "aliases": ["c"],

--- a/modules/schematics/src/reducer/index.spec.ts
+++ b/modules/schematics/src/reducer/index.spec.ts
@@ -179,17 +179,18 @@ describe('Reducer Schematic', () => {
     );
 
     expect(content).toMatch(
-      /import\ \{\ FooActions,\ FooActionTypes\ }\ from\ \'\.\.\/\.\.\/actions\/foo\/foo\.actions';/
+      /import \* as FooActions from '..\/..\/actions\/foo\/foo.actions';/
     );
   });
 
-  it('should create an reducer function with api success and failure, given feature and api', () => {
+  it('should create an reducer function with api success and failure, given creators=false, feature and api', () => {
     const tree = schematicRunner.runSchematic(
       'reducer',
       {
         ...defaultOptions,
         feature: true,
         api: true,
+        creators: false,
       },
       appTree
     );
@@ -205,7 +206,7 @@ describe('Reducer Schematic', () => {
   it('should create an reducer function using createReducer', () => {
     const tree = schematicRunner.runSchematic(
       'reducer',
-      { ...defaultOptions, creators: true },
+      defaultOptions,
       appTree
     );
     const fileContent = tree.readContent(
@@ -221,7 +222,7 @@ describe('Reducer Schematic', () => {
   it('should create an reducer function in a feature using createReducer', () => {
     const tree = schematicRunner.runSchematic(
       'reducer',
-      { ...defaultOptions, creators: true, feature: true },
+      { ...defaultOptions, feature: true },
       appTree
     );
     const fileContent = tree.readContent(
@@ -238,7 +239,7 @@ describe('Reducer Schematic', () => {
   it('should create an reducer function in an api feature using createReducer', () => {
     const tree = schematicRunner.runSchematic(
       'reducer',
-      { ...defaultOptions, creators: true, feature: true, api: true },
+      { ...defaultOptions, feature: true, api: true },
       appTree
     );
     const fileContent = tree.readContent(

--- a/modules/schematics/src/reducer/schema.json
+++ b/modules/schematics/src/reducer/schema.json
@@ -65,7 +65,7 @@
     },
     "creators": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description":
         "Specifies whether to use creator functions for handling actions and reducers.",
       "aliases": ["c"],

--- a/projects/ngrx.io/content/guide/schematics/action.md
+++ b/projects/ngrx.io/content/guide/schematics/action.md
@@ -32,7 +32,7 @@ Use creator functions for actions
 - `--creators`
   - Alias: `-c`
   - Type: `boolean`
-  - Default: `false`
+  - Default: `true`
 
 Nest the actions file within a folder based on the action `name`.
 

--- a/projects/ngrx.io/content/guide/schematics/effect.md
+++ b/projects/ngrx.io/content/guide/schematics/effect.md
@@ -31,7 +31,7 @@ Use creator functions for actions and effects.
 - `--creators`
   - Alias: `-c`
   - Type: `boolean`
-  - Default: `false`
+  - Default: `true`
 
 Nest the effects file within a folder based by the effect `name`.
 

--- a/projects/ngrx.io/content/guide/schematics/entity.md
+++ b/projects/ngrx.io/content/guide/schematics/entity.md
@@ -31,7 +31,7 @@ Use creator functions for actions, reducers, and effects.
 - `--creators`
   - Alias: `-c`
   - Type: `boolean`
-  - Default: `false`
+  - Default: `true`
 
 Nest the effects file within a folder based on the entity `name`.
 

--- a/projects/ngrx.io/content/guide/schematics/feature.md
+++ b/projects/ngrx.io/content/guide/schematics/feature.md
@@ -31,7 +31,7 @@ Use creator functions for actions, reducers, and effects.
 - `--creators`
   - Alias: `-c`
   - Type: `boolean`
-  - Default: `false`
+  - Default: `true`
 
 Nest the feature files within a folder based on the feature `name`.
 

--- a/projects/ngrx.io/content/guide/schematics/reducer.md
+++ b/projects/ngrx.io/content/guide/schematics/reducer.md
@@ -32,7 +32,7 @@ Use creator functions to generate the actions and reducer.
 - `--creators`
   - Alias: `-c`
   - Type: `boolean`
-  - Default: `false`
+  - Default: `true`
 
 Nest the reducer file within a folder based on the reducer `name`.
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2210 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

BREAKING CHANGE:

BEFORE:

The create functions weren't the default to create actions, reducers and effects

AFTER:

The create functions are the default to create actions (`createAction`, reducers (`createReducer`) and effects (`createEffect`)
To fallback to the previous generators, use

```sh
ng generate reducer ReducerName --creators=false
```
