### PR TITLE
Rename addAll to setAll in entityAdapter 

### DIFF
--- a/docs/entity/adapter.md
+++ b/docs/entity/adapter.md
@@ -85,7 +85,8 @@ state if no changes were made.
 
 - `addOne`: Add one entity to the collection
 - `addMany`: Add multiple entities to the collection
-- `addAll`: Replace current collection with provided collection
+- ~~`addAll`~~: (Deprecated, renamed to `setAll`) ~~Replace current collection with provided collection~~
+- `setAll`: Replace current collection with provided collection
 - `removeOne`: Remove one entity from the collection
 - `removeMany`: Remove multiple entities from the collection
 - `removeAll`: Clear entity collection

--- a/modules/entity/spec/sorted_state_adapter.spec.ts
+++ b/modules/entity/spec/sorted_state_adapter.spec.ts
@@ -69,10 +69,10 @@ describe('Sorted State Adapter', () => {
     });
   });
 
-  it('should let you add all entities to the state', () => {
+  it('should remove existing and add new ones on setAll', () => {
     const withOneEntity = adapter.addOne(TheGreatGatsby, state);
 
-    const withAll = adapter.addAll(
+    const withAll = adapter.setAll(
       [AClockworkOrange, AnimalFarm],
       withOneEntity
     );
@@ -98,7 +98,7 @@ describe('Sorted State Adapter', () => {
   });
 
   it('should let you remove many entities by id from the state', () => {
-    const withAll = adapter.addAll(
+    const withAll = adapter.setAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
@@ -117,7 +117,7 @@ describe('Sorted State Adapter', () => {
   });
 
   it('should let you remove many entities by a predicate from the state', () => {
-    const withAll = adapter.addAll(
+    const withAll = adapter.setAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
@@ -133,7 +133,7 @@ describe('Sorted State Adapter', () => {
   });
 
   it('should let you remove all entities from the state', () => {
-    const withAll = adapter.addAll(
+    const withAll = adapter.setAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
@@ -182,7 +182,7 @@ describe('Sorted State Adapter', () => {
   });
 
   it('should not change ids state if you attempt to update an entity that does not impact sorting', () => {
-    const withAll = adapter.addAll(
+    const withAll = adapter.setAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
@@ -223,7 +223,7 @@ describe('Sorted State Adapter', () => {
   });
 
   it('should resort correctly if same id but sort key update', () => {
-    const withAll = adapter.addAll(
+    const withAll = adapter.setAll(
       [TheGreatGatsby, AnimalFarm, AClockworkOrange],
       state
     );
@@ -251,7 +251,7 @@ describe('Sorted State Adapter', () => {
   });
 
   it('should resort correctly if the id and sort key update', () => {
-    const withOne = adapter.addAll(
+    const withOne = adapter.setAll(
       [TheGreatGatsby, AnimalFarm, AClockworkOrange],
       state
     );
@@ -281,7 +281,7 @@ describe('Sorted State Adapter', () => {
   it('should let you update many entities by id in the state', () => {
     const firstChange = { title: 'Zack' };
     const secondChange = { title: 'Aaron' };
-    const withMany = adapter.addAll([TheGreatGatsby, AClockworkOrange], state);
+    const withMany = adapter.setAll([TheGreatGatsby, AClockworkOrange], state);
 
     const withUpdates = adapter.updateMany(
       [
@@ -310,7 +310,7 @@ describe('Sorted State Adapter', () => {
     const firstChange = { ...TheGreatGatsby, title: 'First change' };
     const secondChange = { ...AClockworkOrange, title: 'Second change' };
 
-    const withMany = adapter.addAll(
+    const withMany = adapter.setAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
@@ -372,7 +372,7 @@ describe('Sorted State Adapter', () => {
 
   it('should let you upsert many entities in the state', () => {
     const firstChange = { title: 'Zack' };
-    const withMany = adapter.addAll([TheGreatGatsby], state);
+    const withMany = adapter.setAll([TheGreatGatsby], state);
 
     const withUpserts = adapter.upsertMany(
       [{ ...TheGreatGatsby, ...firstChange }, AClockworkOrange],

--- a/modules/entity/spec/sorted_state_adapter.spec.ts
+++ b/modules/entity/spec/sorted_state_adapter.spec.ts
@@ -86,6 +86,23 @@ describe('Sorted State Adapter', () => {
     });
   });
 
+  it('should remove existing and add new ones on addAll (deprecated)', () => {
+    const withOneEntity = adapter.addOne(TheGreatGatsby, state);
+
+    const withAll = adapter.setAll(
+      [AClockworkOrange, AnimalFarm],
+      withOneEntity
+    );
+
+    expect(withAll).toEqual({
+      ids: [AClockworkOrange.id, AnimalFarm.id],
+      entities: {
+        [AClockworkOrange.id]: AClockworkOrange,
+        [AnimalFarm.id]: AnimalFarm,
+      },
+    });
+  });
+
   it('should let you add remove an entity from the state', () => {
     const withOneEntity = adapter.addOne(TheGreatGatsby, state);
 

--- a/modules/entity/spec/state_selectors.spec.ts
+++ b/modules/entity/spec/state_selectors.spec.ts
@@ -24,7 +24,7 @@ describe('Entity State Selectors', () => {
       });
 
       state = {
-        books: adapter.addAll(
+        books: adapter.setAll(
           [AClockworkOrange, AnimalFarm, TheGreatGatsby],
           adapter.getInitialState()
         ),
@@ -70,7 +70,7 @@ describe('Entity State Selectors', () => {
         selectId: (book: BookModel) => book.id,
       });
 
-      state = adapter.addAll(
+      state = adapter.setAll(
         [AClockworkOrange, AnimalFarm, TheGreatGatsby],
         adapter.getInitialState()
       );

--- a/modules/entity/spec/unsorted_state_adapter.spec.ts
+++ b/modules/entity/spec/unsorted_state_adapter.spec.ts
@@ -68,7 +68,24 @@ describe('Unsorted State Adapter', () => {
     });
   });
 
-  it('should let you add all entities to the state', () => {
+  it('should remove existing and add new ones on setAll', () => {
+    const withOneEntity = adapter.addOne(TheGreatGatsby, state);
+
+    const withAll = adapter.setAll(
+      [AClockworkOrange, AnimalFarm],
+      withOneEntity
+    );
+
+    expect(withAll).toEqual({
+      ids: [AClockworkOrange.id, AnimalFarm.id],
+      entities: {
+        [AClockworkOrange.id]: AClockworkOrange,
+        [AnimalFarm.id]: AnimalFarm,
+      },
+    });
+  });
+
+  it('should remove existing and add new ones on addAll (deprecated)', () => {
     const withOneEntity = adapter.addOne(TheGreatGatsby, state);
 
     const withAll = adapter.addAll(
@@ -97,7 +114,7 @@ describe('Unsorted State Adapter', () => {
   });
 
   it('should let you remove many entities by id from the state', () => {
-    const withAll = adapter.addAll(
+    const withAll = adapter.setAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
@@ -116,7 +133,7 @@ describe('Unsorted State Adapter', () => {
   });
 
   it('should let you remove many entities by a predicate from the state', () => {
-    const withAll = adapter.addAll(
+    const withAll = adapter.setAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
@@ -132,7 +149,7 @@ describe('Unsorted State Adapter', () => {
   });
 
   it('should let you remove all entities from the state', () => {
-    const withAll = adapter.addAll(
+    const withAll = adapter.setAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
@@ -221,7 +238,7 @@ describe('Unsorted State Adapter', () => {
   it('should let you update many entities by id in the state', () => {
     const firstChange = { title: 'First Change' };
     const secondChange = { title: 'Second Change' };
-    const withMany = adapter.addAll([TheGreatGatsby, AClockworkOrange], state);
+    const withMany = adapter.setAll([TheGreatGatsby, AClockworkOrange], state);
 
     const withUpdates = adapter.updateMany(
       [
@@ -250,7 +267,7 @@ describe('Unsorted State Adapter', () => {
     const firstChange = { ...TheGreatGatsby, title: 'First change' };
     const secondChange = { ...AClockworkOrange, title: 'Second change' };
 
-    const withMany = adapter.addAll(
+    const withMany = adapter.setAll(
       [TheGreatGatsby, AClockworkOrange, AnimalFarm],
       state
     );
@@ -312,7 +329,7 @@ describe('Unsorted State Adapter', () => {
 
   it('should let you upsert many entities in the state', () => {
     const firstChange = { title: 'First Change' };
-    const withMany = adapter.addAll([TheGreatGatsby], state);
+    const withMany = adapter.setAll([TheGreatGatsby], state);
 
     const withUpserts = adapter.upsertMany(
       [{ ...TheGreatGatsby, ...firstChange }, AClockworkOrange],

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -45,7 +45,11 @@ export interface EntityDefinition<T> {
 export interface EntityStateAdapter<T> {
   addOne<S extends EntityState<T>>(entity: T, state: S): S;
   addMany<S extends EntityState<T>>(entities: T[], state: S): S;
+
+  /** @deprecated addAll has been renamed. Use setAll instead. */
   addAll<S extends EntityState<T>>(entities: T[], state: S): S;
+
+  setAll<S extends EntityState<T>>(entities: T[], state: S): S;
 
   removeOne<S extends EntityState<T>>(key: string, state: S): S;
   removeOne<S extends EntityState<T>>(key: number, state: S): S;

--- a/modules/entity/src/sorted_state_adapter.ts
+++ b/modules/entity/src/sorted_state_adapter.ts
@@ -50,6 +50,16 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
     return DidMutate.Both;
   }
 
+  function setAllMutably(models: T[], state: R): DidMutate;
+  function setAllMutably(models: any[], state: any): DidMutate {
+    state.entities = {};
+    state.ids = [];
+
+    addManyMutably(models, state);
+
+    return DidMutate.Both;
+  }
+
   function updateOneMutably(update: Update<T>, state: R): DidMutate;
   function updateOneMutably(update: any, state: any): DidMutate {
     return updateManyMutably([update], state);
@@ -200,6 +210,7 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
     updateOne: createStateOperator(updateOneMutably),
     upsertOne: createStateOperator(upsertOneMutably),
     addAll: createStateOperator(addAllMutably),
+    setAll: createStateOperator(setAllMutably),
     addMany: createStateOperator(addManyMutably),
     updateMany: createStateOperator(updateManyMutably),
     upsertMany: createStateOperator(upsertManyMutably),

--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -50,6 +50,16 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
     return DidMutate.Both;
   }
 
+  function setAllMutably(entities: T[], state: R): DidMutate;
+  function setAllMutably(entities: any[], state: any): DidMutate {
+    state.ids = [];
+    state.entities = {};
+
+    addManyMutably(entities, state);
+
+    return DidMutate.Both;
+  }
+
   function removeOneMutably(key: T, state: R): DidMutate;
   function removeOneMutably(key: any, state: any): DidMutate {
     return removeManyMutably([key], state);
@@ -195,6 +205,7 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
     addOne: createStateOperator(addOneMutably),
     addMany: createStateOperator(addManyMutably),
     addAll: createStateOperator(addAllMutably),
+    setAll: createStateOperator(setAllMutably),
     updateOne: createStateOperator(updateOneMutably),
     updateMany: createStateOperator(updateManyMutably),
     upsertOne: createStateOperator(upsertOneMutably),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently `addAll` removes all existing entities and then add all, which is very confusing and bug-prone.
Closes #2330

## What is the new behavior?
Deprecated `addAll` and added an identical `setAll`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
