### PR TITLE
fix(data): make undoMany remove tracking changes in changeState (#2346)

### DIFF
--- a/modules/data/spec/reducers/entity-change-tracker-base.spec.ts
+++ b/modules/data/spec/reducers/entity-change-tracker-base.spec.ts
@@ -649,6 +649,22 @@ describe('EntityChangeTrackerBase', () => {
   });
 
   describe('#undoOne', () => {
+    it('should clear one tracked change', () => {
+      let { collection, deletedEntity } = createTestTrackedEntities();
+
+      expect(Object.keys(collection.changeState).length).toBe(
+        3,
+        'tracking 3 entities'
+      );
+
+      collection = tracker.undoOne(deletedEntity as Hero, collection);
+
+      expect(Object.keys(collection.changeState).length).toBe(
+        2,
+        'tracking 2 entities'
+      );
+    });
+
     it('should restore the collection to the pre-change state for the given entity', () => {
       // tslint:disable-next-line:prefer-const
       let {
@@ -698,6 +714,32 @@ describe('EntityChangeTrackerBase', () => {
   });
 
   describe('#undoMany', () => {
+    it('should clear many tracked changes', () => {
+      // tslint:disable-next-line:prefer-const
+      let {
+        collection,
+        addedEntity,
+        deletedEntity,
+        preUpdatedEntity,
+        updatedEntity,
+      } = createTestTrackedEntities();
+
+      expect(Object.keys(collection.changeState).length).toBe(
+        3,
+        'tracking 3 entities'
+      );
+
+      collection = tracker.undoMany(
+        [addedEntity, deletedEntity, updatedEntity],
+        collection
+      );
+
+      expect(Object.keys(collection.changeState).length).toBe(
+        0,
+        'tracking 2 entities'
+      );
+    });
+
     it('should restore the collection to the pre-change state for the given entities', () => {
       // tslint:disable-next-line:prefer-const
       let {

--- a/modules/data/src/reducers/entity-change-tracker-base.ts
+++ b/modules/data/src/reducers/entity-change-tracker-base.ts
@@ -687,6 +687,7 @@ export class EntityChangeTrackerBase<T> implements EntityChangeTracker<T> {
             didMutate = true;
           }
           delete chgState[id]; // clear tracking of this entity
+          acc.changeState = chgState;
           switch (change.changeType) {
             case ChangeType.Added:
               acc.remove.push(id);
@@ -714,7 +715,7 @@ export class EntityChangeTrackerBase<T> implements EntityChangeTracker<T> {
 
     collection = this.adapter.removeMany(remove as string[], collection);
     collection = this.adapter.upsertMany(upsert, collection);
-    return didMutate ? collection : { ...collection, changeState };
+    return didMutate ? { ...collection, changeState } : collection;
   }
 
   /**


### PR DESCRIPTION
Fixes #2346

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

UNDO_ONE and UNDO_MANY actions reverts one/many entities back to their original state but changeState keeps the tracking the entity/entities.
 
Closes #2346

## What is the new behavior?

UNDO_ONE and UNDO_MANY actions remove the entity/entities from changeState as well as the current behavior of reverting the entities state.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This would be my first ever PR if accepted.

Please confirm if PR is intended behavior before accepting.

Reference https://ngrx.io/guide/data/entity-change-tracker#removing-an-entity-from-the-changestate-map

> The undo operations replace entities in the collection based on information in the changeState map, reverting them their last known server-side state, and removing them from the changeState map. These entities become "unchanged."


