### PR TITLE
docs(data): correct doc for disabling change tracking (2288)

### DIFF
--- a/modules/data/src/actions/merge-strategy.ts
+++ b/modules/data/src/actions/merge-strategy.ts
@@ -2,20 +2,18 @@
 export enum MergeStrategy {
   /**
    * Update the collection entities and ignore all change tracking for this operation.
-   * ChangeState is untouched.
+   * Each entity's `changeState` is untouched.
    */
   IgnoreChanges,
   /**
    * Updates current values for unchanged entities.
-   * If entities are changed, preserves their current values and
-   * overwrites their originalValue with the merge entity.
+   * For each changed entity it preserves the current value and overwrites the `originalValue` with the merge entity.
    * This is the query-success default.
    */
   PreserveChanges,
   /**
    * Replace the current collection entities.
-   * Discards the ChangeState for the merged entities if set
-   * and their ChangeTypes becomes "unchanged".
+   * For each merged entity it discards the `changeState` and sets the `changeType` to "unchanged".
    * This is the save-success default.
    */
   OverwriteChanges,

--- a/modules/data/src/dispatchers/entity-commands.ts
+++ b/modules/data/src/dispatchers/entity-commands.ts
@@ -119,6 +119,8 @@ export interface EntityCacheCommands<T> {
   /**
    * Replace all entities in the cached collection.
    * Does not save to remote storage.
+   * @param entities to add directly to cache.
+   * @param [options] options such as mergeStrategy
    */
   addAllToCache(entities: T[], options?: EntityActionOptions): void;
 
@@ -126,6 +128,8 @@ export interface EntityCacheCommands<T> {
    * Add a new entity directly to the cache.
    * Does not save to remote storage.
    * Ignored if an entity with the same primary key is already in cache.
+   * @param entity to add directly to cache.
+   * @param [options] options such as mergeStrategy
    */
   addOneToCache(entity: T, options?: EntityActionOptions): void;
 
@@ -133,6 +137,8 @@ export interface EntityCacheCommands<T> {
    * Add multiple new entities directly to the cache.
    * Does not save to remote storage.
    * Entities with primary keys already in cache are ignored.
+   * @param entities to add directly to cache.
+   * @param [options] options such as mergeStrategy
    */
   addManyToCache(entities: T[], options?: EntityActionOptions): void;
 
@@ -143,6 +149,7 @@ export interface EntityCacheCommands<T> {
    * Remove an entity directly from the cache.
    * Does not delete that entity from remote storage.
    * @param entity The entity to remove
+   * @param [options] options such as mergeStrategy
    */
   removeOneFromCache(entity: T, options?: EntityActionOptions): void;
 
@@ -150,6 +157,7 @@ export interface EntityCacheCommands<T> {
    * Remove an entity directly from the cache.
    * Does not delete that entity from remote storage.
    * @param key The primary key of the entity to remove
+   * @param [options] options such as mergeStrategy
    */
   removeOneFromCache(key: number | string, options?: EntityActionOptions): void;
 
@@ -157,6 +165,7 @@ export interface EntityCacheCommands<T> {
    * Remove multiple entities directly from the cache.
    * Does not delete these entities from remote storage.
    * @param entity The entities to remove
+   * @param [options] options such as mergeStrategy
    */
   removeManyFromCache(entities: T[], options?: EntityActionOptions): void;
 
@@ -164,6 +173,7 @@ export interface EntityCacheCommands<T> {
    * Remove multiple entities directly from the cache.
    * Does not delete these entities from remote storage.
    * @param keys The primary keys of the entities to remove
+   * @param [options] options such as mergeStrategy
    */
   removeManyFromCache(
     keys: (number | string)[],
@@ -176,6 +186,8 @@ export interface EntityCacheCommands<T> {
    * Ignored if an entity with matching primary key is not in cache.
    * The update entity may be partial (but must have its key)
    * in which case it patches the existing entity.
+   * @param entity to update directly in cache.
+   * @param [options] options such as mergeStrategy
    */
   updateOneInCache(entity: Partial<T>, options?: EntityActionOptions): void;
 
@@ -185,6 +197,8 @@ export interface EntityCacheCommands<T> {
    * Entities whose primary keys are not in cache are ignored.
    * Update entities may be partial but must at least have their keys.
    * such partial entities patch their cached counterparts.
+   * @param entities to update directly in cache.
+   * @param [options] options such as mergeStrategy
    */
   updateManyInCache(
     entities: Partial<T>[],
@@ -195,7 +209,9 @@ export interface EntityCacheCommands<T> {
    * Insert or update a cached entity directly.
    * Does not save to remote storage.
    * Upsert entity might be a partial of T but must at least have its key.
-   * Pass the Update<T> structure as the payload
+   * Pass the Update<T> structure as the payload.
+   * @param entity to upsert directly in cache.
+   * @param [options] options such as mergeStrategy
    */
   upsertOneInCache(entity: Partial<T>, options?: EntityActionOptions): void;
 
@@ -203,7 +219,9 @@ export interface EntityCacheCommands<T> {
    * Insert or update multiple cached entities directly.
    * Does not save to remote storage.
    * Upsert entities might be partial but must at least have their keys.
-   * Pass an array of the Update<T> structure as the payload
+   * Pass an array of the Update<T> structure as the payload.
+   * @param entities to upsert directly in cache.
+   * @param [options] options such as mergeStrategy
    */
   upsertManyInCache(
     entities: Partial<T>[],

--- a/modules/data/src/entity-services/entity-collection-service-base.ts
+++ b/modules/data/src/entity-services/entity-collection-service-base.ts
@@ -149,7 +149,7 @@ export class EntityCollectionServiceBase<
    * Dispatch action to cancel the persistence operation (query or save) with the given correlationId.
    * @param correlationId The correlation id for the corresponding EntityAction
    * @param [reason] explains why canceled and by whom.
-   * @param [options] options such as the tag
+   * @param [options] options such as the tag and mergeStrategy
    */
   cancel(
     correlationId: any,
@@ -271,27 +271,33 @@ export class EntityCollectionServiceBase<
   /**
    * Replace all entities in the cached collection.
    * Does not save to remote storage.
+   * @param entities to add directly to cache.
+   * @param [options] options such as mergeStrategy
    */
-  addAllToCache(entities: T[]): void {
-    this.dispatcher.addAllToCache(entities);
+  addAllToCache(entities: T[], options?: EntityActionOptions): void {
+    this.dispatcher.addAllToCache(entities, options);
   }
 
   /**
    * Add a new entity directly to the cache.
    * Does not save to remote storage.
    * Ignored if an entity with the same primary key is already in cache.
+   * @param entity to add directly to cache.
+   * @param [options] options such as mergeStrategy
    */
-  addOneToCache(entity: T): void {
-    this.dispatcher.addOneToCache(entity);
+  addOneToCache(entity: T, options?: EntityActionOptions): void {
+    this.dispatcher.addOneToCache(entity, options);
   }
 
   /**
    * Add multiple new entities directly to the cache.
    * Does not save to remote storage.
    * Entities with primary keys already in cache are ignored.
+   * @param entities to add directly to cache.
+   * @param [options] options such as mergeStrategy
    */
-  addManyToCache(entities: T[]): void {
-    this.dispatcher.addManyToCache(entities);
+  addManyToCache(entities: T[], options?: EntityActionOptions): void {
+    this.dispatcher.addManyToCache(entities, options);
   }
 
   /** Clear the cached entity collection */
@@ -303,34 +309,47 @@ export class EntityCollectionServiceBase<
    * Remove an entity directly from the cache.
    * Does not delete that entity from remote storage.
    * @param entity The entity to remove
+   * @param [options] options such as mergeStrategy
    */
-  removeOneFromCache(entity: T): void;
+  removeOneFromCache(entity: T, options?: EntityActionOptions): void;
 
   /**
    * Remove an entity directly from the cache.
    * Does not delete that entity from remote storage.
    * @param key The primary key of the entity to remove
+   * @param [options] options such as mergeStrategy
    */
-  removeOneFromCache(key: number | string): void;
-  removeOneFromCache(arg: (number | string) | T): void {
-    this.dispatcher.removeOneFromCache(arg as any);
+  removeOneFromCache(key: number | string, options?: EntityActionOptions): void;
+  removeOneFromCache(
+    arg: (number | string) | T,
+    options?: EntityActionOptions
+  ): void {
+    this.dispatcher.removeOneFromCache(arg as any, options);
   }
 
   /**
    * Remove multiple entities directly from the cache.
    * Does not delete these entities from remote storage.
    * @param entity The entities to remove
+   * @param [options] options such as mergeStrategy
    */
-  removeManyFromCache(entities: T[]): void;
+  removeManyFromCache(entities: T[], options?: EntityActionOptions): void;
 
   /**
    * Remove multiple entities directly from the cache.
    * Does not delete these entities from remote storage.
    * @param keys The primary keys of the entities to remove
+   * @param [options] options such as mergeStrategy
    */
-  removeManyFromCache(keys: (number | string)[]): void;
-  removeManyFromCache(args: (number | string)[] | T[]): void {
-    this.dispatcher.removeManyFromCache(args as any[]);
+  removeManyFromCache(
+    keys: (number | string)[],
+    options?: EntityActionOptions
+  ): void;
+  removeManyFromCache(
+    args: (number | string)[] | T[],
+    options?: EntityActionOptions
+  ): void {
+    this.dispatcher.removeManyFromCache(args as any[], options);
   }
 
   /**
@@ -339,11 +358,13 @@ export class EntityCollectionServiceBase<
    * Ignored if an entity with matching primary key is not in cache.
    * The update entity may be partial (but must have its key)
    * in which case it patches the existing entity.
+   * @param entity to update directly in cache.
+   * @param [options] options such as mergeStrategy
    */
-  updateOneInCache(entity: Partial<T>): void {
+  updateOneInCache(entity: Partial<T>, options?: EntityActionOptions): void {
     // update entity might be a partial of T but must at least have its key.
     // pass the Update<T> structure as the payload
-    this.dispatcher.updateOneInCache(entity);
+    this.dispatcher.updateOneInCache(entity, options);
   }
 
   /**
@@ -352,27 +373,41 @@ export class EntityCollectionServiceBase<
    * Entities whose primary keys are not in cache are ignored.
    * Update entities may be partial but must at least have their keys.
    * such partial entities patch their cached counterparts.
+   * @param entities to update directly in cache.
+   * @param [options] options such as mergeStrategy
    */
-  updateManyInCache(entities: Partial<T>[]): void {
-    this.dispatcher.updateManyInCache(entities);
+  updateManyInCache(
+    entities: Partial<T>[],
+    options?: EntityActionOptions
+  ): void {
+    this.dispatcher.updateManyInCache(entities, options);
   }
 
   /**
-   * Add or update a new entity directly to the cache.
+   * Insert or update a cached entity directly.
    * Does not save to remote storage.
    * Upsert entity might be a partial of T but must at least have its key.
-   * Pass the Update<T> structure as the payload
+   * Pass the Update<T> structure as the payload.
+   * @param entity to upsert directly in cache.
+   * @param [options] options such as mergeStrategy
    */
-  upsertOneInCache(entity: Partial<T>): void {
-    this.dispatcher.upsertOneInCache(entity);
+  upsertOneInCache(entity: Partial<T>, options?: EntityActionOptions): void {
+    this.dispatcher.upsertOneInCache(entity, options);
   }
 
   /**
-   * Add or update multiple cached entities directly.
+   * Insert or update multiple cached entities directly.
    * Does not save to remote storage.
+   * Upsert entities might be partial but must at least have their keys.
+   * Pass an array of the Update<T> structure as the payload.
+   * @param entities to upsert directly in cache.
+   * @param [options] options such as mergeStrategy
    */
-  upsertManyInCache(entities: Partial<T>[]): void {
-    this.dispatcher.upsertManyInCache(entities);
+  upsertManyInCache(
+    entities: Partial<T>[],
+    options?: EntityActionOptions
+  ): void {
+    this.dispatcher.upsertManyInCache(entities, options);
   }
 
   /**

--- a/projects/ngrx.io/content/guide/data/architecture-overview.md
+++ b/projects/ngrx.io/content/guide/data/architecture-overview.md
@@ -18,9 +18,11 @@ such as `QUERY_ALL` for the `Hero` entity type.
 
 2.  NgRx kicks into gear ...
 
-    1.  The NgRx Data [EntityReducer](guide/data/entity-reducer) reads the action's `entityName` property (`Hero` in this example) and forwards the action and existing entity collection state to the `EntityCollectionReducer` for heroes.
+    1.  The NgRx Data [EntityReducer](guide/data/entity-reducer) reads the action's `entityName` property (`Hero` in this example) and 
+    forwards the action and existing entity collection state to the `EntityCollectionReducer` for heroes.
 
-    1.  The collection reducer picks a switch-case based on the action's `op` (operation) property. That case processes the action and collection state into a new (updated) hero collection.
+    1.  The collection reducer picks a switch-case based on the action's `entityOp` (operation) property. 
+    That case processes the action and collection state into a new (updated) hero collection.
 
     1.  The store updates the _entity cache_ in the state tree with that updated collection.
 

--- a/projects/ngrx.io/content/guide/data/extension-points.md
+++ b/projects/ngrx.io/content/guide/data/extension-points.md
@@ -17,12 +17,12 @@ You can do that easily without abandoning NgRx Data for the rest of your entity 
 
 You can take it over completely simply by removing it from the entity metadata.
 Create your own collection and add it to the store's state-tree as you would in vanilla NgRx. Create your own actions, reducers, selectors and effects.
-As long as your actions don't have an `entityName` or `op` property,
+As long as your actions don't have an `entityName` or `entityOp` property,
 NgRx Data will ignore them.
 
 Or you can keep the entity type in the NgRx Data system and take over the behaviors that matter to you.
 
-* Create supplemental actions for that type. Give them custom `op` names that suit your purpose.
+* Create supplemental actions for that type. Give them custom `entityOp` names that suit your purpose.
 
 * Register an alternative `EntityCollectionReducer` for that type with the `EntityCollectionReducerFactory`. Your custom reducer can respond to your custom actions and implement the standard operations in its own way.
 
@@ -31,7 +31,7 @@ Or you can keep the entity type in the NgRx Data system and take over the behavi
 
 * Add additional properties to the collection state with the `EntityMetadata.additionalCollectionState` property. Manage these properties with custom reducer actions and selectors.
 
-* By-pass the `EntityEffects` completely by never dispatching an action with an `op` that it intercepts.
+* By-pass the `EntityEffects` completely by never dispatching an action with an `entityOp` that it intercepts.
   Create a custom _NgRx/effect_ that handles your custom persistence actions.
 
 ## Provide alternative service implementations
@@ -84,10 +84,10 @@ call to an `EntityDataService` and channels the HTTP response through a
 `PersistenceResultHandler` which produces a persistence results observable that
 goes back to the NgRx store.
 
-The `EntityEffects` class intercepts actions that have an `op` property whose
+The `EntityEffects` class intercepts actions that have an `entityOp` property whose
 value is one of the `persistOps`. Other actions are ignored by this effect.
 
-It tries to process any action with such an `op` property by looking for a
+It tries to process any action with such an `entityOp` property by looking for a
 
 ### Choose data service for the type
 


### PR DESCRIPTION
closes issue #2288

Also
- fix similar documentation error for optimistic/pessimistic
- add/correct code comments in EntityCommands and EntityCollectionServiceBase
- extends `EntityCollectionService` methods to accept optional EntityActionOptions and pass through to dispatch methods (omission was oversight)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix (trivial)
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

See #2288 

Closes #2288

## What is the new behavior?
Mostly documentation.

Appropriate command methods of `EntityCollectionServiceBase` accept optional `options: EntityActionOptions` to pass along options such as `MergeStrategy` and `isOptimistic` to the corresponding `dispatcher` methods. This pass-through should have been there all along.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
