### PR TITLE
fix(effects): dispatch OnInitEffects action after registration

### DIFF
--- a/modules/effects/spec/effect_sources.spec.ts
+++ b/modules/effects/spec/effect_sources.spec.ts
@@ -328,8 +328,8 @@ describe('EffectSources', () => {
       const d = { not: 'a valid action' };
       const e = undefined;
       const f = null;
-      const identifierAction1 = { type: 'From Source Identifier' };
-      const identifierAction2 = { type: 'From Source Identifier 2' };
+      const i = { type: 'From Source Identifier' };
+      const i2 = { type: 'From Source Identifier 2' };
       const initAction = { type: '[SourceWithInitAction] Init' };
 
       let circularRef = {} as any;
@@ -394,7 +394,7 @@ describe('EffectSources', () => {
 
       class SourceWithIdentifier implements OnIdentifyEffects {
         effectIdentifier: string;
-        i$ = createEffect(() => alwaysOf(identifierAction1));
+        i$ = createEffect(() => alwaysOf(i));
 
         ngrxOnIdentifyEffects() {
           return this.effectIdentifier;
@@ -407,7 +407,7 @@ describe('EffectSources', () => {
 
       class SourceWithIdentifier2 implements OnIdentifyEffects {
         effectIdentifier: string;
-        i2$ = createEffect(() => alwaysOf(identifierAction2));
+        i2$ = createEffect(() => alwaysOf(i2));
 
         ngrxOnIdentifyEffects() {
           return this.effectIdentifier;
@@ -447,238 +447,230 @@ describe('EffectSources', () => {
         }
       }
 
-      describe('instance registration', () => {
-        it('should resolve effects from instances', () => {
-          const sources$ = cold('--a--', { a: new SourceA() });
-          const expected = cold('--a--', { a });
+      it('should resolve effects from instances', () => {
+        const sources$ = cold('--a--', { a: new SourceA() });
+        const expected = cold('--a--', { a });
 
-          const output = toActions(sources$);
+        const output = toActions(sources$);
 
-          expect(output).toBeObservable(expected);
-        });
-
-        it('should ignore duplicate sources', () => {
-          const sources$ = cold('--a--a--a--', {
-            a: new SourceA(),
-          });
-          const expected = cold('--a--------', { a });
-
-          const output = toActions(sources$);
-
-          expect(output).toBeObservable(expected);
-        });
+        expect(output).toBeObservable(expected);
       });
 
-      describe('OnIdentifyEffects', () => {
-        it('should resolve effects with different identifiers', () => {
-          const sources$ = cold('--a--b--c--', {
-            a: new SourceWithIdentifier('a'),
-            b: new SourceWithIdentifier('b'),
-            c: new SourceWithIdentifier('c'),
-          });
-          const expected = cold('--i--i--i--', { i: identifierAction1 });
-
-          const output = toActions(sources$);
-
-          expect(output).toBeObservable(expected);
+      it('should ignore duplicate sources', () => {
+        const sources$ = cold('--a--a--a--', {
+          a: new SourceA(),
         });
+        const expected = cold('--a--------', { a });
 
-        it('should ignore effects with the same identifier', () => {
-          const sources$ = cold('--a--b--c--', {
-            a: new SourceWithIdentifier('a'),
-            b: new SourceWithIdentifier('a'),
-            c: new SourceWithIdentifier('a'),
-          });
-          const expected = cold('--i--------', { i: identifierAction1 });
+        const output = toActions(sources$);
 
-          const output = toActions(sources$);
-
-          expect(output).toBeObservable(expected);
-        });
-
-        it('should resolve effects with same identifiers but different classes', () => {
-          const sources$ = cold('--a--b--c--d--', {
-            a: new SourceWithIdentifier('a'),
-            b: new SourceWithIdentifier2('a'),
-            c: new SourceWithIdentifier('b'),
-            d: new SourceWithIdentifier2('b'),
-          });
-          const expected = cold('--a--b--a--b--', {
-            a: identifierAction1,
-            b: identifierAction2,
-          });
-
-          const output = toActions(sources$);
-
-          expect(output).toBeObservable(expected);
-        });
+        expect(output).toBeObservable(expected);
       });
 
-      describe('OnInitEffects', () => {
-        it('should start with an the action after being registered', () => {
-          const sources$ = cold('--a--', {
-            a: new SourceWithInitAction(new Subject()),
-          });
-          const expected = cold('--a--', { a: initAction });
-
-          const output = toActions(sources$);
-
-          expect(output).toBeObservable(expected);
+      it('should resolve effects with different identifiers', () => {
+        const sources$ = cold('--a--b--c--', {
+          a: new SourceWithIdentifier('a'),
+          b: new SourceWithIdentifier('b'),
+          c: new SourceWithIdentifier('c'),
         });
+        const expected = cold('--i--i--i--', { i });
 
-        it('should not start twice for the same instance', () => {
-          const sources$ = cold('--a--a--', {
-            a: new SourceWithInitAction(new Subject()),
-          });
-          const expected = cold('--a--', { a: initAction });
+        const output = toActions(sources$);
 
-          const output = toActions(sources$);
-
-          expect(output).toBeObservable(expected);
-        });
-
-        it('should start twice for the same instance with a different key', () => {
-          const sources$ = cold('--a--b--', {
-            a: new SourceWithInitAction(new Subject(), 'a'),
-            b: new SourceWithInitAction(new Subject(), 'b'),
-          });
-          const expected = cold('--a--a--', { a: initAction });
-
-          const output = toActions(sources$);
-
-          expect(output).toBeObservable(expected);
-        });
+        expect(output).toBeObservable(expected);
       });
 
-      describe('error handling', () => {
-        it('should report an error if an effect dispatches an invalid action', () => {
-          const sources$ = of(new SourceD());
+      it('should ignore effects with the same identifier', () => {
+        const sources$ = cold('--a--b--c--', {
+          a: new SourceWithIdentifier('a'),
+          b: new SourceWithIdentifier('a'),
+          c: new SourceWithIdentifier('a'),
+        });
+        const expected = cold('--i--------', { i });
 
-          toActions(sources$).subscribe();
+        const output = toActions(sources$);
 
-          expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
-            new Error(
-              'Effect "SourceD.d$" dispatched an invalid action: {"not":"a valid action"}'
-            )
-          );
+        expect(output).toBeObservable(expected);
+      });
+
+      it('should resolve effects with same identifiers but different classes', () => {
+        const sources$ = cold('--a--b--c--d--', {
+          a: new SourceWithIdentifier('a'),
+          b: new SourceWithIdentifier2('a'),
+          c: new SourceWithIdentifier('b'),
+          d: new SourceWithIdentifier2('b'),
+        });
+        const expected = cold('--a--b--a--b--', {
+          a: i,
+          b: i2,
         });
 
-        it('should report an error if an effect dispatches an `undefined`', () => {
-          const sources$ = of(new SourceE());
+        const output = toActions(sources$);
 
-          toActions(sources$).subscribe();
+        expect(output).toBeObservable(expected);
+      });
 
-          expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
-            new Error(
-              'Effect "SourceE.e$" dispatched an invalid action: undefined'
-            )
-          );
+      it('should start with an  action after being registered with OnInitEffects', () => {
+        const sources$ = cold('--a--', {
+          a: new SourceWithInitAction(new Subject()),
         });
+        const expected = cold('--a--', { a: initAction });
 
-        it('should report an error if an effect dispatches a `null`', () => {
-          const sources$ = of(new SourceF());
+        const output = toActions(sources$);
 
-          toActions(sources$).subscribe();
+        expect(output).toBeObservable(expected);
+      });
 
-          expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
-            new Error('Effect "SourceF.f$" dispatched an invalid action: null')
-          );
+      it('should not start twice for the same instance', () => {
+        const sources$ = cold('--a--a--', {
+          a: new SourceWithInitAction(new Subject()),
         });
+        const expected = cold('--a--', { a: initAction });
 
-        it('should report an error if an effect throws one', () => {
-          const sources$ = of(new SourceError());
+        const output = toActions(sources$);
 
-          toActions(sources$).subscribe();
+        expect(output).toBeObservable(expected);
+      });
 
-          expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
-            new Error('An Error')
-          );
+      it('should start twice for the same instance with a different key', () => {
+        const sources$ = cold('--a--b--', {
+          a: new SourceWithInitAction(new Subject(), 'a'),
+          b: new SourceWithInitAction(new Subject(), 'b'),
         });
+        const expected = cold('--a--a--', { a: initAction });
 
-        it('should resubscribe on error by default', () => {
-          const sources$ = of(
-            new class {
-              b$ = createEffect(() =>
-                hot('a--e--b--e--c--e--d').pipe(
+        const output = toActions(sources$);
+
+        expect(output).toBeObservable(expected);
+      });
+
+      it('should report an error if an effect dispatches an invalid action', () => {
+        const sources$ = of(new SourceD());
+
+        toActions(sources$).subscribe();
+
+        expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
+          new Error(
+            'Effect "SourceD.d$" dispatched an invalid action: {"not":"a valid action"}'
+          )
+        );
+      });
+
+      it('should report an error if an effect dispatches an `undefined`', () => {
+        const sources$ = of(new SourceE());
+
+        toActions(sources$).subscribe();
+
+        expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
+          new Error(
+            'Effect "SourceE.e$" dispatched an invalid action: undefined'
+          )
+        );
+      });
+
+      it('should report an error if an effect dispatches a `null`', () => {
+        const sources$ = of(new SourceF());
+
+        toActions(sources$).subscribe();
+
+        expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
+          new Error('Effect "SourceF.f$" dispatched an invalid action: null')
+        );
+      });
+
+      it('should report an error if an effect throws one', () => {
+        const sources$ = of(new SourceError());
+
+        toActions(sources$).subscribe();
+
+        expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
+          new Error('An Error')
+        );
+      });
+
+      it('should resubscribe on error by default', () => {
+        const sources$ = of(
+          new class {
+            b$ = createEffect(() =>
+              hot('a--e--b--e--c--e--d').pipe(
+                map(v => {
+                  if (v == 'e') throw new Error('An Error');
+                  return v;
+                })
+              )
+            );
+          }()
+        );
+
+        //                       👇 'e' is ignored.
+        const expected = cold('a-----b-----c-----d');
+
+        expect(toActions(sources$)).toBeObservable(expected);
+      });
+
+      it('should resubscribe on error by default when dispatch is false', () => {
+        const sources$ = of(
+          new class {
+            b$ = createEffect(
+              () =>
+                hot('a--b--c--d').pipe(
                   map(v => {
-                    if (v == 'e') throw new Error('An Error');
+                    if (v == 'b') throw new Error('An Error');
                     return v;
                   })
-                )
-              );
-            }()
-          );
+                ),
+              { dispatch: false }
+            );
+          }()
+        );
+        //                    👇 doesn't complete and doesn't dispatch
+        const expected = cold('----------');
 
-          //                       👇 'e' is ignored.
-          const expected = cold('a-----b-----c-----d');
+        expect(toActions(sources$)).toBeObservable(expected);
+      });
 
-          expect(toActions(sources$)).toBeObservable(expected);
+      it('should not resubscribe on error when useEffectsErrorHandler is false', () => {
+        const sources$ = of(
+          new class {
+            b$ = createEffect(
+              () =>
+                hot('a--b--c--d').pipe(
+                  map(v => {
+                    if (v == 'b') throw new Error('An Error');
+                    return v;
+                  })
+                ),
+              { dispatch: false, useEffectsErrorHandler: false }
+            );
+          }()
+        );
+        //                       👇 errors with dispatch false
+        const expected = cold('---#', undefined, new Error('An Error'));
+
+        expect(toActions(sources$)).toBeObservable(expected);
+      });
+
+      it(`should not break when the action in the error message can't be stringified`, () => {
+        const sources$ = of(new SourceG());
+
+        toActions(sources$).subscribe();
+
+        expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
+          new Error(
+            'Effect "SourceG.g$" dispatched an invalid action: [object Object]'
+          )
+        );
+      });
+
+      it('should not complete the group if just one effect completes', () => {
+        const sources$ = cold('g', {
+          g: new SourceH(),
         });
+        const expected = cold('a----b-----', { a: 'value', b: 'update' });
 
-        it('should resubscribe on error by default when dispatch is false', () => {
-          const sources$ = of(
-            new class {
-              b$ = createEffect(
-                () =>
-                  hot('a--b--c--d').pipe(
-                    map(v => {
-                      if (v == 'b') throw new Error('An Error');
-                      return v;
-                    })
-                  ),
-                { dispatch: false }
-              );
-            }()
-          );
-          //                    👇 doesn't complete and doesn't dispatch
-          const expected = cold('----------');
+        const output = toActions(sources$);
 
-          expect(toActions(sources$)).toBeObservable(expected);
-        });
-
-        it('should not resubscribe on error when useEffectsErrorHandler is false', () => {
-          const sources$ = of(
-            new class {
-              b$ = createEffect(
-                () =>
-                  hot('a--b--c--d').pipe(
-                    map(v => {
-                      if (v == 'b') throw new Error('An Error');
-                      return v;
-                    })
-                  ),
-                { dispatch: false, useEffectsErrorHandler: false }
-              );
-            }()
-          );
-          //                       👇 errors with dispatch false
-          const expected = cold('---#', undefined, new Error('An Error'));
-
-          expect(toActions(sources$)).toBeObservable(expected);
-        });
-
-        it(`should not break when the action in the error message can't be stringified`, () => {
-          const sources$ = of(new SourceG());
-
-          toActions(sources$).subscribe();
-
-          expect(mockErrorReporter.handleError).toHaveBeenCalledWith(
-            new Error(
-              'Effect "SourceG.g$" dispatched an invalid action: [object Object]'
-            )
-          );
-        });
-
-        it('should not complete the group if just one effect completes', () => {
-          const sources$ = cold('g', {
-            g: new SourceH(),
-          });
-          const expected = cold('a----b-----', { a: 'value', b: 'update' });
-
-          const output = toActions(sources$);
-
-          expect(output).toBeObservable(expected);
-        });
+        expect(output).toBeObservable(expected);
       });
     });
   });

--- a/modules/effects/spec/integration.spec.ts
+++ b/modules/effects/spec/integration.spec.ts
@@ -1,81 +1,32 @@
-import { NgModuleFactoryLoader, NgModule } from '@angular/core';
+import { NgModuleFactoryLoader, NgModule, Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   RouterTestingModule,
   SpyNgModuleFactoryLoader,
 } from '@angular/router/testing';
 import { Router } from '@angular/router';
-import { Store, Action } from '@ngrx/store';
+import { Action, StoreModule, INIT } from '@ngrx/store';
 import {
   EffectsModule,
   OnInitEffects,
   ROOT_EFFECTS_INIT,
   OnIdentifyEffects,
   EffectSources,
+  Actions,
 } from '..';
+import { ofType, createEffect } from '../src';
+import { mapTo } from 'rxjs/operators';
 
 describe('NgRx Effects Integration spec', () => {
-  let dispatch: jasmine.Spy;
-
-  beforeEach(() => {
+  it('throws if forRoot() is used more than once', (done: DoneFn) => {
     TestBed.configureTestingModule({
       imports: [
-        EffectsModule.forRoot([
-          RootEffectWithInitAction,
-          RootEffectWithoutLifecycle,
-          RootEffectWithInitActionWithPayload,
-        ]),
-        EffectsModule.forFeature([FeatEffectWithInitAction]),
+        StoreModule.forRoot({}),
+        EffectsModule.forRoot([]),
         RouterTestingModule.withRoutes([]),
-      ],
-      providers: [
-        {
-          provide: Store,
-          useValue: {
-            dispatch: jasmine.createSpy('dispatch'),
-          },
-        },
       ],
     });
 
-    const store = TestBed.get(Store) as Store<any>;
-
-    const effectSources = TestBed.get(EffectSources) as EffectSources;
-    effectSources.addEffects(new FeatEffectWithIdentifierAndInitAction('one'));
-    effectSources.addEffects(new FeatEffectWithIdentifierAndInitAction('two'));
-    effectSources.addEffects(new FeatEffectWithIdentifierAndInitAction('one'));
-
-    dispatch = store.dispatch as jasmine.Spy;
-  });
-
-  it('should dispatch init actions in the correct order', () => {
-    expect(dispatch.calls.count()).toBe(6);
-
-    // All of the root effects init actions are dispatched first
-    expect(dispatch.calls.argsFor(0)).toEqual([
-      { type: '[RootEffectWithInitAction]: INIT' },
-    ]);
-
-    expect(dispatch.calls.argsFor(1)).toEqual([new ActionWithPayload()]);
-
-    // After all of the root effects are registered, the ROOT_EFFECTS_INIT action is dispatched
-    expect(dispatch.calls.argsFor(2)).toEqual([{ type: ROOT_EFFECTS_INIT }]);
-
-    // After the root effects init, the feature effects are dispatched
-    expect(dispatch.calls.argsFor(3)).toEqual([
-      { type: '[FeatEffectWithInitAction]: INIT' },
-    ]);
-
-    expect(dispatch.calls.argsFor(4)).toEqual([
-      { type: '[FeatEffectWithIdentifierAndInitAction]: INIT' },
-    ]);
-
-    expect(dispatch.calls.argsFor(5)).toEqual([
-      { type: '[FeatEffectWithIdentifierAndInitAction]: INIT' },
-    ]);
-  });
-
-  it('throws if forRoot() is used more than once', (done: DoneFn) => {
     let router: Router = TestBed.get(Router);
     const loader: SpyNgModuleFactoryLoader = TestBed.get(NgModuleFactoryLoader);
 
@@ -90,9 +41,202 @@ describe('NgRx Effects Integration spec', () => {
     });
   });
 
+  describe('actions', () => {
+    const createDispatchedReducer = (dispatchedActions: string[] = []) => (
+      state = {},
+      action: Action
+    ) => {
+      dispatchedActions.push(action.type);
+      return state;
+    };
+
+    describe('init actions', () => {
+      it('should dispatch and react to init effect', () => {
+        let dispatchedActionsLog: string[] = [];
+        TestBed.configureTestingModule({
+          imports: [
+            StoreModule.forRoot({
+              dispatched: createDispatchedReducer(dispatchedActionsLog),
+            }),
+            EffectsModule.forRoot([EffectWithOnInitAndResponse]),
+          ],
+        });
+        TestBed.get(EffectSources);
+
+        expect(dispatchedActionsLog).toEqual([
+          INIT,
+
+          '[EffectWithOnInitAndResponse]: INIT',
+          '[EffectWithOnInitAndResponse]: INIT Response',
+
+          ROOT_EFFECTS_INIT,
+        ]);
+      });
+
+      it('should dispatch once for an instance', () => {
+        let dispatchedActionsLog: string[] = [];
+        TestBed.configureTestingModule({
+          imports: [
+            StoreModule.forRoot({
+              dispatched: createDispatchedReducer(dispatchedActionsLog),
+            }),
+            EffectsModule.forRoot([
+              RootEffectWithInitAction,
+              RootEffectWithInitAction,
+              RootEffectWithInitAction2,
+            ]),
+            EffectsModule.forFeature([
+              RootEffectWithInitAction,
+              RootEffectWithInitAction2,
+            ]),
+          ],
+        });
+        TestBed.get(EffectSources);
+
+        expect(dispatchedActionsLog).toEqual([
+          INIT,
+
+          '[RootEffectWithInitAction]: INIT',
+          '[RootEffectWithInitAction2]: INIT',
+
+          ROOT_EFFECTS_INIT,
+        ]);
+      });
+
+      it('should dispatch once per instance key', () => {
+        let dispatchedActionsLog: string[] = [];
+        TestBed.configureTestingModule({
+          imports: [
+            StoreModule.forRoot({
+              dispatched: createDispatchedReducer(dispatchedActionsLog),
+            }),
+            EffectsModule.forRoot([]),
+          ],
+        });
+        const effectsSources = TestBed.inject(EffectSources);
+
+        effectsSources.addEffects(
+          new FeatEffectWithIdentifierAndInitAction('One')
+        );
+        effectsSources.addEffects(
+          new FeatEffectWithIdentifierAndInitAction('Two')
+        );
+        effectsSources.addEffects(
+          new FeatEffectWithIdentifierAndInitAction('One')
+        );
+        effectsSources.addEffects(
+          new FeatEffectWithIdentifierAndInitAction('Two')
+        );
+
+        expect(dispatchedActionsLog).toEqual([
+          INIT,
+          ROOT_EFFECTS_INIT,
+
+          // for One
+          '[FeatEffectWithIdentifierAndInitAction]: INIT',
+          // for Two
+          '[FeatEffectWithIdentifierAndInitAction]: INIT',
+        ]);
+      });
+    });
+
+    it('should dispatch actions in the correct order', async () => {
+      let dispatchedActionsLog: string[] = [];
+      TestBed.configureTestingModule({
+        imports: [
+          StoreModule.forRoot({
+            dispatched: createDispatchedReducer(dispatchedActionsLog),
+          }),
+          EffectsModule.forRoot([
+            RootEffectWithInitAction,
+            EffectWithOnInitAndResponse,
+            RootEffectWithoutLifecycle,
+            RootEffectWithInitActionWithPayload,
+          ]),
+          EffectsModule.forFeature([FeatEffectWithInitAction]),
+          RouterTestingModule.withRoutes([]),
+        ],
+      });
+
+      const effectSources = TestBed.get(EffectSources) as EffectSources;
+      effectSources.addEffects(
+        new FeatEffectWithIdentifierAndInitAction('one')
+      );
+      effectSources.addEffects(
+        new FeatEffectWithIdentifierAndInitAction('two')
+      );
+      effectSources.addEffects(
+        new FeatEffectWithIdentifierAndInitAction('one')
+      );
+
+      let router: Router = TestBed.get(Router);
+      const loader: SpyNgModuleFactoryLoader = TestBed.get(
+        NgModuleFactoryLoader
+      );
+
+      loader.stubbedModules = { feature: FeatModuleWithForFeature };
+      router.resetConfig([{ path: 'feature-path', loadChildren: 'feature' }]);
+
+      await router.navigateByUrl('/feature-path');
+
+      expect(dispatchedActionsLog).toEqual([
+        // first store init
+        INIT,
+
+        // second root effects
+        '[RootEffectWithInitAction]: INIT',
+        '[EffectWithOnInitAndResponse]: INIT',
+        '[EffectWithOnInitAndResponse]: INIT Response',
+        '[RootEffectWithInitActionWithPayload]: INIT',
+
+        // third effects init
+        ROOT_EFFECTS_INIT,
+
+        // next feat effects
+        '[FeatEffectWithInitAction]: INIT',
+
+        // lastly added features (3 effects but 2 unique keys)
+        '[FeatEffectWithIdentifierAndInitAction]: INIT',
+        '[FeatEffectWithIdentifierAndInitAction]: INIT',
+
+        // from lazy loaded module
+        '[FeatEffectFromLazyLoadedModuleWithInitAction]: INIT',
+      ]);
+    });
+  });
+
+  @Injectable()
+  class EffectWithOnInitAndResponse implements OnInitEffects {
+    ngrxOnInitEffects(): Action {
+      return { type: '[EffectWithOnInitAndResponse]: INIT' };
+    }
+
+    response = createEffect(() => {
+      return this.actions$.pipe(
+        ofType('[EffectWithOnInitAndResponse]: INIT'),
+        mapTo({ type: '[EffectWithOnInitAndResponse]: INIT Response' })
+      );
+    });
+
+    noop = createEffect(() => {
+      return this.actions$.pipe(
+        ofType('noop'),
+        mapTo({ type: 'noop response' })
+      );
+    });
+
+    constructor(private actions$: Actions) {}
+  }
+
   class RootEffectWithInitAction implements OnInitEffects {
     ngrxOnInitEffects(): Action {
       return { type: '[RootEffectWithInitAction]: INIT' };
+    }
+  }
+
+  class RootEffectWithInitAction2 implements OnInitEffects {
+    ngrxOnInitEffects(): Action {
+      return { type: '[RootEffectWithInitAction2]: INIT' };
     }
   }
 
@@ -128,8 +272,23 @@ describe('NgRx Effects Integration spec', () => {
     constructor(private effectIdentifier: string) {}
   }
 
+  class FeatEffectFromLazyLoadedModuleWithInitAction implements OnInitEffects {
+    ngrxOnInitEffects(): Action {
+      return { type: '[FeatEffectFromLazyLoadedModuleWithInitAction]: INIT' };
+    }
+  }
+
   @NgModule({
     imports: [EffectsModule.forRoot([])],
   })
   class FeatModuleWithForRoot {}
+
+  @NgModule({
+    imports: [
+      EffectsModule.forFeature([FeatEffectFromLazyLoadedModuleWithInitAction]),
+      // should not be loaded because it's already loaded in forRoot
+      EffectsModule.forFeature([FeatEffectWithInitAction]),
+    ],
+  })
+  class FeatModuleWithForFeature {}
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2373

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The problem wasn't Ivy, but that the action was dispatched before the registration of the effect sources. The action was dispatched, but the effects didn't catch this action because it was dispatched too early.
