### PR TITLE
feat(store): add strictActionWithinNgZone runtime check

### DIFF
--- a/modules/store/spec/meta-reducers/inNgZoneAssert_reducer.spec.ts
+++ b/modules/store/spec/meta-reducers/inNgZoneAssert_reducer.spec.ts
@@ -15,7 +15,7 @@ describe('inNgZoneAssertMetaReducer:', () => {
       .createSpy('isInAngularZone')
       .and.returnValue(false);
     expect(() => invokeActionReducer((state: any) => state)).toThrowError(
-      `strictActionWithinNgZone: Action 'invoke' running outside NgZone.`
+      `Action 'invoke' running outside NgZone. https://ngrx.io/guide/store/configuration/runtime-checks#strictactionwithinngzone`
     );
     expect(ngCore.NgZone.isInAngularZone).toHaveBeenCalled();
   });

--- a/modules/store/spec/meta-reducers/inNgZoneAssert_reducer.spec.ts
+++ b/modules/store/spec/meta-reducers/inNgZoneAssert_reducer.spec.ts
@@ -1,5 +1,5 @@
 import * as ngCore from '@angular/core';
-import { inNgZoneAssertMetaReducer } from '../../src/meta-reducers/inNgZoneAssert_reducer';
+import { inNgZoneAssertMetaReducer } from '../../src/meta-reducers';
 
 describe('inNgZoneAssertMetaReducer:', () => {
   it('should not throw if in NgZone', () => {

--- a/modules/store/spec/meta-reducers/inNgZoneAssert_reducer.spec.ts
+++ b/modules/store/spec/meta-reducers/inNgZoneAssert_reducer.spec.ts
@@ -1,0 +1,36 @@
+import * as ngCore from '@angular/core';
+import { inNgZoneAssertMetaReducer } from '../../src/meta-reducers/inNgZoneAssert_reducer';
+
+describe('inNgZoneAssertMetaReducer:', () => {
+  it('should not throw if in NgZone', () => {
+    ngCore.NgZone.isInAngularZone = jasmine
+      .createSpy('isInAngularZone')
+      .and.returnValue(true);
+    expect(() => invokeActionReducer((state: any) => state)).not.toThrow();
+    expect(ngCore.NgZone.isInAngularZone).toHaveBeenCalled();
+  });
+
+  it('should throw when not in NgZone', () => {
+    ngCore.NgZone.isInAngularZone = jasmine
+      .createSpy('isInAngularZone')
+      .and.returnValue(false);
+    expect(() => invokeActionReducer((state: any) => state)).toThrowError(
+      `strictActionWithinNgZone: Action 'invoke' running outside NgZone.`
+    );
+    expect(ngCore.NgZone.isInAngularZone).toHaveBeenCalled();
+  });
+
+  it('should not call isInAngularZone when check is off', () => {
+    ngCore.NgZone.isInAngularZone = jasmine.createSpy('isInAngularZone');
+    expect(() =>
+      invokeActionReducer((state: any) => state, false)
+    ).not.toThrow();
+    expect(ngCore.NgZone.isInAngularZone).not.toHaveBeenCalled();
+  });
+
+  function invokeActionReducer(reduce: Function, checkIsOn = true) {
+    inNgZoneAssertMetaReducer((state, action) => reduce(state, action), {
+      action: () => checkIsOn,
+    })({}, { type: 'invoke' });
+  }
+});

--- a/modules/store/spec/meta-reducers/serialization_reducer.spec.ts
+++ b/modules/store/spec/meta-reducers/serialization_reducer.spec.ts
@@ -62,7 +62,7 @@ describe('serializationCheckMetaReducer:', () => {
           payload: { foo: { bar: unSerializables['date'] } },
         })
       ).toThrowError(
-        /Detected unserializable action at "payload.foo.bar.value"/
+        `Detected unserializable action at "payload.foo.bar.value". https://ngrx.io/guide/store/configuration/runtime-checks#strictactionserializability`
       );
     });
   });
@@ -80,13 +80,13 @@ describe('serializationCheckMetaReducer:', () => {
       ).toThrowError(/Detected unserializable state at "foo.bar.value"/);
     });
 
