### PR TITLE
fix(data): make mergeServerUpserts change state immutably (#2374)

### DIFF
--- a/modules/data/spec/reducers/entity-change-tracker-base.spec.ts
+++ b/modules/data/spec/reducers/entity-change-tracker-base.spec.ts
@@ -104,6 +104,358 @@ describe('EntityChangeTrackerBase', () => {
     });
   });
 
+  describe('#mergeQueryResults', () => {
+    it('should use default preserve changes strategy', () => {
+      let {
+        unchangedHero,
+        unchangedHeroServerUpdated,
+        updatedHero,
+        serverUpdatedHero,
+        locallyUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+      const collection = tracker.mergeQueryResults(
+        [unchangedHeroServerUpdated, serverUpdatedHero],
+        initialCache.Hero
+      );
+
+      expect(collection.entities[unchangedHero.id]).toEqual(
+        unchangedHeroServerUpdated,
+        'Replace the current collection entity for unchanged entity'
+      );
+      expect(collection.entities[updatedHero.id]).toEqual(
+        locallyUpdatedHero,
+        'Preserves the current value for changed entity'
+      );
+      expect(collection.changeState[updatedHero.id]!.originalValue).toEqual(
+        serverUpdatedHero,
+        'Overwrites the originalValue with the merge entity'
+      );
+    });
+
+    it('should be able to use ignore changes strategy', () => {
+      const {
+        updatedHero,
+        serverUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+
+      const collection = tracker.mergeQueryResults(
+        [serverUpdatedHero],
+        initialCache.Hero,
+        MergeStrategy.IgnoreChanges // manually provide strategy
+      );
+
+      expect(collection.entities[updatedHero.id]).toEqual(
+        serverUpdatedHero,
+        'Update the collection entity'
+      );
+      expect(collection.changeState[updatedHero.id]!.originalValue).toEqual(
+        updatedHero,
+        'changeState is untouched'
+      );
+    });
+
+    it('should be able to use preserve changes strategy', () => {
+      const {
+        unchangedHero,
+        unchangedHeroServerUpdated,
+        updatedHero,
+        serverUpdatedHero,
+        locallyUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+
+      const collection = tracker.mergeQueryResults(
+        [unchangedHeroServerUpdated, serverUpdatedHero],
+        initialCache.Hero,
+        MergeStrategy.PreserveChanges // manually provide strategy
+      );
+
+      expect(collection.entities[unchangedHero.id]).toEqual(
+        unchangedHeroServerUpdated,
+        'Replace the current collection entity for unchanged entity'
+      );
+      expect(collection.entities[updatedHero.id]).toEqual(
+        locallyUpdatedHero,
+        'Preserves the current value for changed entity'
+      );
+      expect(collection.changeState[updatedHero.id]!.originalValue).toEqual(
+        serverUpdatedHero,
+        'Overwrites the originalValue with the merge entity'
+      );
+    });
+
+    it('should be able to use overwrite changes strategy', () => {
+      const {
+        unchangedHero,
+        unchangedHeroServerUpdated,
+        updatedHero,
+        serverUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+
+      const collection = tracker.mergeQueryResults(
+        [unchangedHeroServerUpdated, serverUpdatedHero],
+        initialCache.Hero,
+        MergeStrategy.OverwriteChanges // manually provide strategy
+      );
+
+      expect(collection.entities[unchangedHero.id]).toEqual(
+        unchangedHeroServerUpdated,
+        'Replace the current collection entity for unchanged entity'
+      );
+      expect(collection.changeState[unchangedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for unchanged entity'
+      );
+      expect(collection.entities[updatedHero.id]).toEqual(
+        serverUpdatedHero,
+        'Replace the current collection entity for changed entity'
+      );
+      expect(collection.changeState[updatedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for changed entity'
+      );
+    });
+  });
+
+  describe('#mergeSaveAdds', () => {
+    it('should use default overwrite changes strategy', () => {
+      let {
+        unchangedHero,
+        unchangedHeroServerUpdated,
+        updatedHero,
+        serverUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+      const collection = tracker.mergeSaveAdds(
+        [unchangedHeroServerUpdated, serverUpdatedHero],
+        initialCache.Hero
+      );
+
+      expect(collection.entities[unchangedHero.id]).toEqual(
+        unchangedHeroServerUpdated,
+        'Replace the current collection entity for unchanged entity'
+      );
+      expect(collection.changeState[unchangedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for unchanged entity'
+      );
+      expect(collection.entities[updatedHero.id]).toEqual(
+        serverUpdatedHero,
+        'Replace the current collection entity for changed entity'
+      );
+      expect(collection.changeState[updatedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for changed entity'
+      );
+    });
+
+    it('should be able to use ignore changes strategy', () => {
+      const {
+        updatedHero,
+        serverUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+
+      const collection = tracker.mergeSaveAdds(
+        [serverUpdatedHero],
+        initialCache.Hero,
+        MergeStrategy.IgnoreChanges // manually provide strategy
+      );
+
+      expect(collection.entities[updatedHero.id]).toEqual(
+        serverUpdatedHero,
+        'Update the collection entity'
+      );
+      expect(collection.changeState[updatedHero.id]!.originalValue).toEqual(
+        updatedHero,
+        'changeState is untouched'
+      );
+    });
+
+    it('should be able to use preserve changes strategy', () => {
+      const {
+        unchangedHero,
+        unchangedHeroServerUpdated,
+        updatedHero,
+        serverUpdatedHero,
+        locallyUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+
+      const collection = tracker.mergeSaveAdds(
+        [unchangedHeroServerUpdated, serverUpdatedHero],
+        initialCache.Hero,
+        MergeStrategy.PreserveChanges // manually provide strategy
+      );
+
+      expect(collection.entities[unchangedHero.id]).toEqual(
+        unchangedHeroServerUpdated,
+        'Replace the current collection entity for unchanged entity'
+      );
+      expect(collection.entities[updatedHero.id]).toEqual(
+        locallyUpdatedHero,
+        'Preserves the current value for changed entity'
+      );
+      expect(collection.changeState[updatedHero.id]!.originalValue).toEqual(
+        serverUpdatedHero,
+        'Overwrites the originalValue with the merge entity'
+      );
+    });
+
+    it('should be able to use overwrite changes strategy', () => {
+      const {
+        unchangedHero,
+        unchangedHeroServerUpdated,
+        updatedHero,
+        serverUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+
+      const collection = tracker.mergeSaveAdds(
+        [unchangedHeroServerUpdated, serverUpdatedHero],
+        initialCache.Hero,
+        MergeStrategy.OverwriteChanges // manually provide strategy
+      );
+
+      expect(collection.entities[unchangedHero.id]).toEqual(
+        unchangedHeroServerUpdated,
+        'Replace the current collection entity for unchanged entity'
+      );
+      expect(collection.changeState[unchangedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for unchanged entity'
+      );
+      expect(collection.entities[updatedHero.id]).toEqual(
+        serverUpdatedHero,
+        'Replace the current collection entity for changed entity'
+      );
+      expect(collection.changeState[updatedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for changed entity'
+      );
+    });
+  });
+
+  describe('#mergeSaveDeletes', () => {
+    // TODO: add some tests
+  });
+
+  describe('#mergeSaveUpdates', () => {
+    // TODO: add some tests
+  });
+
+  describe('#mergeSaveUpserts', () => {
+    it('should use default overwrite changes strategy', () => {
+      let {
+        unchangedHero,
+        unchangedHeroServerUpdated,
+        updatedHero,
+        serverUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+      const collection = tracker.mergeSaveUpserts(
+        [unchangedHeroServerUpdated, serverUpdatedHero],
+        initialCache.Hero
+      );
+
+      expect(collection.entities[unchangedHero.id]).toEqual(
+        unchangedHeroServerUpdated,
+        'Replace the current collection entity for unchanged entity'
+      );
+      expect(collection.changeState[unchangedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for unchanged entity'
+      );
+      expect(collection.entities[updatedHero.id]).toEqual(
+        serverUpdatedHero,
+        'Replace the current collection entity for changed entity'
+      );
+      expect(collection.changeState[updatedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for changed entity'
+      );
+    });
+
+    it('should be able to use ignore changes strategy', () => {
+      const {
+        updatedHero,
+        serverUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+
+      const collection = tracker.mergeSaveUpserts(
+        [serverUpdatedHero],
+        initialCache.Hero,
+        MergeStrategy.IgnoreChanges // manually provide strategy
+      );
+
+      expect(collection.entities[updatedHero.id]).toEqual(
+        serverUpdatedHero,
+        'Update the collection entity'
+      );
+      expect(collection.changeState[updatedHero.id]!.originalValue).toEqual(
+        updatedHero,
+        'changeState is untouched'
+      );
+    });
+
+    it('should be able to use preserve changes strategy', () => {
+      const {
+        unchangedHero,
+        unchangedHeroServerUpdated,
+        updatedHero,
+        serverUpdatedHero,
+        locallyUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+
+      const collection = tracker.mergeSaveUpserts(
+        [unchangedHeroServerUpdated, serverUpdatedHero],
+        initialCache.Hero,
+        MergeStrategy.PreserveChanges // manually provide strategy
+      );
+
+      expect(collection.entities[unchangedHero.id]).toEqual(
+        unchangedHeroServerUpdated,
+        'Replace the current collection entity for unchanged entity'
+      );
+      expect(collection.entities[updatedHero.id]).toEqual(
+        locallyUpdatedHero,
+        'Preserves the current value for changed entity'
+      );
+      expect(collection.changeState[updatedHero.id]!.originalValue).toEqual(
+        serverUpdatedHero,
+        'Overwrites the originalValue with the merge entity'
+      );
+    });
+
+    it('should be able to use overwrite changes strategy', () => {
+      const {
+        unchangedHero,
+        unchangedHeroServerUpdated,
+        updatedHero,
+        serverUpdatedHero,
+        initialCache,
+      } = createInitialCacheForMerges();
+
+      const collection = tracker.mergeSaveUpserts(
+        [unchangedHeroServerUpdated, serverUpdatedHero],
+        initialCache.Hero,
+        MergeStrategy.OverwriteChanges // manually provide strategy
+      );
+
+      expect(collection.entities[unchangedHero.id]).toEqual(
+        unchangedHeroServerUpdated,
+        'Replace the current collection entity for unchanged entity'
+      );
+      expect(collection.changeState[unchangedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for unchanged entity'
+      );
+      expect(collection.entities[updatedHero.id]).toEqual(
+        serverUpdatedHero,
+        'Replace the current collection entity for changed entity'
+      );
+      expect(collection.changeState[updatedHero.id]).toBeUndefined(
+        'Discards the changeState (changeType unchanged) for changed entity'
+      );
+    });
+  });
+
   describe('#trackAddOne', () => {
     it('should return a new collection with tracked new entity', () => {
       const addedEntity = { id: 42, name: 'Ted', power: 'Chatty' };
@@ -821,6 +1173,61 @@ describe('EntityChangeTrackerBase', () => {
       deletedEntity,
       preUpdatedEntity,
       updatedEntity,
+    };
+  }
+
+  function createInitialCacheForMerges() {
+    // general test data for testing mergeStrategy
+    const unchangedHero = { id: 1, name: 'Unchanged', power: 'Hammer' };
+    const unchangedHeroServerUpdated = {
+      id: 1,
+      name: 'UnchangedUpdated',
+      power: 'Bish',
+    };
+    const deletedHero = { id: 2, name: 'Deleted', power: 'Bash' };
+    const addedHero = { id: 3, name: 'Added', power: 'Tiny' };
+    const updatedHero = { id: 4, name: 'Pre Updated', power: 'Tech' };
+    const locallyUpdatedHero = {
+      id: 4,
+      name: 'Locally Updated',
+      power: 'Suit',
+    };
+    const serverUpdatedHero = { id: 4, name: 'Server Updated', power: 'Nano' };
+    const ids = [unchangedHero.id, addedHero.id, updatedHero.id];
+    const initialCache = {
+      Hero: {
+        ids,
+        entities: {
+          [unchangedHero.id]: unchangedHero,
+          [addedHero.id]: addedHero,
+          [updatedHero.id]: locallyUpdatedHero,
+        },
+        entityName: 'Hero',
+        filter: '',
+        loaded: true,
+        loading: false,
+        changeState: {
+          [deletedHero.id]: {
+            changeType: ChangeType.Deleted,
+            originalValue: deletedHero,
+          },
+          [updatedHero.id]: {
+            changeType: ChangeType.Updated,
+            originalValue: updatedHero,
+          },
+          [addedHero.id]: { changeType: ChangeType.Added },
+        },
+      },
+    };
+    return {
+      unchangedHero,
+      unchangedHeroServerUpdated,
+      deletedHero,
+      addedHero,
+      updatedHero,
+      locallyUpdatedHero,
+      serverUpdatedHero,
+      initialCache,
     };
   }
 

--- a/modules/data/src/reducers/entity-change-tracker-base.ts
+++ b/modules/data/src/reducers/entity-change-tracker-base.ts
@@ -337,10 +337,15 @@ export class EntityChangeTrackerBase<T> implements EntityChangeTracker<T> {
           const change = chgState[id];
           if (change) {
             if (!didMutate) {
-              chgState = { ...chgState };
+              chgState = {
+                ...chgState,
+                [id]: {
+                  ...chgState[id]!,
+                  originalValue: entity,
+                },
+              };
               didMutate = true;
             }
-            change.originalValue = entity;
           } else {
             upsertEntities.push(entity);
           }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Runtime error thrown if performing a QUERY action (with the default preserve changes strategy) after an UPSERT action due to mutably changing state.
```
can't define property "originalValue": Object is not extensible
```
Closes #2374

## What is the new behavior?

`mergeServerUpserts` which is used by QUERY actions changes state immutably without error.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I believe this also fixes #2307

A failing test that simulates runtime checks is the following (not included as this becomes immediately redundant):
```
  describe('#mergeQueryResults', () => {
    it('should change state immutably', () => {
      let {
        updatedHero,
        serverUpdatedHero,
        initialCache,
      } = createInitialCacheForMerges();

      const test = function() {
        'use strict';
        // freeze part of original state
        Object.freeze(initialCache.Hero.changeState[updatedHero.id]!);

        const collection = tracker.mergeQueryResults(
          [serverUpdatedHero],
          initialCache.Hero
        );

        // check state does not hold copy of original state -  will throw error if this is the case
        collection.changeState[updatedHero.id]!.originalValue = updatedHero;
      };
      expect(test).not.toThrow();
    });
```



