### PR TITLE
feat: add disable forRoot() guard check

### DIFF
--- a/modules/effects/spec/integration.spec.ts
+++ b/modules/effects/spec/integration.spec.ts
@@ -14,7 +14,13 @@ import {
   EffectSources,
   Actions,
 } from '..';
-import { ofType, createEffect, OnRunEffects, EffectNotification } from '../src';
+import {
+  ofType,
+  createEffect,
+  OnRunEffects,
+  EffectNotification,
+  DISABLE_ROOT_EFFECTS_GUARD,
+} from '../src';
 import { mapTo, exhaustMap, tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
@@ -40,6 +46,34 @@ describe('NgRx Effects Integration spec', () => {
       expect(err.message).toBe(
         'EffectsModule.forRoot() called twice. Feature modules should use EffectsModule.forFeature() instead.'
       );
+      done();
+    });
+  });
+
+  it('disables the forRoot() guard by providing the DISABLE_ROOT_EFFECTS_GUARD token', (done: any) => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({}),
+        EffectsModule.forRoot([]),
+        RouterTestingModule.withRoutes([]),
+      ],
+      providers: [
+        {
+          provide: DISABLE_ROOT_EFFECTS_GUARD,
+          useValue: true,
+        },
+      ],
+    });
+
+    let router: Router = TestBed.inject(Router);
+    const loader: SpyNgModuleFactoryLoader = TestBed.inject(
+      NgModuleFactoryLoader
+    ) as SpyNgModuleFactoryLoader;
+
+    loader.stubbedModules = { feature: FeatModuleWithForRoot };
+    router.resetConfig([{ path: 'feature-path', loadChildren: 'feature' }]);
+
+    router.navigateByUrl('/feature-path').then(() => {
       done();
     });
   });

--- a/modules/effects/src/effects_module.ts
+++ b/modules/effects/src/effects_module.ts
@@ -16,6 +16,7 @@ import {
   EFFECTS_ERROR_HANDLER,
   FEATURE_EFFECTS,
   ROOT_EFFECTS,
+  DISABLE_ROOT_EFFECTS_GUARD,
 } from './tokens';
 
 @NgModule({})