-    it('should not throw if state is null', () => {
+    it('should throw if state is null', () => {
       expect(() => invokeStateReducer(null)).toThrowError(
-        /Detected unserializable state at "root"/
+        `Detected unserializable state at "root". https://ngrx.io/guide/store/configuration/runtime-checks#strictstateserializability`
       );
     });
 
-    it('should not throw if state is undefined', () => {
+    it('should throw if state is undefined', () => {
       expect(() => invokeStateReducer(undefined)).toThrowError(
         /Detected unserializable state at "root"/
       );

--- a/modules/store/spec/runtime_checks.spec.ts
+++ b/modules/store/spec/runtime_checks.spec.ts
@@ -347,7 +347,7 @@ describe('Runtime checks:', () => {
           store.dispatch(invalidAction());
           flush();
         }).toThrowError(
-          "strictActionWithinNgZone: Action 'Action triggered outside of NgZone' running outside NgZone."
+          "Action 'Action triggered outside of NgZone' running outside NgZone. https://ngrx.io/guide/store/configuration/runtime-checks#strictactionwithinngzone"
         );
       })
     );

--- a/modules/store/spec/runtime_checks.spec.ts
+++ b/modules/store/spec/runtime_checks.spec.ts
@@ -13,6 +13,7 @@ describe('Runtime checks:', () => {
         strictActionSerializability: false,
         strictActionImmutability: true,
         strictStateImmutability: true,
+        strictActionWithinNgZone: false,
       });
     });
 
@@ -23,12 +24,14 @@ describe('Runtime checks:', () => {
           strictActionSerializability: true,
           strictActionImmutability: false,
           strictStateImmutability: false,
+          strictActionWithinNgZone: true,
         })
       ).toEqual({
         strictStateSerializability: true,
         strictActionSerializability: true,
         strictActionImmutability: false,
         strictStateImmutability: false,
+        strictActionWithinNgZone: true,
       });
     });
 
@@ -40,6 +43,7 @@ describe('Runtime checks:', () => {
         strictActionSerializability: false,
         strictActionImmutability: false,
         strictStateImmutability: false,
+        strictActionWithinNgZone: false,
       });
     });
 
@@ -50,12 +54,14 @@ describe('Runtime checks:', () => {
         createActiveRuntimeChecks({
           strictStateSerializability: true,
           strictActionSerializability: true,
+          strictActionWithinNgZone: true,
         })
       ).toEqual({
         strictStateSerializability: false,
         strictActionSerializability: false,
         strictActionImmutability: false,
         strictStateImmutability: false,
+        strictActionWithinNgZone: false,
       });
     });
   });
