### PR TITLE
docs(marketing): Fix duplicated link

### DIFF
--- a/projects/ngrx.io/content/marketing/resources.json
+++ b/projects/ngrx.io/content/marketing/resources.json
@@ -35,7 +35,7 @@
             "desc":
               "Mike Ryan talk about the benefits and complexity of NgRx, and introducing the SHARI principle",
             "url":
-              "https://www.youtube.com/playlist?list=PL8OUS498tQP3FFsZzULTGnbyIcILFjHd3",
+              "https://www.youtube.com/watch?v=omnwu_etHTY",
             "rev": true
           },
           "international-javascript-conference-london-2019": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The link for "You might not need NgRx by Mike Ryan at AngularConnect 2018" is a duplicate of the link to the "NgRx at ng-conf 2018" playlist.

## What is the new behavior?

Fix link to point at the correct video

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