@@ -46,7 +47,10 @@ export class EffectsModule {
         {
           provide: _ROOT_EFFECTS_GUARD,
           useFactory: _provideForRootGuard,
-          deps: [[EffectsRunner, new Optional(), new SkipSelf()]],
+          deps: [
+            [EffectsRunner, new Optional(), new SkipSelf()],
+            [DISABLE_ROOT_EFFECTS_GUARD, new Optional(), SkipSelf()],
+          ],
         },
         {
           provide: EFFECTS_ERROR_HANDLER,
@@ -70,8 +74,11 @@ export function createSourceInstances(...instances: any[]) {
   return instances;
 }
 
-export function _provideForRootGuard(runner: EffectsRunner): any {
-  if (runner) {
+export function _provideForRootGuard(
+  runner: EffectsRunner,
+  disableRootGuardCheck: boolean | null
+): any {
+  if (runner && disableRootGuardCheck !== true) {
     throw new TypeError(
       `EffectsModule.forRoot() called twice. Feature modules should use EffectsModule.forFeature() instead.`
     );

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -13,12 +13,13 @@ export { EffectsModule } from './effects_module';
 export { EffectSources } from './effect_sources';
 export { EffectNotification } from './effect_notification';
 export { EffectsFeatureModule } from './effects_feature_module';
+
 export {
   ROOT_EFFECTS_INIT,
   rootEffectsInit,
   EffectsRootModule,
 } from './effects_root_module';
-export { EFFECTS_ERROR_HANDLER } from './tokens';
+export { DISABLE_ROOT_EFFECTS_GUARD, EFFECTS_ERROR_HANDLER } from './tokens';
 export { act } from './act';
 export {
   OnIdentifyEffects,

--- a/modules/effects/src/tokens.ts
+++ b/modules/effects/src/tokens.ts
@@ -1,6 +1,9 @@
 import { InjectionToken, Type } from '@angular/core';
 import { EffectsErrorHandler } from './effects_error_handler';
 
+export const DISABLE_ROOT_EFFECTS_GUARD = new InjectionToken<boolean>(
+  '@ngrx/effects Disable Internal Root Guard'
+);
 export const _ROOT_EFFECTS_GUARD = new InjectionToken<void>(
   '@ngrx/effects Internal Root Guard'
 );

--- a/modules/store/spec/integration.spec.ts
+++ b/modules/store/spec/integration.spec.ts
@@ -28,6 +28,7 @@ import {
 } from '@angular/router/testing';
 import { NgModuleFactoryLoader, NgModule } from '@angular/core';
 import { Router } from '@angular/router';
+import { DISABLE_ROOT_STORE_GUARD } from '../src';
 
 interface Todo {
   id: number;
@@ -501,6 +502,35 @@ describe('ngRx Integration spec', () => {
         expect(err.message).toBe(
           'StoreModule.forRoot() called twice. Feature modules should use StoreModule.forFeature() instead.'
         );
+        done();
+      });
+    });
+
+    it('disables the forRoot() guard by providing the DISABLE_ROOT_STORE_GUARD token', (done: any) => {
+      @NgModule({
+        imports: [StoreModule.forRoot({})],
+      })
+      class FeatureModule {}
+
+      TestBed.configureTestingModule({
+        imports: [StoreModule.forRoot({}), RouterTestingModule.withRoutes([])],
+        providers: [
+          {
+            provide: DISABLE_ROOT_STORE_GUARD,
+            useValue: true,
+          },
+        ],
+      });
+
+      let router: Router = TestBed.get(Router);
+      const loader: SpyNgModuleFactoryLoader = TestBed.get(
+        NgModuleFactoryLoader
+      );
+
+      loader.stubbedModules = { feature: FeatureModule };
+      router.resetConfig([{ path: 'feature-path', loadChildren: 'feature' }]);
+
+      router.navigateByUrl('/feature-path').then(() => {
         done();
       });
     });

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -45,6 +45,7 @@ export {
   FEATURE_REDUCERS,
   USER_PROVIDED_META_REDUCERS,
   USER_RUNTIME_CHECKS,
+  DISABLE_ROOT_STORE_GUARD,
 } from './tokens';
 export {
   StoreModule,

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -37,6 +37,7 @@ import {
   USER_PROVIDED_META_REDUCERS,
   _RESOLVED_META_REDUCERS,
   _ROOT_STORE_GUARD,
+  DISABLE_ROOT_STORE_GUARD,
 } from './tokens';
 import { ACTIONS_SUBJECT_PROVIDERS, ActionsSubject } from './actions_subject';
 import {
@@ -121,7 +122,10 @@ export class StoreModule {
         {
           provide: _ROOT_STORE_GUARD,
           useFactory: _provideForRootGuard,
-          deps: [[Store, new Optional(), new SkipSelf()]],
+          deps: [
+            [Store, new Optional(), new SkipSelf()],
+            [DISABLE_ROOT_STORE_GUARD, new Optional(), new SkipSelf()],
+          ],
         },
         { provide: _INITIAL_STATE, useValue: config.initialState },
         {
@@ -297,8 +301,11 @@ export function _concatMetaReducers(
   return metaReducers.concat(userProvidedMetaReducers);
 }
 
-export function _provideForRootGuard(store: Store<any>): any {
-  if (store) {
+export function _provideForRootGuard(
+  store: Store<any>,
+  disableRootGuardCheck: boolean | null
+): any {
+  if (store && disableRootGuardCheck !== true) {
     throw new TypeError(
       `StoreModule.forRoot() called twice. Feature modules should use StoreModule.forFeature() instead.`
     );

--- a/modules/store/src/tokens.ts
+++ b/modules/store/src/tokens.ts
@@ -1,6 +1,9 @@
 import { InjectionToken } from '@angular/core';
 import { RuntimeChecks, MetaReducer } from './models';
 
+export const DISABLE_ROOT_STORE_GUARD = new InjectionToken<boolean>(
+  '@ngrx/store Disable Internal Root Guard'
+);
 export const _ROOT_STORE_GUARD = new InjectionToken<void>(
   '@ngrx/store Internal Root Guard'
 );


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

I don't know if we want to add documentation around this because this is a feature that should be used _very_ sparingly.

## PR Type

What kind of change does this PR introduce?

In some complex applications, it may be necessary to provide a way to disable the forRoot() guard check. This is very rare, but in some instances, it's required when dealing with applications that are sandboxed and built in a parent application without using Angular Elements. By injecting the `DISABLE_ROOT_EFFECTS_GUARD` or `DISABLE_ROOT_STORE_GUARD` in a parent injector, this will allow the guard to be bypassed for advanced use cases.

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

A developer is unable to bypass the forRoot() guard since #2108 was added which leads the application to be not stuck on an old version of ngrx anymore and unable to upgrade for Angular 9.

This will also unblock this comment as well: https://github.com/ngrx/platform/commit/b46748c292813577d5d542702f2ecc26b8307ac7#r37029451

## What is the new behavior?
This new behavior provides the ability to disable the forRoot() guard for complex scenarios.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
