### PR TITLE
feature(store): catch action creators being passed to dispatch without () even sooner

### DIFF
--- a/modules/store/spec/types/store.spec.ts
+++ b/modules/store/spec/types/store.spec.ts
@@ -1,0 +1,22 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('Store', () => {
+  const expectSnippet = expecter(
+    code => `
+      import { Store, createAction } '@ngrx/store';
+
+      const store = {} as Store<{}>;
+      const fooAction = createAction('foo')
+
+      ${code}
+    `,
+    compilerOptions()
+  );
+
+  it('should not allow passing action creator function without calling it', () => {
+    expectSnippet(`store.dispatch(fooAction);`).toFail(
+      /is not assignable to type '"Functions are not allowed to be dispatched. Did you forget to call action creator/
+    );
+  });
+});

--- a/modules/store/spec/types/store.spec.ts
+++ b/modules/store/spec/types/store.spec.ts
@@ -16,7 +16,7 @@ describe('Store', () => {
 
   it('should not allow passing action creator function without calling it', () => {
     expectSnippet(`store.dispatch(fooAction);`).toFail(
-      /is not assignable to type '"Functions are not allowed to be dispatched. Did you forget to call action creator/
+      /is not assignable to type '"Functions are not allowed to be dispatched. Did you forget to call action creator function/
     );
   });
 });

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -65,6 +65,10 @@ export const typePropertyIsNotAllowedMsg =
   'type property is not allowed in action creators';
 type TypePropertyIsNotAllowed = typeof typePropertyIsNotAllowedMsg;
 
+export type FunctionIsNotAllowed<
+  T,
+  ErrorMessage extends string
+> = T extends Function ? ErrorMessage : T;
 /**
  * A function that returns an object in the shape of the `Action` interface.  Configured using `createAction`.
  */

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -97,7 +97,7 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
     action: V &
       FunctionIsNotAllowed<
         V,
-        'Functions are not allowed to be dispatched. Did you forget to call action creator?'
+        'Functions are not allowed to be dispatched. Did you forget to call action creator function?'
       >
   ) {
     this.actionsObserver.next(action);

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -3,7 +3,7 @@ import { Observable, Observer, Operator } from 'rxjs';
 import { distinctUntilChanged, map, pluck } from 'rxjs/operators';
 
 import { ActionsSubject } from './actions_subject';
-import { Action, ActionReducer } from './models';
+import { Action, ActionReducer, FunctionIsNotAllowed } from './models';
 import { ReducerManager } from './reducer_manager';
 import { StateObservable } from './state';
 
@@ -93,7 +93,13 @@ export class Store<T> extends Observable<T> implements Observer<Action> {
     return store;
   }
 
-  dispatch<V extends Action = Action>(action: V) {
+  dispatch<V extends Action = Action>(
+    action: V &
+      FunctionIsNotAllowed<
+        V,
+        'Functions are not allowed to be dispatched. Did you forget to call action creator?'
+      >
+  ) {
     this.actionsObserver.next(action);
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

During the recent merge of NgRx to Google I discovered a number of dispatch calls of new action creators without actual calls, e.g. `store.dispatch(fooAction)` instead of `store.dispatch(fooAction())`.

In NgRx we already added the runtime check, but I think we can do even better and catch it at compile time (IDEs will catch this too).

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Errors (warnings) at runtime

## What is the new behavior?

Type Error: Functions are not allowed to be dispatched. Did you forget to call action creator?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
