### PR TITLE
docs(data): add @Injectable to PluralHttpUrlGenerator

### DIFF
--- a/projects/ngrx.io/content/guide/data/extension-points.md
+++ b/projects/ngrx.io/content/guide/data/extension-points.md
@@ -172,6 +172,7 @@ This example replaces the `DefaultHttpUrlGenerator` with a customized `HttpUrlGe
 The implementation simply overrides `DefaultHttpUrlGenerator.getResourceUrls(string, string)`:
 
 ```ts
+import { Injectable } from '@angular/core';
 import {
   DefaultHttpUrlGenerator,
   HttpResourceUrls,
@@ -179,6 +180,7 @@ import {
   Pluralizer
 } from '@ngrx/data';
 
+@Injectable()
 export class PluralHttpUrlGenerator extends DefaultHttpUrlGenerator {
   constructor(private pluralizzer: Pluralizer) {
     super(pluralizzer);


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I used the code referenced in the docs which resulted in:
```
ERROR in projects/ngrx-playground/src/app/app.module.ts:68:48 - error NG2005: The class 'PluralHttpUrlGenerator' cannot be created via dependency injection, as it does not have an Angular decorator. This will result in an error at runtime.
    
    Either add the @Injectable() decorator to 'PluralHttpUrlGenerator', or configure a different provider (such as a provider with 'useFactory').
    
    
    68         { provide: HttpUrlGenerator, useClass: PluralHttpUrlGenerator },
                                                      ~~~~~~~~~~~~~~~~~~~~~~
    
      projects/ngrx-playground/src/app/core/plural-http-url-generator.ts:8:1
          8 export class PluralHttpUrlGenerator extends DefaultHttpUrlGenerator {
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          9     constructor(private pluralizzer: Pluralizer) {
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        ... 
         30     }
            ~~~~~
         31 }
            ~
        'PluralHttpUrlGenerator' is declared here.
```

## What is the new behavior?
Compilation suceeds.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

