### PR TITLE
fix(store): replace Creator with ActionCreator on createAction

### DIFF
--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -5,7 +5,6 @@ import {
   FunctionWithParametersType,
   PropsReturnType,
   DisallowArraysAndTypeProperty,
-  TypedCreator,
 } from './models';
 
 // Action creators taken from ts-action library and modified a bit to better
@@ -136,7 +135,7 @@ export function union<
 
 function defineType<T extends string>(
   type: T,
-  creator: TypedCreator<T>
+  creator: Creator
 ): ActionCreator<T> {
   return Object.defineProperty(creator, 'type', {
     value: type,

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -5,6 +5,7 @@ import {
   FunctionWithParametersType,
   PropsReturnType,
   DisallowArraysAndTypeProperty,
+  TypedCreator,
 } from './models';
 
 // Action creators taken from ts-action library and modified a bit to better
@@ -100,7 +101,7 @@ export function createAction<
 export function createAction<T extends string, C extends Creator>(
   type: T,
   config?: { _as: 'props' } | C
-): Creator {
+): ActionCreator<T> {
   if (typeof config === 'function') {
     return defineType(type, (...args: any[]) => ({
       ...config(...args),
@@ -133,7 +134,10 @@ export function union<
   return undefined!;
 }
 
-function defineType(type: string, creator: Creator): Creator {
+function defineType<T extends string>(
+  type: T,
+  creator: TypedCreator<T>
+): ActionCreator<T> {
   return Object.defineProperty(creator, 'type', {
     value: type,
     writable: false,

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -77,6 +77,12 @@ export type Creator<
     ? TypePropertyIsNotAllowed
     : FunctionWithParametersType<P, R>;
 
+export type TypedCreator<
+  T extends string,
+  P extends any[] = any[],
+  R extends object = object
+> = FunctionWithParametersType<P, R & TypedAction<T>>;
+
 export type PropsReturnType<T extends object> = T extends any[]
   ? ArraysAreNotAllowed
   : T extends { type: any }
@@ -88,7 +94,7 @@ export type PropsReturnType<T extends object> = T extends any[]
  */
 export type ActionCreator<
   T extends string = string,
-  C extends Creator = Creator
+  C extends Creator = TypedCreator<T>
 > = C & TypedAction<T>;
 
 export type FunctionWithParametersType<P extends unknown[], R = void> = (

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -77,12 +77,6 @@ export type Creator<
     ? TypePropertyIsNotAllowed
     : FunctionWithParametersType<P, R>;
 
-export type TypedCreator<
-  T extends string,
-  P extends any[] = any[],
-  R extends object = object
-> = FunctionWithParametersType<P, R & TypedAction<T>>;
-
 export type PropsReturnType<T extends object> = T extends any[]
   ? ArraysAreNotAllowed
   : T extends { type: any }
@@ -94,7 +88,7 @@ export type PropsReturnType<T extends object> = T extends any[]
  */
 export type ActionCreator<
   T extends string = string,
-  C extends Creator = TypedCreator<T>
+  C extends Creator = Creator
 > = C & TypedAction<T>;
 
 export type FunctionWithParametersType<P extends unknown[], R = void> = (


### PR DESCRIPTION
`createAction` returns incorrect type as neither `Creator` not it's return type contains `type`.
The proper return type is `ActionCreator` with the inner typed creator

Closes https://github.com/meeroslav/ng-helpers/issues/2

Could contribute to https://github.com/ngrx/platform/issues/2192 as well.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Using type `ActionCreator` as the input parameter is causing type errors due to the `Creator` type being insufficient. ActionCreator is a function that has `type` defined and returns typed Action. `Creator` does not return typed Action.

Closes https://github.com/meeroslav/ng-helpers/issues/2

## What is the new behavior?

`ActionCreator` now returns `TypedCreator` that extends CreatorFunctionality by returning `TypedAction`

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
