### PR TITLE
feat(router): enabling MinimalRouterStateSerializer by default

### DIFF
--- a/modules/router-store/spec/router_store_module.spec.ts
+++ b/modules/router-store/spec/router_store_module.spec.ts
@@ -141,7 +141,7 @@ describe('Router Store Module', () => {
   });
 
   describe('routerState', () => {
-    function setup(routerState: RouterState, serializer?: any) {
+    function setup(routerState?: RouterState, serializer?: any) {
       createTestModule({
         reducers: {},
         config: {
@@ -172,7 +172,17 @@ describe('Router Store Module', () => {
         await router.navigateByUrl('/');
       });
 
-      it('should use the default router serializer', () => {
+      it('should use the minimal router serializer by default', () => {
+        const { serializer } = setup();
+        expect(serializer).toEqual(new MinimalRouterStateSerializer());
+      });
+
+      it('should use the minimal router serializer if minimal state option is passed in', () => {
+        const { serializer } = setup(RouterState.Minimal);
+        expect(serializer).toEqual(new MinimalRouterStateSerializer());
+      });
+
+      it('should use the default router serializer if full state option is passed in', () => {
         const { serializer } = setup(RouterState.Full);
         expect(serializer).toEqual(new DefaultRouterStateSerializer());
       });

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -94,7 +94,7 @@ export function _createRouterConfig(
 ): StoreRouterConfig {
   return {
     stateKey: DEFAULT_ROUTER_FEATURENAME,
-    serializer: DefaultRouterStateSerializer,
+    serializer: MinimalRouterStateSerializer,
     navigationActionTiming: NavigationActionTiming.PreActivation,
     ...config,
   };
@@ -168,9 +168,9 @@ export class StoreRouterConnectingModule {
           provide: RouterStateSerializer,
           useClass: config.serializer
             ? config.serializer
-            : config.routerState === RouterState.Minimal
-              ? MinimalRouterStateSerializer
-              : DefaultRouterStateSerializer,
+            : config.routerState === RouterState.Full
+              ? DefaultRouterStateSerializer
+              : MinimalRouterStateSerializer,
         },
       ],
     };
@@ -328,9 +328,9 @@ export class StoreRouterConnectingModule {
           routerState: this.routerState,
           ...payload,
           event:
-            this.config.routerState === RouterState.Minimal
-              ? { id: payload.event.id, url: payload.event.url }
-              : payload.event,
+            this.config.routerState === RouterState.Full
+              ? payload.event
+              : { id: payload.event.id, url: payload.event.url },
         },
       });
     } finally {

--- a/projects/example-app/src/app/app.module.ts
+++ b/projects/example-app/src/app/app.module.ts
@@ -15,10 +15,7 @@ import { ROOT_REDUCERS, metaReducers } from '@example-app/reducers';
 
 import { CoreModule } from '@example-app/core';
 import { AppRoutingModule } from '@example-app/app-routing.module';
-import {
-  UserEffects,
-  RouterEffects
-} from '@example-app/core/effects';
+import { UserEffects, RouterEffects } from '@example-app/core/effects';
 import { AppComponent } from '@example-app/core/containers';
 
 @NgModule({
@@ -50,9 +47,7 @@ import { AppComponent } from '@example-app/core/containers';
     /**
      * @ngrx/router-store keeps router state up-to-date in the store.
      */
-    StoreRouterConnectingModule.forRoot({
-      routerState: RouterState.Minimal,
-    }),
+    StoreRouterConnectingModule.forRoot(),
 
     /**
      * Store devtools instrument the store retaining past versions of state

--- a/projects/ngrx.io/content/guide/router-store/configuration.md
+++ b/projects/ngrx.io/content/guide/router-store/configuration.md
@@ -16,12 +16,12 @@ interface StoreRouterConfig {
 
 ## Default Router State Serializer
 
-If no router state serializer is provided through the [configuration](#configuration-options) of router store, the `DefaultRouterStateSerializer` is used. This router state serializer, serializes the URL together with the [ActivatedRouteSnapshot](https://angular.io/api/router/ActivatedRouteSnapshot) from [Angular Router](https://angular.io/guide/router). The latter is serialized recursively, but only with the possibility to traverse the route downward since `root` and `parent` parameters are set to `undefined`.
+`DefaultRouterStateSerializer` router state serializer, serializes the URL together with the [ActivatedRouteSnapshot](https://angular.io/api/router/ActivatedRouteSnapshot) from [Angular Router](https://angular.io/guide/router). The latter is serialized recursively, but only with the possibility to traverse the route downward since `root` and `parent` parameters are set to `undefined`.
 
 <div class="alert is-important">
 
-The `DefaultRouterStateSerializer` cannot be used when [serializability runtime checks](guide/store/configuration/runtime-checks) are enabled. If you want to use runtime checks to enforce serializability of your state and actions, you can configure `RouterStoreModule` to use the `MinimalRouterStateSerializer` or implement a custom router state serializer.
-This also applies to Ivy with immutability runtime checks.
+The `DefaultRouterStateSerializer` cannot be used when [serializability runtime checks](guide/store/configuration/runtime-checks) are enabled.
+With runtime checks enabled `MinimalRouterStateSerializer` serializer is used by default in `RouterStoreModule` when no other serializer is provided. This also applies to Ivy with immutability runtime checks.
 
 </div>
 
@@ -41,14 +41,14 @@ import { Params, RouterStateSnapshot } from '@angular/router';
 import { RouterStateSerializer } from '@ngrx/router-store';
 
 export interface RouterStateUrl {
-  url: string;
-  params: Params;
-  queryParams: Params;
+url: string;
+params: Params;
+queryParams: Params;
 }
 
 export class CustomSerializer implements RouterStateSerializer&lt;RouterStateUrl&gt; {
-  serialize(routerState: RouterStateSnapshot): RouterStateUrl {
-    let route = routerState.root;
+serialize(routerState: RouterStateSnapshot): RouterStateUrl {
+let route = routerState.root;
 
     while (route.firstChild) {
       route = route.firstChild;
@@ -63,7 +63,8 @@ export class CustomSerializer implements RouterStateSerializer&lt;RouterStateUrl
     // Only return an object including the URL, params and query params
     // instead of the entire snapshot
     return { url, params, queryParams };
-  }
+
+}
 }
 </code-example>
 

--- a/projects/ngrx.io/content/guide/router-store/configuration.md
+++ b/projects/ngrx.io/content/guide/router-store/configuration.md
@@ -63,8 +63,7 @@ export class CustomSerializer implements RouterStateSerializer&lt;RouterStateUrl
     // Only return an object including the URL, params and query params
     // instead of the entire snapshot
     return { url, params, queryParams };
-
-}
+  }
 }
 </code-example>
 

--- a/projects/ngrx.io/content/guide/router-store/configuration.md
+++ b/projects/ngrx.io/content/guide/router-store/configuration.md
@@ -21,7 +21,7 @@ interface StoreRouterConfig {
 <div class="alert is-important">
 
 The `DefaultRouterStateSerializer` cannot be used when [serializability runtime checks](guide/store/configuration/runtime-checks) are enabled.
-With runtime checks enabled `MinimalRouterStateSerializer` serializer is used by default in `RouterStoreModule` when no other serializer is provided. This also applies to Ivy with immutability runtime checks.
+With serializability runtime checks enabled, the `MinimalRouterStateSerializer` serializer **must** be used. This also applies to Ivy with immutability runtime checks.
 
 </div>
 
@@ -41,14 +41,14 @@ import { Params, RouterStateSnapshot } from '@angular/router';
 import { RouterStateSerializer } from '@ngrx/router-store';
 
 export interface RouterStateUrl {
-url: string;
-params: Params;
-queryParams: Params;
+  url: string;
+  params: Params;
+  queryParams: Params;
 }
 
 export class CustomSerializer implements RouterStateSerializer&lt;RouterStateUrl&gt; {
-serialize(routerState: RouterStateSnapshot): RouterStateUrl {
-let route = routerState.root;
+  serialize(routerState: RouterStateSnapshot): RouterStateUrl {
+    let route = routerState.root;
 
     while (route.firstChild) {
       route = route.firstChild;

--- a/projects/ngrx.io/content/guide/router-store/index.md
+++ b/projects/ngrx.io/content/guide/router-store/index.md
@@ -21,7 +21,7 @@ import { AppComponent } from './app.component';
     RouterModule.forRoot([
       // routes
     ]),
-    // Connects RouterModule with StoreModule
+    // Connects RouterModule with StoreModule, uses MinimalRouterStateSerializer by default
     StoreRouterConnectingModule.forRoot(),
   ],
   bootstrap: [AppComponent],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

If no router state serializer is provided through the configuration of router store, the DefaultRouterStateSerializer is used.
Closes #2225

## What is the new behavior?
If no router state serializer is provided through the configuration of router store, the MinimalRouterStateSerializer is used.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```
The default option for `rooterState` in `StoreRouterConnectingModule` is changing. If still need to support `DefaultRouterStateSerializer` will need to explicitly pass in `RouterState.Full` for `routerState`.

## Other information

It is very confusing to me that `serializer` which is set in `_createRouterConfig` does not play any effect right now. @timdeschryver said that it was done for backward compatibility reasons and probably will be addressed in another PR by @alex-okrushko. If not, we can discuss here how to make it better.
