### PR TITLE
fix(effects): support resubscribe if throw in error handler

### DIFF
--- a/modules/effects/spec/effect_sources.spec.ts
+++ b/modules/effects/spec/effect_sources.spec.ts
@@ -282,6 +282,28 @@ describe('EffectSources', () => {
         expect(toActions(sources$)).toBeObservable(expected);
       });
 
+      it('should resubscribe on error if errorHandler throws error', () => {
+        (mockErrorReporter.handleError as jasmine.Spy).and.throwError(
+          'Some error'
+        );
+
+        class Eff {
+          @Effect()
+          b$ = hot('a--e--b--e--c--e--d').pipe(
+            map(v => {
+              if (v == 'e') throw new Error('An Error');
+              return v;
+            })
+          );
+        }
+
+        const sources$ = of(new Eff());
+
+        //                       👇 'e' is ignored.
+        const expected = cold('a-----b-----c-----d');
+        expect(toActions(sources$)).toBeObservable(expected);
+      });
+
       it(`should not break when the action in the error message can't be stringified`, () => {
         const sources$ = of(new SourceG());
 

--- a/modules/effects/src/effect_notification.ts
+++ b/modules/effects/src/effect_notification.ts
@@ -19,13 +19,16 @@ export function reportInvalidActions(
     const isInvalidAction = !isAction(action);
 
     if (isInvalidAction) {
-      reporter.handleError(
-        new Error(
-          `Effect ${getEffectName(
-            output
-          )} dispatched an invalid action: ${stringify(action)}`
-        )
-      );
+      try {
+        // handleError can throw errors
+        reporter.handleError(
+          new Error(
+            `Effect ${getEffectName(
+              output
+            )} dispatched an invalid action: ${stringify(action)}`
+          )
+        );
+      } catch {}
     }
   }
 }

--- a/modules/effects/src/effects_resolver.ts
+++ b/modules/effects/src/effects_resolver.ts
@@ -57,7 +57,13 @@ function resubscribeInCaseOfError<T extends Action>(
 ): Observable<T> {
   return observable$.pipe(
     catchError(error => {
-      if (errorHandler) errorHandler.handleError(error);
+      if (errorHandler) {
+        try {
+          errorHandler.handleError(error);
+        } catch {
+          // Handle throw in error handler
+        }
+      }
       // Return observable that produces this particular effect
       return resubscribeInCaseOfError(observable$, errorHandler);
     })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
If an error is thrown in the `ErrorHandler` it will not resubscribe the effects observable stream on error.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?
Now it is possible to throw an error in `ErrorHandler` and still resubscribe the effects observable stream on error. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
