### PR TITLE
fix(example): fix an example-app's typo in app reducers - showSidenav selector

### DIFF
--- a/projects/example-app/src/app/core/containers/app.component.ts
+++ b/projects/example-app/src/app/core/containers/app.component.ts
@@ -43,7 +43,7 @@ export class AppComponent {
      * Selectors can be applied with the `select` operator which passes the state
      * tree to the provided selector
      */
-    this.showSidenav$ = this.store.pipe(select(fromRoot.selecthowSidenav));
+    this.showSidenav$ = this.store.pipe(select(fromRoot.selectShowSidenav));
     this.loggedIn$ = this.store.pipe(select(fromAuth.selectLoggedIn));
   }
 

--- a/projects/example-app/src/app/reducers/index.ts
+++ b/projects/example-app/src/app/reducers/index.ts
@@ -72,7 +72,7 @@ export const selectLayoutState = createFeatureSelector<State, fromLayout.State>(
   fromLayout.layoutFeatureKey
 );
 
-export const selecthowSidenav = createSelector(
+export const selectShowSidenav = createSelector(
   selectLayoutState,
   fromLayout.selectShowSidenav
 );


### PR DESCRIPTION
Fix an example-app's typo by replacing selecthowSidenav by selectShowSidenav

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

It fixes a typo.

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: typo for an example-app's selector
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```