### PR TITLE
docs(data): change registerReducer to registerReducers

### DIFF
--- a/projects/ngrx.io/content/guide/data/entity-reducer.md
+++ b/projects/ngrx.io/content/guide/data/entity-reducer.md
@@ -48,7 +48,7 @@ You can create a custom reducer for an entity type and
 register it directly with `EntityCollectionReducerRegistry.registerReducer()`.
 
 You can register several custom reducers at the same time
-by calling `EntityCollectionReducerRegistry.registerReducer(reducerMap)` where
+by calling `EntityCollectionReducerRegistry.registerReducers(reducerMap)` where
 the `reducerMap` is a hash of reducers, keyed by _entity-type-name_.
 
 <a id="collection-reducer-factory"></a>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

This change of the function name `EntityCollectionReducerRegistry.registerReducer()` to `EntityCollectionReducerRegistry.registerReducers(reducerMap)` in the documentation would be in line with the correct function name in the `EntityCollectionReducerRegistry` class responsible for registering several custom reducers.

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the documentation reads as follows, "You can register several custom reducers at the same time by calling `EntityCollectionReducerRegistry.registerReducer(reducerMap)` where the `reducerMap` is a hash of reducers, keyed by _entity-type-name_."

This is misleading as it is not the correct function name for registering several custom reducers.

Closes #

## What is the new behavior?

After the change, the documentation reads as follows, "You can register several custom reducers at the same time by calling `EntityCollectionReducerRegistry.registerReducers(reducerMap)` where the `reducerMap` is a hash of reducers, keyed by _entity-type-name_."

This is not misleading as it is the correct function name for registering several custom reducers.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
