### PR TITLE
fix(data): mergeQuerySet uses mergeStrategy

### DIFF
--- a/modules/data/spec/reducers/entity-cache-reducer.spec.ts
+++ b/modules/data/spec/reducers/entity-cache-reducer.spec.ts
@@ -28,6 +28,8 @@ import {
   ChangeSet,
   ChangeSetOperation,
   Logger,
+  MergeStrategy,
+  ChangeType,
 } from '../..';
 
 class Hero {
@@ -302,6 +304,121 @@ describe('EntityCacheReducer', () => {
           { id: 42, name: 'Bobby' },
           'merged hero'
         );
+      });
+
+      it('should use default preserve changes merge strategy', () => {
+        const {
+          unchangedHero,
+          unchangedHeroServerUpdated,
+          updatedHero,
+          locallyUpdatedHero,
+          serverUpdatedHero,
+          initialCache,
+        } = createInitialCacheForMerges();
+        const querySet: EntityCacheQuerySet = {
+          Hero: [unchangedHeroServerUpdated, serverUpdatedHero],
+        };
+        const action = new MergeQuerySet(querySet);
+
+        const state = entityCacheReducer(initialCache, action);
+        expect(state['Hero'].entities[unchangedHero.id]).toEqual(
+          unchangedHeroServerUpdated,
+          'Updates current value for unchanged entity'
+        );
+        expect(state['Hero'].entities[updatedHero.id]).toEqual(
+          locallyUpdatedHero,
+          'Preserves the current value for changed entity'
+        );
+        expect(
+          state['Hero'].changeState[updatedHero.id]!.originalValue
+        ).toEqual(
+          serverUpdatedHero,
+          'Overwrites the originalValue with the merge entity'
+        );
+      });
+
+      it('should be able to use ignore changes merge strategy', () => {
+        const {
+          updatedHero,
+          serverUpdatedHero,
+          initialCache,
+        } = createInitialCacheForMerges();
+        const querySet: EntityCacheQuerySet = {
+          Hero: [serverUpdatedHero],
+        };
+        const action = new MergeQuerySet(querySet, MergeStrategy.IgnoreChanges);
+
+        const state = entityCacheReducer(initialCache, action);
+        expect(state['Hero'].entities[updatedHero.id]).toEqual(
+          serverUpdatedHero,
+          'Update the collection entity'
+        );
+        expect(
+          state['Hero'].changeState[updatedHero.id]!.originalValue
+        ).toEqual(updatedHero, 'changeState is untouched');
+      });
+
+      it('should be able to use preserve changes merge strategy', () => {
+        const {
+          unchangedHero,
+          unchangedHeroServerUpdated,
+          updatedHero,
+          locallyUpdatedHero,
+          serverUpdatedHero,
+          initialCache,
+        } = createInitialCacheForMerges();
+        const querySet: EntityCacheQuerySet = {
+          Hero: [unchangedHeroServerUpdated, serverUpdatedHero],
+        };
+        const action = new MergeQuerySet(
+          querySet,
+          MergeStrategy.PreserveChanges
+        );
+
+        const state = entityCacheReducer(initialCache, action);
+        expect(state['Hero'].entities[unchangedHero.id]).toEqual(
+          unchangedHeroServerUpdated,
+          'Updates current value for unchanged entity'
+        );
+        expect(state['Hero'].entities[updatedHero.id]).toEqual(
+          locallyUpdatedHero,
+          'Preserves the current value for changed entity'
+        );
+        expect(
+          state['Hero'].changeState[updatedHero.id]!.originalValue
+        ).toEqual(
+          serverUpdatedHero,
+          'Overwrites the originalValue with the merge entity'
+        );
+      });
+
+      it('should be able to use overwrite changes merge strategy', () => {
+        const {
+          unchangedHero,
+          unchangedHeroServerUpdated,
+          updatedHero,
+          serverUpdatedHero,
+          initialCache,
+        } = createInitialCacheForMerges();
+        const querySet: EntityCacheQuerySet = {
+          Hero: [unchangedHeroServerUpdated, serverUpdatedHero],
+        };
+        const action = new MergeQuerySet(
+          querySet,
+          MergeStrategy.OverwriteChanges
+        );
+
+        const state = entityCacheReducer(initialCache, action);
+        expect(state['Hero'].entities[unchangedHero.id]).toEqual(
+          unchangedHeroServerUpdated,
+          'Replace the current collection entity for unchanged entity'
+        );
+        expect(state['Hero'].changeState[unchangedHero.id]).toBeUndefined();
+        expect(state['Hero'].entities[updatedHero.id]).toEqual(
+          serverUpdatedHero,
+          'Replace the current collection entity for changed entity'
+        );
+        expect(state['Hero'].changeState[updatedHero.id]).toBeUndefined();
       });
     });
 