@@ -88,6 +94,10 @@ describe('Runtime checks:', () => {
         metaReducers,
         'serializationCheckMetaReducer'
       ).and.callThrough();
+      const inNgZoneAssertMetaReducerSpy = spyOn(
+        metaReducers,
+        'inNgZoneAssertMetaReducer'
+      ).and.callThrough();
 
       TestBed.configureTestingModule({
         imports: [StoreModule.forRoot({})],
@@ -96,6 +106,7 @@ describe('Runtime checks:', () => {
             provide: USER_RUNTIME_CHECKS,
             useValue: {
               strictStateSerializability: false,
+              strictActionWithinNgZone: false,
             },
           },
         ],
@@ -103,6 +114,7 @@ describe('Runtime checks:', () => {
 
       const _store = TestBed.get<Store<any>>(Store);
       expect(serializationCheckMetaReducerSpy).not.toHaveBeenCalled();
+      expect(inNgZoneAssertMetaReducerSpy).not.toHaveBeenCalled();
     });
 
     it('should create immutability meta reducer without config', () => {
@@ -320,6 +332,56 @@ describe('Runtime checks:', () => {
       })
     );
   });
+
+  describe('Action in NgZone', () => {
+    const invalidAction = () => ({ type: ErrorTypes.OutOfNgZoneAction });
+
+    it(
+      'should throw when running outside ngZone',
+      fakeAsync(() => {
+        ngCore.NgZone.isInAngularZone = jasmine
+          .createSpy('isInAngularZone')
+          .and.returnValue(false);
+        const store = setupStore({ strictActionWithinNgZone: true });
+        expect(() => {
+          store.dispatch(invalidAction());
+          flush();
+        }).toThrowError(
+          "strictActionWithinNgZone: Action 'Action triggered outside of NgZone' running outside NgZone."
+        );
+      })
+    );
+
+    it(
+      'should not throw when running in ngZone',
+      fakeAsync(() => {
+        ngCore.NgZone.isInAngularZone = jasmine
+          .createSpy('isInAngularZone')
+          .and.returnValue(true);
+        const store = setupStore({ strictActionWithinNgZone: true });
+        expect(() => {
+          store.dispatch(invalidAction());
+          flush();
+        }).not.toThrowError();
+
+        expect(ngCore.NgZone.isInAngularZone).toHaveBeenCalled();
+      })
+    );
+
+    it(
+      'should not be called when disabled',
+      fakeAsync(() => {
+        const store = setupStore({ strictActionWithinNgZone: false });
+        ngCore.NgZone.isInAngularZone = jasmine.createSpy('isInAngularZone');
+        expect(() => {
+          store.dispatch(invalidAction());
+          flush();
+        }).not.toThrow();
+
+        expect(ngCore.NgZone.isInAngularZone).not.toHaveBeenCalled();
+      })
+    );
+  });
 });
 
 function setupStore(runtimeChecks?: Partial<RuntimeChecks>): Store<any> {
@@ -342,6 +404,7 @@ enum ErrorTypes {
   UnserializableAction = 'Action type producing unserializable action',
   MutateAction = 'Action type producing action mutation',
   MutateState = 'Action type producing state mutation',
+  OutOfNgZoneAction = 'Action triggered outside of NgZone',
 }
 
 function reducerWithBugs(state: any = {}, action: any) {

--- a/modules/store/src/meta-reducers/inNgZoneAssert_reducer.ts
+++ b/modules/store/src/meta-reducers/inNgZoneAssert_reducer.ts
@@ -1,5 +1,6 @@
 import * as ngCore from '@angular/core';
-import { ActionReducer, Action } from '../models';
+import { Action, ActionReducer } from '../models';
+import { RUNTIME_CHECK_URL } from './utils';
 
 export function inNgZoneAssertMetaReducer(
   reducer: ActionReducer<any, Action>,
@@ -8,9 +9,9 @@ export function inNgZoneAssertMetaReducer(
   return function(state: any, action: Action) {
     if (checks.action(action) && !ngCore.NgZone.isInAngularZone()) {
       throw new Error(
-        `strictActionWithinNgZone: Action '${
+        `Action '${
           action.type
-        }' running outside NgZone.`
+        }' running outside NgZone. ${RUNTIME_CHECK_URL}#strictactionwithinngzone`
       );
     }
     return reducer(state, action);

--- a/modules/store/src/meta-reducers/inNgZoneAssert_reducer.ts
+++ b/modules/store/src/meta-reducers/inNgZoneAssert_reducer.ts
@@ -1,0 +1,18 @@
+import * as ngCore from '@angular/core';
+import { ActionReducer, Action } from '../models';
+
+export function inNgZoneAssertMetaReducer(
+  reducer: ActionReducer<any, Action>,
+  checks: { action: (action: Action) => boolean }
+) {
+  return function(state: any, action: Action) {
+    if (checks.action(action) && !ngCore.NgZone.isInAngularZone()) {
+      throw new Error(
+        `strictActionWithinNgZone: Action '${
+          action.type
+        }' running outside NgZone.`
+      );
+    }
+    return reducer(state, action);
+  };
+}

--- a/modules/store/src/meta-reducers/index.ts
+++ b/modules/store/src/meta-reducers/index.ts
@@ -1,2 +1,3 @@
 export { immutabilityCheckMetaReducer } from './immutability_reducer';
 export { serializationCheckMetaReducer } from './serialization_reducer';
+export { inNgZoneAssertMetaReducer } from './inNgZoneAssert_reducer';

--- a/modules/store/src/meta-reducers/serialization_reducer.ts
+++ b/modules/store/src/meta-reducers/serialization_reducer.ts
@@ -7,6 +7,7 @@ import {
   isBoolean,
   isString,
   isArray,
+  RUNTIME_CHECK_URL,
 } from './utils';
 
 export function serializationCheckMetaReducer(
@@ -82,7 +83,7 @@ function throwIfUnserializable(
 
   const unserializablePath = unserializable.path.join('.');
   const error: any = new Error(
-    `Detected unserializable ${context} at "${unserializablePath}"`
+    `Detected unserializable ${context} at "${unserializablePath}". ${RUNTIME_CHECK_URL}#strict${context}serializability`
   );
   error.value = unserializable.value;
   error.unserializablePath = unserializablePath;

--- a/modules/store/src/meta-reducers/utils.ts
+++ b/modules/store/src/meta-reducers/utils.ts
@@ -1,3 +1,6 @@
+export const RUNTIME_CHECK_URL =
+  'https://ngrx.io/guide/store/configuration/runtime-checks';
+
 export function isUndefined(target: any): target is undefined {
   return target === undefined;
 }

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -115,4 +115,9 @@ export interface RuntimeChecks {
    * Verifies that actions aren't mutated
    */
   strictActionImmutability: boolean;
+
+  /**
+   * Verifies that actions are dispatched within NgZone
+   */
+  strictActionWithinNgZone: boolean;
 }

--- a/projects/example-app/src/app/app.module.ts
+++ b/projects/example-app/src/app/app.module.ts
@@ -41,6 +41,7 @@ import { AppComponent } from '@example-app/core/containers';
         strictActionImmutability: true,
         strictStateSerializability: true,
         strictActionSerializability: true,
+        strictActionWithinNgZone: true,
       },
     }),
 

--- a/projects/ngrx.io/content/guide/store/configuration/runtime-checks.md
+++ b/projects/ngrx.io/content/guide/store/configuration/runtime-checks.md
@@ -4,17 +4,19 @@ Runtime checks are here to guide developers to follow the NgRx and Redux core co
 
 `@ngrx/store` ships with five (5) built-in runtime checks:
 
-- [`strictStateImmutability`](#strictstateimmutability): verifies that the state isn't mutated
-- [`strictActionImmutability`](#strictactionimmutability): verifies that actions aren't mutated
-- [`strictStateSerializability`](#strictstateserializability): verifies if the state is serializable
-- [`strictActionSerializability`](#strictactionserializability): verifies if the actions are serializable
-- [`strictActionWithinNgZone`](#strictactionwithinngzone): verifies if actions are dispatched within NgZone
+- Default On:
+  - [`strictStateImmutability`](#strictstateimmutability): verifies that the state isn't mutated.
+  - [`strictActionImmutability`](#strictactionimmutability): verifies that actions aren't mutated
+- Default Off:
+  - [`strictStateSerializability`](#strictstateserializability): verifies if the state is serializable
+  - [`strictActionSerializability`](#strictactionserializability): verifies if the actions are serializable
+  - [`strictActionWithinNgZone`](#strictactionwithinngzone): verifies if actions are dispatched within NgZone
 
-These checks are all opt-in and will automatically be disabled in production builds.
+All checks will automatically be disabled in production builds.
 
-## Enabling runtime checks
+## Configuring runtime checks
 
-It's possible to turn on the runtime checks one by one. To do so, you must enable them while providing the root store. Use the `runtimeChecks` property on the root store's config object. For each runtime check you can toggle the check with a `boolean`, `true` to enable the check, `false` to disable the check.
+It's possible to override the default configuration of runtime checks. To do so, use the `runtimeChecks` property on the root store's config object. For each runtime check you can toggle the check with a `boolean`, `true` to enable the check, `false` to disable the check.
 
 ```ts
 @NgModule({
@@ -176,7 +178,7 @@ Please note, you may not need to set `strictActionSerializability` to `true` unl
 
 ### strictActionWithinNgZone
 
-The `strictActionWithinNgZone` check verifies that Actions are dispatched by asynchonous tasks running within `NgZone`. Actions dispatched by tasks, running outside of `NgZone`, will not trigger ChangeDetection upon completion and may result in a stale view.
+The `strictActionWithinNgZone` check verifies that Actions are dispatched by asynchronous tasks running within `NgZone`. Actions dispatched by tasks, running outside of `NgZone`, will not trigger ChangeDetection upon completion and may result in a stale view.
 
 Example violation of the rule:
 

--- a/projects/ngrx.io/content/guide/store/configuration/runtime-checks.md
+++ b/projects/ngrx.io/content/guide/store/configuration/runtime-checks.md
@@ -8,7 +8,7 @@ Runtime checks are here to guide developers to follow the NgRx and Redux core co
 - [`strictActionImmutability`](#strictactionimmutability): verifies that actions aren't mutated
 - [`strictStateSerializability`](#strictstateserializability): verifies if the state is serializable
 - [`strictActionSerializability`](#strictactionserializability): verifies if the actions are serializable
-- [`strictActionWithinNgZone`](#strictActionWithinNgZone): verifies if actions are dispatched within NgZone
+- [`strictActionWithinNgZone`](#strictactionwithinngzone): verifies if actions are dispatched within NgZone
 
 These checks are all opt-in and will automatically be disabled in production builds.
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently there is no alert if an Action is running outside of NgZone which can lead to stale views as change detection will not be triggered. Would help prevent issues like 
https://github.com/ngrx/platform/issues/476.

Add a runtime check that asserts dispatched actions are running within NgZone. Will be off by default and activated by the strictActionWithinNgZone flag.

Closes https://github.com/ngrx/platform/issues/2339

## What is the new behavior?
An error will be thrown if an Action is running outside of NgZone and this flag is enabled.

```
strictActionWithinNgZone: Action '[TODO] Update Todo' running outside NgZone.
```
## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
