### PR TITLE
fix(data): mergeQuerySet uses mergeStrategy with default PreserveChan…

### DIFF
--- a/modules/data/spec/reducers/entity-change-tracker-base.spec.ts
+++ b/modules/data/spec/reducers/entity-change-tracker-base.spec.ts
@@ -720,7 +720,6 @@ describe('EntityChangeTrackerBase', () => {
         collection,
         addedEntity,
         deletedEntity,
-        preUpdatedEntity,
         updatedEntity,
       } = createTestTrackedEntities();
 

--- a/modules/data/src/reducers/entity-cache-reducer.ts
+++ b/modules/data/src/reducers/entity-cache-reducer.ts
@@ -188,7 +188,7 @@ export class EntityCacheReducerFactory {
     let { mergeStrategy, querySet, tag } = action.payload;
     mergeStrategy =
       mergeStrategy === null ? MergeStrategy.PreserveChanges : mergeStrategy;
-    const entityOp = EntityOp.UPSERT_MANY;
+    const entityOp = EntityOp.QUERY_ALL_SUCCESS;
 
     const entityNames = Object.keys(querySet);
     entityCache = entityNames.reduce((newCache, entityName) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`mergeQuerySet` accessible via `EntityCacheDispatcher` does not implement the `mergeStrategy` parameter which governs how queried data and changes tracked via `changeState` merge.

API - https://ngrx.io/api/data/EntityCacheDispatcher
`mergeQuerySet(querySet: EntityCacheQuerySet, mergeStrategy?: MergeStrategy, tag?: string)`

Closes #2368

## What is the new behavior?

Passing various merge strategies IgnoreChanges, PreserveChanges, OverwriteChanges to mergeQuerySet will implement the documented behaviour (referenced below). 
```
    this.entityCacheDispatcher.mergeQuerySet(
      querySet,
      MergeStrategy.PreserveChanges
    );
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The fix works because GET_ALL works well with mergeStrategy
Happy path: `EntityOp.QUERY_ALL_SUCCESS → mergeQueryResults → mergeServerUpserts`
The issue #2368 details current code path caused by UPSERT_MANY

`upsertMany` in `entity-collection-reducer-methods.ts` should not be trusted with mergeStrategy:- `this.adapter.upsertMany(entities, collection);` will upsert **all** the entities into the entities state for the entityName collection and `trackUpsertMany` does not utilise mergeStrategy.

Similarly for the other upsert methods.

# References 

References to EntityCacheDispatcher
https://ngrx.io/guide/data/save-entities#saving-multiple-entities
> Multiple entity saves are a first class feature. By "first class" we mean that NgRx Data offers a built-in, multiple entity save solution that is consistent with NgRx Data itself:
> -  defines a ChangeSet, describing ChangeOperations to be performed on multiple entities of multiple types.
> -  has a set of SAVE_ENTITIES... cache-level actions.
> -  **has an EntityCacheDispatcher to dispatch those actions**.

Reference to Merge Strategy
https://ngrx.io/guide/data/entity-change-tracker#merge-strategies
> You can determine how NgRx Data will merge entities after a query, a save, or a cache operation by setting the entity action's optional mergeStrategy property to one of the three strategy enums:
> 1.  **IgnoreChanges** - Update the collection entities and ignore all change tracking for this operation. Each entity's changeState is untouched.
> 2. **PreserveChanges** - Updates current values for unchanged entities. For each changed entity it preserves the current value and overwrites the originalValue with the merge entity. This is the query-success default.
> 3. **OverwriteChanges** - Replace the current collection entities. For each merged entity it discards the changeState and sets the changeType to "unchanged". This is the save-success default.
