### PR TITLE
feat(store): testing - clean up mock store a bit

### DIFF
--- a/modules/store/testing/spec/mock_store.spec.ts
+++ b/modules/store/testing/spec/mock_store.spec.ts
@@ -344,6 +344,17 @@ describe('Refreshing state', () => {
     expect(getTodoItems('p').length).toBe(1);
     expect(getTodoItems('p')[0].nativeElement.textContent.trim()).toBe('bbb');
   });
+
+  it('should work with overrideSelector twice', () => {
+    const newTodos = [{ name: 'bbb', done: true }];
+    mockStore.overrideSelector(todos, newTodos);
+    mockStore.refreshState();
+
+    fixture.detectChanges();
+
+    expect(getTodoItems('li').length).toBe(1);
+    expect(getTodoItems('li')[0].nativeElement.textContent.trim()).toBe('bbb');
+  });
 });
 
 describe('Cleans up after each test', () => {
@@ -385,6 +396,65 @@ describe('Cleans up after each test', () => {
     const store = TestBed.get<Store<any>>(Store) as Store<any>;
     store.pipe(select(selectData)).subscribe(v => {
       expect(v).toBe(300);
+      done();
+    });
+  });
+});
+
+describe('Resets selectors after each test', () => {
+  const selectorUnderTest = createSelector(
+    (state: any) => state,
+    state => state.value
+  );
+  let shouldSetMockStore = true;
+
+  function setupModules(shouldSetMockStore: boolean) {
+    if (shouldSetMockStore) {
+      TestBed.configureTestingModule({
+        providers: [
+          provideMockStore({
+            initialState: {
+              value: 100,
+            },
+            selectors: [{ selector: selectorUnderTest, value: 200 }],
+          }),
+        ],
+      });
+    } else {
+      TestBed.configureTestingModule({
+        imports: [
+          StoreModule.forRoot({} as any, {
+            initialState: {
+              value: 300,
+            },
+          }),
+        ],
+      });
+    }
+  }
+
+  /**
+   * Tests run in random order, so that's why we have two attempts (one runs
+   * before another - in any order) and whichever runs the test first would
+   * setup MockStore and override selector. The next one would use the regular
+   * Store and verifies that the selector is cleared/reset.
+   */
+  it('should reset selector - attempt one', (done: DoneFn) => {
+    setupModules(shouldSetMockStore);
+    const store: Store<{}> = TestBed.get<Store<{}>>(Store);
+    store.select(selectorUnderTest).subscribe(v => {
+      expect(v).toBe(shouldSetMockStore ? 200 : 300);
+      shouldSetMockStore = false;
+      done();
+    });
+  });
+
+  it('should reset selector - attempt two', (done: DoneFn) => {
+    setupModules(shouldSetMockStore);
+    const store: Store<{}> = TestBed.get<Store<{}>>(Store);
+    store.select(selectorUnderTest).subscribe(v => {
+      expect(v).toBe(shouldSetMockStore ? 200 : 300);
+      shouldSetMockStore = false;
       done();
     });
   });

--- a/modules/store/testing/spec/mock_store.spec.ts
+++ b/modules/store/testing/spec/mock_store.spec.ts
@@ -408,8 +408,8 @@ describe('Resets selectors after each test', () => {
   );
   let shouldSetMockStore = true;
 
-  function setupModules(shouldSetMockStore: boolean) {
-    if (shouldSetMockStore) {
+  function setupModules(isMock: boolean) {
+    if (isMock) {
       TestBed.configureTestingModule({
         providers: [
           provideMockStore({

--- a/modules/store/testing/src/mock_store.ts
+++ b/modules/store/testing/src/mock_store.ts
@@ -28,7 +28,13 @@ if (typeof afterEach === 'function') {
 
 type OnlyMemoized<T, Result> = T extends string
   ? MemoizedSelector<any, Result>
-  : T;
+  : T extends MemoizedSelector<any, any>
+    ? Extract<T, MemoizedSelector<any, any>>
+    : Extract<T, MemoizedSelectorWithProps<any, any, any>>;
+
+type Memoized<Result> =
+  | MemoizedSelector<any, Result>
+  | MemoizedSelectorWithProps<any, any, Result>;
 
 @Injectable()
 export class MockStore<T = object> extends Store<T> {
@@ -63,19 +69,17 @@ export class MockStore<T = object> extends Store<T> {
     this.lastState = nextState;
   }
 
-  overrideSelector<
-    Result,
-    Memoized extends
+  overrideSelector<Result, Value extends Result>(
+    selector:
       | MemoizedSelector<any, Result>
       | MemoizedSelectorWithProps<any, any, Result>
-  >(
-    selector: Memoized | string,
-    value: Result
+      | string,
+    value: Value
   ): OnlyMemoized<typeof selector, Result> {
     this.selectors.set(selector, value);
 
     if (typeof selector === 'string') {
-      const stringSelector = createSelector(() => {}, () => value);
+      const stringSelector = createSelector(() => {}, (): Result => value);
       return stringSelector;
     }
     selector.setResult(value);

--- a/modules/store/testing/src/mock_store.ts
+++ b/modules/store/testing/src/mock_store.ts
@@ -78,14 +78,14 @@ export class MockStore<T = object> extends Store<T> {
   ): OnlyMemoized<typeof selector, Result> {
     this.selectors.set(selector, value);
 
-    const resultSelector: OnlyMemoized<typeof selector, Result> =
+    const resultSelector: Memoized<Result> =
       typeof selector === 'string'
         ? createSelector(() => {}, (): Result => value)
-        : ((selector as unknown) as OnlyMemoized<typeof selector, Result>);
+        : selector;
 
     resultSelector.setResult(value);
 
-    return resultSelector;
+    return resultSelector as OnlyMemoized<typeof selector, Result>;
   }
 
   resetSelectors() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- Add tests that would consistently catch `resetSelectors` in `afterEach`
- Make `selectors` private, instead of static
- cleanup constructor
- remove function overloads for `overrideSelector` - can we typed all at once

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

`MockStore.selectors` is not longer static or visible. I don't think that's the API that we meant to support to begin with.

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
