### PR TITLE
fix(entity): support primitive type entities

### DIFF
--- a/modules/entity/spec/fixtures/type.ts
+++ b/modules/entity/spec/fixtures/type.ts
@@ -1,0 +1,5 @@
+export type TypeModel = 'BOOK' | 'MOVIE' | 'SHOW';
+
+export const MovieType: TypeModel = 'MOVIE';
+export const BookType: TypeModel = 'BOOK';
+export const ShowType: TypeModel = 'SHOW';

--- a/modules/entity/spec/utils.spec.ts
+++ b/modules/entity/spec/utils.spec.ts
@@ -1,6 +1,6 @@
 import * as ngCore from '@angular/core';
 import { selectIdValue } from '../src/utils';
-import { BookModel, AClockworkOrange } from './fixtures/book';
+import { AClockworkOrange } from './fixtures/book';
 
 describe('Entity utils', () => {
   describe(`selectIdValue()`, () => {

--- a/modules/entity/src/sorted_state_adapter.ts
+++ b/modules/entity/src/sorted_state_adapter.ts
@@ -8,7 +8,7 @@ import {
 } from './models';
 import { createStateOperator, DidMutate } from './state_adapter';
 import { createUnsortedStateAdapter } from './unsorted_state_adapter';
-import { selectIdValue } from './utils';
+import { isObject, selectIdValue } from './utils';
 
 export function createSortedStateAdapter<T>(
   selectId: IdSelector<T>,
@@ -62,7 +62,9 @@ export function createSortedStateAdapter<T>(selectId: any, sort: any): any {
     }
 
     const original = state.entities[update.id];
-    const updated = Object.assign({}, original, update.changes);
+    const updated = isObject(update.changes)
+      ? Object.assign({}, original, update.changes)
+      : update.changes;
     const newKey = selectIdValue(updated, selectId);
 
     delete state.entities[update.id];

--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -7,7 +7,7 @@ import {
   EntityMap,
 } from './models';
 import { createStateOperator, DidMutate } from './state_adapter';
-import { selectIdValue } from './utils';
+import { isObject, selectIdValue } from './utils';
 
 export function createUnsortedStateAdapter<T>(
   selectId: IdSelector<T>
@@ -97,7 +97,9 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
     state: any
   ): boolean {
     const original = state.entities[update.id];
-    const updated: T = Object.assign({}, original, update.changes);
+    const updated: T = isObject(update.changes)
+      ? Object.assign({}, original, update.changes)
+      : update.changes;
     const newKey = selectIdValue(updated, selectId);
     const hasNewKey = newKey !== update.id;
 

--- a/modules/entity/src/utils.ts
+++ b/modules/entity/src/utils.ts
@@ -17,3 +17,11 @@ export function selectIdValue<T>(entity: T, selectId: IdSelector<T>) {
 
   return key;
 }
+
+export function isObjectLike(target: any): target is object {
+  return typeof target === 'object' && target !== null;
+}
+
+export function isObject(target: any): target is object {
+  return isObjectLike(target) && !Array.isArray(target);
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
It is not currently possible to update a list of string values.
Object.assign({}, ...) transforms a string value (ex: Book) into an array['B', 'o', 'o', 'k'] on update

My use case: backend has multiple string enums that might change between deployments or context. I really didn't want to hack the response to transform those strings into objects with ids.

## What is the new behavior?
check if the update value is a string, and return value as is.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