@@ -616,6 +733,61 @@ describe('EntityCacheReducer', () => {
     }
 
     return cache;
+  }
+
+  function createInitialCacheForMerges() {
+    // general test data for testing mergeStrategy
+    const unchangedHero = { id: 1, name: 'Unchanged', power: 'Hammer' };
+    const unchangedHeroServerUpdated = {
+      id: 1,
+      name: 'UnchangedUpdated',
+      power: 'Bish',
+    };
+    const deletedHero = { id: 2, name: 'Deleted', power: 'Bash' };
+    const addedHero = { id: 3, name: 'Added', power: 'Tiny' };
+    const updatedHero = { id: 4, name: 'Pre Updated', power: 'Tech' };
+    const locallyUpdatedHero = {
+      id: 4,
+      name: 'Locally Updated',
+      power: 'Suit',
+    };
+    const serverUpdatedHero = { id: 4, name: 'Server Updated', power: 'Nano' };
+    const ids = [unchangedHero.id, addedHero.id, updatedHero.id];
+    const initialCache = {
+      Hero: {
+        ids,
+        entities: {
+          [unchangedHero.id]: unchangedHero,
+          [addedHero.id]: addedHero,
+          [updatedHero.id]: locallyUpdatedHero,
+        },
+        entityName: 'Hero',
+        filter: '',
+        loaded: true,
+        loading: false,
+        changeState: {
+          [deletedHero.id]: {
+            changeType: ChangeType.Deleted,
+            originalValue: deletedHero,
+          },
+          [updatedHero.id]: {
+            changeType: ChangeType.Updated,
+            originalValue: updatedHero,
+          },
+          [addedHero.id]: { changeType: ChangeType.Added },
+        },
+      },
+    };
+    return {
+      unchangedHero,
+      unchangedHeroServerUpdated,
+      deletedHero,
+      addedHero,
+      updatedHero,
+      locallyUpdatedHero,
+      serverUpdatedHero,
+      initialCache,
+    };
   }
 
   function createInitialSaveTestEntities() {

--- a/modules/data/src/reducers/entity-cache-reducer.ts
+++ b/modules/data/src/reducers/entity-cache-reducer.ts
@@ -188,7 +188,7 @@ export class EntityCacheReducerFactory {
     let { mergeStrategy, querySet, tag } = action.payload;
     mergeStrategy =
       mergeStrategy === null ? MergeStrategy.PreserveChanges : mergeStrategy;
-    const entityOp = EntityOp.UPSERT_MANY;
+    const entityOp = EntityOp.QUERY_MANY_SUCCESS;
 
     const entityNames = Object.keys(querySet);
     entityCache = entityNames.reduce((newCache, entityName) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`mergeQuerySet` accessible via `EntityCacheDispatcher` does not implement the `mergeStrategy` parameter which governs how queried data and changes tracked via `changeState` merge.

API - https://ngrx.io/api/data/EntityCacheDispatcher
`mergeQuerySet(querySet: EntityCacheQuerySet, mergeStrategy?: MergeStrategy, tag?: string)`

Closes #2368

## What is the new behavior?

Passing various merge strategies IgnoreChanges, PreserveChanges, OverwriteChanges to mergeQuerySet will implement the documented behaviour (referenced below). 
```
    this.entityCacheDispatcher.mergeQuerySet(
      querySet,
      MergeStrategy.PreserveChanges
    );
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

# References 

References to EntityCacheDispatcher
https://ngrx.io/guide/data/save-entities#saving-multiple-entities
> Multiple entity saves are a first class feature. By "first class" we mean that NgRx Data offers a built-in, multiple entity save solution that is consistent with NgRx Data itself:
> -  defines a ChangeSet, describing ChangeOperations to be performed on multiple entities of multiple types.
> -  has a set of SAVE_ENTITIES... cache-level actions.
> -  **has an EntityCacheDispatcher to dispatch those actions**.

Reference to Merge Strategy
https://ngrx.io/guide/data/entity-change-tracker#merge-strategies
> You can determine how NgRx Data will merge entities after a query, a save, or a cache operation by setting the entity action's optional mergeStrategy property to one of the three strategy enums:
> 1.  **IgnoreChanges** - Update the collection entities and ignore all change tracking for this operation. Each entity's changeState is untouched.
> 2. **PreserveChanges** - Updates current values for unchanged entities. For each changed entity it preserves the current value and overwrites the originalValue with the merge entity. This is the query-success default.
> 3. **OverwriteChanges** - Replace the current collection entities. For each merged entity it discards the changeState and sets the changeType to "unchanged". This is the save-success default.