### PR TITLE
fix(store): allow union of types in props

### DIFF
--- a/modules/store/spec/action_creator.spec.ts
+++ b/modules/store/spec/action_creator.spec.ts
@@ -76,6 +76,28 @@ describe('Action Creators', () => {
       narrow(foo({ foo: 42 }));
     });
 
+    it('should allow the union of types in props', () => {
+      interface A {
+        sameProp: 'A';
+      }
+      interface B {
+        sameProp: 'B';
+        extraProp: string;
+      }
+      type U = A | B;
+      const foo = createAction('FOO', props<U>());
+
+      const fooA = foo({ sameProp: 'A' });
+      const fooB = foo({ sameProp: 'B', extraProp: 'allowed' });
+
+      expect(fooA).toEqual({ type: 'FOO', sameProp: 'A' });
+      expect(fooB).toEqual({
+        type: 'FOO',
+        sameProp: 'B',
+        extraProp: 'allowed',
+      });
+    });
+
     it('should be serializable', () => {
       const foo = createAction('FOO', props<{ foo: number }>());
       const fooAction = foo({ foo: 42 });

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -3,8 +3,7 @@ import {
   ActionCreator,
   TypedAction,
   FunctionWithParametersType,
-  PropsReturnType,
-  DisallowArraysAndTypeProperty,
+  NotAllowedCheck,
 } from './models';
 
 // Action creators taken from ts-action library and modified a bit to better
@@ -16,14 +15,14 @@ export function createAction<T extends string>(
 export function createAction<T extends string, P extends object>(
   type: T,
   config: { _as: 'props'; _p: P }
-): ActionCreator<T, (props: P) => P & TypedAction<T>>;
+): ActionCreator<T, (props: P & NotAllowedCheck<P>) => P & TypedAction<T>>;
 export function createAction<
   T extends string,
   P extends any[],
   R extends object
 >(
   type: T,
-  creator: Creator<P, DisallowArraysAndTypeProperty<R>>
+  creator: Creator<P, R> & NotAllowedCheck<R>
 ): FunctionWithParametersType<P, R & TypedAction<T>> & TypedAction<T>;
 /**
  * @description
@@ -121,10 +120,8 @@ export function createAction<T extends string, C extends Creator>(
   }
 }
 
-export function props<P extends object>(): PropsReturnType<P> {
-  // the return type does not match TypePropertyIsNotAllowed, so double casting
-  // is used.
-  return ({ _as: 'props', _p: undefined! } as unknown) as PropsReturnType<P>;
+export function props<P extends object>(): { _as: 'props'; _p: P } {
+  return { _as: 'props', _p: undefined! };
 }
 
 export function union<

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -4,6 +4,7 @@ import {
   TypedAction,
   FunctionWithParametersType,
   NotAllowedCheck,
+  Props,
 } from './models';
 
 // Action creators taken from ts-action library and modified a bit to better
@@ -14,7 +15,7 @@ export function createAction<T extends string>(
 ): ActionCreator<T, () => TypedAction<T>>;
 export function createAction<T extends string, P extends object>(
   type: T,
-  config: { _as: 'props'; _p: P }
+  config: Props<P>
 ): ActionCreator<T, (props: P & NotAllowedCheck<P>) => P & TypedAction<T>>;
 export function createAction<
   T extends string,
@@ -120,7 +121,7 @@ export function createAction<T extends string, C extends Creator>(
   }
 }
 
-export function props<P extends object>(): { _as: 'props'; _p: P } {
+export function props<P extends object>(): Props<P> {
   return { _as: 'props', _p: undefined! };
 }
 

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -75,17 +75,11 @@ export type FunctionIsNotAllowed<
 export type Creator<
   P extends any[] = any[],
   R extends object = object
-> = R extends any[]
-  ? ArraysAreNotAllowed
-  : R extends { type: any }
-    ? TypePropertyIsNotAllowed
-    : FunctionWithParametersType<P, R>;
+> = FunctionWithParametersType<P, R>;
 
-export type PropsReturnType<T extends object> = T extends any[]
+export type NotAllowedCheck<T extends object> = T extends any[]
   ? ArraysAreNotAllowed
-  : T extends { type: any }
-    ? TypePropertyIsNotAllowed
-    : { _as: 'props'; _p: T };
+  : T extends { type: any } ? TypePropertyIsNotAllowed : unknown;
 
 /**
  * See `Creator`.

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -57,10 +57,6 @@ export const arraysAreNotAllowedMsg =
   'arrays are not allowed in action creators';
 type ArraysAreNotAllowed = typeof arraysAreNotAllowedMsg;
 
-export type DisallowArraysAndTypeProperty<T> = T extends any[]
-  ? ArraysAreNotAllowed
-  : T extends { type: any } ? TypePropertyIsNotAllowed : T;
-
 export const typePropertyIsNotAllowedMsg =
   'type property is not allowed in action creators';
 type TypePropertyIsNotAllowed = typeof typePropertyIsNotAllowedMsg;
@@ -88,6 +84,11 @@ export type ActionCreator<
   T extends string = string,
   C extends Creator = Creator
 > = C & TypedAction<T>;
+
+export interface Props<T> {
+  _as: 'props';
+  _p: T;
+}
 
 export type FunctionWithParametersType<P extends unknown[], R = void> = (
   ...args: P


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Instead of modifying the type of the `Creator`, it appears to be better to add intersection `& NotAllowedCheck` where it used.

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

```typescript
     interface A {
        sameProp: 'A';
      }
      interface B {
        sameProp: 'B';
        extraProp: string;
      }
      type U = A | B;
      const foo = createAction('FOO', props<U>()); // <--- Error
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2300 

## What is the new behavior?

Allows to take `props<U>()` where `U = A | B`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
