### PR TITLE
feat(store): add default generic type to Store and MockStore

### DIFF
--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -8,7 +8,8 @@ import { ReducerManager } from './reducer_manager';
 import { StateObservable } from './state';
 
 @Injectable()
-export class Store<T> extends Observable<T> implements Observer<Action> {
+export class Store<T = object> extends Observable<T>
+  implements Observer<Action> {
   constructor(
     state$: StateObservable,
     private actionsObserver: ActionsSubject,

--- a/modules/store/testing/src/mock_store.ts
+++ b/modules/store/testing/src/mock_store.ts
@@ -27,7 +27,7 @@ if (typeof afterEach === 'function') {
 }
 
 @Injectable()
-export class MockStore<T> extends Store<T> {
+export class MockStore<T = object> extends Store<T> {
   static selectors = new Map<
     | string
     | MemoizedSelector<any, any>

--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -244,7 +244,7 @@ selectTotal.release();
 
 When injecting `Store` into components and other injectables, it is possible to omit the generic type. If injected without the generic, the default generic is applied as follows `Store<T = object>`.
 
-The most common way to select information the store is to use a selector function defined with `createSelector`. When doing so, TypeScript is able to automatically infer types from the selector function, therefore reducing the need to define the type in the store generic.
+The most common way to select information from the store is to use a selector function defined with `createSelector`. When doing so, TypeScript is able to automatically infer types from the selector function, therefore reducing the need to define the type in the store generic.
 
 <div class="alert is-important">
 It is important to continue to provide a Store type generic if you are using the string version of selectors as types cannot be inferred automatically in those instances.
@@ -254,9 +254,9 @@ The follow example demonstrates the use of Store without providing a generic:
 
 <code-example header="app.component.ts">
 export class AppComponent {
-  counter$ = this.store.pipe(select(fromCounter.selectCounter));
+  counter$ = this.store.select(fromCounter.selectCounter);
 
-  constructor(private store: Store) {}
+  constructor(private readonly store: Store) {}
 }
 </code-example>
 

--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -240,6 +240,26 @@ selectTotal.release();
  */
 </code-example>
 
+## Using Store Without Type Generic
+
+When injecting `Store` into components and other injectables, it is possible to omit the generic type. If injected without the generic, the default generic is applied as follows `Store<T = object>`.
+
+The most common way to select information the store is to use a selector function defined with `createSelector`. When doing so, TypeScript is able to automatically infer types from the selector function, therefore reducing the need to define the type in the store generic.
+
+<div class="alert is-important">
+It is important to continue to provide a Store type generic if you are using the string version of selectors as types cannot be inferred automatically in those instances.
+</div>
+
+The follow example demonstrates the use of Store without providing a generic:
+
+<code-example header="app.component.ts">
+export class AppComponent {
+  counter$ = this.store.pipe(select(fromCounter.selectCounter));
+
+  constructor(private store: Store) {}
+}
+</code-example>
+
 ## Advanced Usage
 
 Selectors empower you to compose a [read model for your application state](https://docs.microsoft.com/en-us/azure/architecture/patterns/cqrs#solution).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

A common pattern has emerged in NgRx usage where types are no longer being provided to the Store injection point, and as such, most code is just getting an empty object `{}` for the generic. The type safety is nominal as we are already using Selectors and suggesting that selectors are the preferred way to select information from the store. Selectors themselves have types, so it is nice to be able to use the Store without providing redundant, and often unused typing.

Adding a default to the `Store` and `MockStore` class generics, so that `Store` and `MockStore` can be injected without the need for providing a type. 
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently you must provide a generic type to the `Store` class:

```typescript
export class MyAppComponent {
  counter: Observable<number>;

  constructor(private store: Store<AppState>) {
    this.counter = store.pipe(select(fromCounter.selectCounter));
  }
}
```
Closes #

## What is the new behavior?

After this change you can do as follows:

```typescript
export class MyAppComponent {
  counter: Observable<number>;

  constructor(private store: Store) {
    this.counter = store.pipe(select(fromCounter.selectCounter));
  }
}
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
