### PR TITLE
feat(components): add ngrxPush migration

### DIFF
--- a/modules/data/schematics-core/index.ts
+++ b/modules/data/schematics-core/index.ts
@@ -81,4 +81,11 @@ export { addPackageToPackageJson } from './utility/package';
 
 export { platformVersion } from './utility/libs-version';
 
-export { visitTSSourceFiles, visitNgModuleImports } from './utility/visitors';
+export {
+  visitTSSourceFiles,
+  visitNgModuleImports,
+  visitComponents,
+  visitDecorator,
+  visitNgModules,
+  visitTemplates,
+} from './utility/visitors';

--- a/modules/data/schematics-core/index.ts
+++ b/modules/data/schematics-core/index.ts
@@ -84,6 +84,7 @@ export { platformVersion } from './utility/libs-version';
 export {
   visitTSSourceFiles,
   visitNgModuleImports,
+  visitNgModuleExports,
   visitComponents,
   visitDecorator,
   visitNgModules,

--- a/modules/data/schematics-core/utility/visitors.ts
+++ b/modules/data/schematics-core/utility/visitors.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { normalize, resolve } from '@angular-devkit/core';
 import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
@@ -15,6 +16,170 @@ export function visitTSSourceFiles<Result = void>(
   }
 
   return result;
+}
+
+export function visitTemplates(
+  tree: Tree,
+  visitor: (
+    template: {
+      fileName: string;
+      content: string;
+      inline: boolean;
+      start: number;
+    },
+    tree: Tree
+  ) => void
+): void {
+  visitTSSourceFiles(tree, source => {
+    visitComponents(source, (_, decoratorExpressionNode) => {
+      ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+        if (ts.isPropertyAssignment(n) && ts.isIdentifier(n.name)) {
+          if (
+            n.name.text === 'template' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            // Need to add an offset of one to the start because the template quotes are
+            // not part of the template content.
+            const templateStartIdx = n.initializer.getStart() + 1;
+            visitor(
+              {
+                fileName: source.fileName,
+                content: n.initializer.text,
+                inline: true,
+                start: templateStartIdx,
+              },
+              tree
+            );
+            return;
+          } else if (
+            n.name.text === 'templateUrl' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            const parts = normalize(source.fileName)
+              .split('/')
+              .slice(0, -1);
+            const templatePath = resolve(
+              normalize(parts.join('/')),
+              normalize(n.initializer.text)
+            );
+            if (!tree.exists(templatePath)) {
+              return;
+            }
+
+            const fileContent = tree.read(templatePath);
+            if (!fileContent) {
+              return;
+            }
+
+            visitor(
+              {
+                fileName: templatePath,
+                content: fileContent.toString(),
+                inline: false,
+                start: 0,
+              },
+              tree
+            );
+            return;
+          }
+        }
+
+        ts.forEachChild(n, findTemplates);
+      });
+    });
+  });
+}
+
+export function visitNgModuleImports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    importNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
+    ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+      if (
+        ts.isPropertyAssignment(n) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === 'imports' &&
+        ts.isArrayLiteralExpression(n.initializer)
+      ) {
+        callback(n, n.initializer.elements);
+        return;
+      }
+
+      ts.forEachChild(n, findTemplates);
+    });
+  });
+}
+
+export function visitComponents(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'Component', callback);
+}
+
+export function visitNgModules(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'NgModule', callback);
+}
+
+export function visitDecorator(
+  sourceFile: ts.SourceFile,
+  decoratorName: string,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  ts.forEachChild(sourceFile, function findClassDeclaration(node) {
+    if (!ts.isClassDeclaration(node)) {
+      ts.forEachChild(node, findClassDeclaration);
+    }
+
+    const classDeclarationNode = node as ts.ClassDeclaration;
+
+    if (
+      !classDeclarationNode.decorators ||
+      !classDeclarationNode.decorators.length
+    ) {
+      return;
+    }
+
+    const componentDecorator = classDeclarationNode.decorators.find(d => {
+      return (
+        ts.isCallExpression(d.expression) &&
+        ts.isIdentifier(d.expression.expression) &&
+        d.expression.expression.text === decoratorName
+      );
+    });
+
+    if (!componentDecorator) {
+      return;
+    }
+
+    const { expression } = componentDecorator;
+    if (!ts.isCallExpression(expression)) {
+      return;
+    }
+
+    const [arg] = expression.arguments;
+    if (!ts.isObjectLiteralExpression(arg)) {
+      return;
+    }
+
+    callback(classDeclarationNode, arg);
+  });
 }
 
 function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
@@ -41,32 +206,4 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
 
     yield* visit(directory.dir(path));
   }
-}
-
-export function visitNgModuleImports(
-  sourceFile: ts.SourceFile,
-  callback: (
-    importNode: ts.PropertyAssignment,
-    elementExpressions: ts.NodeArray<ts.Expression>
-  ) => void
-) {
-  ts.forEachChild(sourceFile, function findDecorator(node) {
-    if (!ts.isDecorator(node)) {
-      ts.forEachChild(node, findDecorator);
-      return;
-    }
-
-    ts.forEachChild(node, function findImportsNode(n) {
-      if (
-        ts.isPropertyAssignment(n) &&
-        ts.isArrayLiteralExpression(n.initializer) &&
-        ts.isIdentifier(n.name) &&
-        n.name.text === 'imports'
-      ) {
-        callback(n, n.initializer.elements);
-      }
-
-      ts.forEachChild(n, findImportsNode);
-    });
-  });
 }

--- a/modules/data/schematics-core/utility/visitors.ts
+++ b/modules/data/schematics-core/utility/visitors.ts
@@ -97,12 +97,33 @@ export function visitNgModuleImports(
     elementExpressions: ts.NodeArray<ts.Expression>
   ) => void
 ) {
+  visitNgModuleProperty(sourceFile, callback, 'imports');
+}
+
+export function visitNgModuleExports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    exportNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModuleProperty(sourceFile, callback, 'exports');
+}
+
+function visitNgModuleProperty(
+  sourceFile: ts.SourceFile,
+  callback: (
+    nodes: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void,
+  property: string
+) {
   visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
     ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
       if (
         ts.isPropertyAssignment(n) &&
         ts.isIdentifier(n.name) &&
-        n.name.text === 'imports' &&
+        n.name.text === property &&
         ts.isArrayLiteralExpression(n.initializer)
       ) {
         callback(n, n.initializer.elements);
@@ -113,7 +134,6 @@ export function visitNgModuleImports(
     });
   });
 }
-
 export function visitComponents(
   sourceFile: ts.SourceFile,
   callback: (

--- a/modules/effects/schematics-core/index.ts
+++ b/modules/effects/schematics-core/index.ts
@@ -81,4 +81,11 @@ export { addPackageToPackageJson } from './utility/package';
 
 export { platformVersion } from './utility/libs-version';
 
-export { visitTSSourceFiles, visitNgModuleImports } from './utility/visitors';
+export {
+  visitTSSourceFiles,
+  visitNgModuleImports,
+  visitComponents,
+  visitDecorator,
+  visitNgModules,
+  visitTemplates,
+} from './utility/visitors';

--- a/modules/effects/schematics-core/index.ts
+++ b/modules/effects/schematics-core/index.ts
@@ -84,6 +84,7 @@ export { platformVersion } from './utility/libs-version';
 export {
   visitTSSourceFiles,
   visitNgModuleImports,
+  visitNgModuleExports,
   visitComponents,
   visitDecorator,
   visitNgModules,

--- a/modules/effects/schematics-core/utility/visitors.ts
+++ b/modules/effects/schematics-core/utility/visitors.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { normalize, resolve } from '@angular-devkit/core';
 import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
@@ -15,6 +16,170 @@ export function visitTSSourceFiles<Result = void>(
   }
 
   return result;
+}
+
+export function visitTemplates(
+  tree: Tree,
+  visitor: (
+    template: {
+      fileName: string;
+      content: string;
+      inline: boolean;
+      start: number;
+    },
+    tree: Tree
+  ) => void
+): void {
+  visitTSSourceFiles(tree, source => {
+    visitComponents(source, (_, decoratorExpressionNode) => {
+      ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+        if (ts.isPropertyAssignment(n) && ts.isIdentifier(n.name)) {
+          if (
+            n.name.text === 'template' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            // Need to add an offset of one to the start because the template quotes are
+            // not part of the template content.
+            const templateStartIdx = n.initializer.getStart() + 1;
+            visitor(
+              {
+                fileName: source.fileName,
+                content: n.initializer.text,
+                inline: true,
+                start: templateStartIdx,
+              },
+              tree
+            );
+            return;
+          } else if (
+            n.name.text === 'templateUrl' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            const parts = normalize(source.fileName)
+              .split('/')
+              .slice(0, -1);
+            const templatePath = resolve(
+              normalize(parts.join('/')),
+              normalize(n.initializer.text)
+            );
+            if (!tree.exists(templatePath)) {
+              return;
+            }
+
+            const fileContent = tree.read(templatePath);
+            if (!fileContent) {
+              return;
+            }
+
+            visitor(
+              {
+                fileName: templatePath,
+                content: fileContent.toString(),
+                inline: false,
+                start: 0,
+              },
+              tree
+            );
+            return;
+          }
+        }
+
+        ts.forEachChild(n, findTemplates);
+      });
+    });
+  });
+}
+
+export function visitNgModuleImports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    importNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
+    ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+      if (
+        ts.isPropertyAssignment(n) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === 'imports' &&
+        ts.isArrayLiteralExpression(n.initializer)
+      ) {
+        callback(n, n.initializer.elements);
+        return;
+      }
+
+      ts.forEachChild(n, findTemplates);
+    });
+  });
+}
+
+export function visitComponents(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'Component', callback);
+}
+
+export function visitNgModules(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'NgModule', callback);
+}
+
+export function visitDecorator(
+  sourceFile: ts.SourceFile,
+  decoratorName: string,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  ts.forEachChild(sourceFile, function findClassDeclaration(node) {
+    if (!ts.isClassDeclaration(node)) {
+      ts.forEachChild(node, findClassDeclaration);
+    }
+
+    const classDeclarationNode = node as ts.ClassDeclaration;
+
+    if (
+      !classDeclarationNode.decorators ||
+      !classDeclarationNode.decorators.length
+    ) {
+      return;
+    }
+
+    const componentDecorator = classDeclarationNode.decorators.find(d => {
+      return (
+        ts.isCallExpression(d.expression) &&
+        ts.isIdentifier(d.expression.expression) &&
+        d.expression.expression.text === decoratorName
+      );
+    });
+
+    if (!componentDecorator) {
+      return;
+    }
+
+    const { expression } = componentDecorator;
+    if (!ts.isCallExpression(expression)) {
+      return;
+    }
+
+    const [arg] = expression.arguments;
+    if (!ts.isObjectLiteralExpression(arg)) {
+      return;
+    }
+
+    callback(classDeclarationNode, arg);
+  });
 }
 
 function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
@@ -41,32 +206,4 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
 
     yield* visit(directory.dir(path));
   }
-}
-
-export function visitNgModuleImports(
-  sourceFile: ts.SourceFile,
-  callback: (
-    importNode: ts.PropertyAssignment,
-    elementExpressions: ts.NodeArray<ts.Expression>
-  ) => void
-) {
-  ts.forEachChild(sourceFile, function findDecorator(node) {
-    if (!ts.isDecorator(node)) {
-      ts.forEachChild(node, findDecorator);
-      return;
-    }
-
-    ts.forEachChild(node, function findImportsNode(n) {
-      if (
-        ts.isPropertyAssignment(n) &&
-        ts.isArrayLiteralExpression(n.initializer) &&
-        ts.isIdentifier(n.name) &&
-        n.name.text === 'imports'
-      ) {
-        callback(n, n.initializer.elements);
-      }
-
-      ts.forEachChild(n, findImportsNode);
-    });
-  });
 }

--- a/modules/effects/schematics-core/utility/visitors.ts
+++ b/modules/effects/schematics-core/utility/visitors.ts
@@ -97,12 +97,33 @@ export function visitNgModuleImports(
     elementExpressions: ts.NodeArray<ts.Expression>
   ) => void
 ) {
+  visitNgModuleProperty(sourceFile, callback, 'imports');
+}
+
+export function visitNgModuleExports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    exportNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModuleProperty(sourceFile, callback, 'exports');
+}
+
+function visitNgModuleProperty(
+  sourceFile: ts.SourceFile,
+  callback: (
+    nodes: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void,
+  property: string
+) {
   visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
     ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
       if (
         ts.isPropertyAssignment(n) &&
         ts.isIdentifier(n.name) &&
-        n.name.text === 'imports' &&
+        n.name.text === property &&
         ts.isArrayLiteralExpression(n.initializer)
       ) {
         callback(n, n.initializer.elements);
@@ -113,7 +134,6 @@ export function visitNgModuleImports(
     });
   });
 }
-
 export function visitComponents(
   sourceFile: ts.SourceFile,
   callback: (

--- a/modules/entity/schematics-core/index.ts
+++ b/modules/entity/schematics-core/index.ts
@@ -81,4 +81,11 @@ export { addPackageToPackageJson } from './utility/package';
 
 export { platformVersion } from './utility/libs-version';
 
-export { visitTSSourceFiles, visitNgModuleImports } from './utility/visitors';
+export {
+  visitTSSourceFiles,
+  visitNgModuleImports,
+  visitComponents,
+  visitDecorator,
+  visitNgModules,
+  visitTemplates,
+} from './utility/visitors';

--- a/modules/entity/schematics-core/index.ts
+++ b/modules/entity/schematics-core/index.ts
@@ -84,6 +84,7 @@ export { platformVersion } from './utility/libs-version';
 export {
   visitTSSourceFiles,
   visitNgModuleImports,
+  visitNgModuleExports,
   visitComponents,
   visitDecorator,
   visitNgModules,

--- a/modules/entity/schematics-core/utility/visitors.ts
+++ b/modules/entity/schematics-core/utility/visitors.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { normalize, resolve } from '@angular-devkit/core';
 import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
@@ -15,6 +16,170 @@ export function visitTSSourceFiles<Result = void>(
   }
 
   return result;
+}
+
+export function visitTemplates(
+  tree: Tree,
+  visitor: (
+    template: {
+      fileName: string;
+      content: string;
+      inline: boolean;
+      start: number;
+    },
+    tree: Tree
+  ) => void
+): void {
+  visitTSSourceFiles(tree, source => {
+    visitComponents(source, (_, decoratorExpressionNode) => {
+      ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+        if (ts.isPropertyAssignment(n) && ts.isIdentifier(n.name)) {
+          if (
+            n.name.text === 'template' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            // Need to add an offset of one to the start because the template quotes are
+            // not part of the template content.
+            const templateStartIdx = n.initializer.getStart() + 1;
+            visitor(
+              {
+                fileName: source.fileName,
+                content: n.initializer.text,
+                inline: true,
+                start: templateStartIdx,
+              },
+              tree
+            );
+            return;
+          } else if (
+            n.name.text === 'templateUrl' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            const parts = normalize(source.fileName)
+              .split('/')
+              .slice(0, -1);
+            const templatePath = resolve(
+              normalize(parts.join('/')),
+              normalize(n.initializer.text)
+            );
+            if (!tree.exists(templatePath)) {
+              return;
+            }
+
+            const fileContent = tree.read(templatePath);
+            if (!fileContent) {
+              return;
+            }
+
+            visitor(
+              {
+                fileName: templatePath,
+                content: fileContent.toString(),
+                inline: false,
+                start: 0,
+              },
+              tree
+            );
+            return;
+          }
+        }
+
+        ts.forEachChild(n, findTemplates);
+      });
+    });
+  });
+}
+
+export function visitNgModuleImports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    importNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
+    ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+      if (
+        ts.isPropertyAssignment(n) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === 'imports' &&
+        ts.isArrayLiteralExpression(n.initializer)
+      ) {
+        callback(n, n.initializer.elements);
+        return;
+      }
+
+      ts.forEachChild(n, findTemplates);
+    });
+  });
+}
+
+export function visitComponents(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'Component', callback);
+}
+
+export function visitNgModules(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'NgModule', callback);
+}
+
+export function visitDecorator(
+  sourceFile: ts.SourceFile,
+  decoratorName: string,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  ts.forEachChild(sourceFile, function findClassDeclaration(node) {
+    if (!ts.isClassDeclaration(node)) {
+      ts.forEachChild(node, findClassDeclaration);
+    }
+
+    const classDeclarationNode = node as ts.ClassDeclaration;
+
+    if (
+      !classDeclarationNode.decorators ||
+      !classDeclarationNode.decorators.length
+    ) {
+      return;
+    }
+
+    const componentDecorator = classDeclarationNode.decorators.find(d => {
+      return (
+        ts.isCallExpression(d.expression) &&
+        ts.isIdentifier(d.expression.expression) &&
+        d.expression.expression.text === decoratorName
+      );
+    });
+
+    if (!componentDecorator) {
+      return;
+    }
+
+    const { expression } = componentDecorator;
+    if (!ts.isCallExpression(expression)) {
+      return;
+    }
+
+    const [arg] = expression.arguments;
+    if (!ts.isObjectLiteralExpression(arg)) {
+      return;
+    }
+
+    callback(classDeclarationNode, arg);
+  });
 }
 
 function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
@@ -41,32 +206,4 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
 
     yield* visit(directory.dir(path));
   }
-}
-
-export function visitNgModuleImports(
-  sourceFile: ts.SourceFile,
-  callback: (
-    importNode: ts.PropertyAssignment,
-    elementExpressions: ts.NodeArray<ts.Expression>
-  ) => void
-) {
-  ts.forEachChild(sourceFile, function findDecorator(node) {
-    if (!ts.isDecorator(node)) {
-      ts.forEachChild(node, findDecorator);
-      return;
-    }
-
-    ts.forEachChild(node, function findImportsNode(n) {
-      if (
-        ts.isPropertyAssignment(n) &&
-        ts.isArrayLiteralExpression(n.initializer) &&
-        ts.isIdentifier(n.name) &&
-        n.name.text === 'imports'
-      ) {
-        callback(n, n.initializer.elements);
-      }
-
-      ts.forEachChild(n, findImportsNode);
-    });
-  });
 }

--- a/modules/entity/schematics-core/utility/visitors.ts
+++ b/modules/entity/schematics-core/utility/visitors.ts
@@ -97,12 +97,33 @@ export function visitNgModuleImports(
     elementExpressions: ts.NodeArray<ts.Expression>
   ) => void
 ) {
+  visitNgModuleProperty(sourceFile, callback, 'imports');
+}
+
+export function visitNgModuleExports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    exportNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModuleProperty(sourceFile, callback, 'exports');
+}
+
+function visitNgModuleProperty(
+  sourceFile: ts.SourceFile,
+  callback: (
+    nodes: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void,
+  property: string
+) {
   visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
     ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
       if (
         ts.isPropertyAssignment(n) &&
         ts.isIdentifier(n.name) &&
-        n.name.text === 'imports' &&
+        n.name.text === property &&
         ts.isArrayLiteralExpression(n.initializer)
       ) {
         callback(n, n.initializer.elements);
@@ -113,7 +134,6 @@ export function visitNgModuleImports(
     });
   });
 }
-
 export function visitComponents(
   sourceFile: ts.SourceFile,
   callback: (

--- a/modules/router-store/schematics-core/index.ts
+++ b/modules/router-store/schematics-core/index.ts
@@ -81,4 +81,11 @@ export { addPackageToPackageJson } from './utility/package';
 
 export { platformVersion } from './utility/libs-version';
 
-export { visitTSSourceFiles, visitNgModuleImports } from './utility/visitors';
+export {
+  visitTSSourceFiles,
+  visitNgModuleImports,
+  visitComponents,
+  visitDecorator,
+  visitNgModules,
+  visitTemplates,
+} from './utility/visitors';

--- a/modules/router-store/schematics-core/index.ts
+++ b/modules/router-store/schematics-core/index.ts
@@ -84,6 +84,7 @@ export { platformVersion } from './utility/libs-version';
 export {
   visitTSSourceFiles,
   visitNgModuleImports,
+  visitNgModuleExports,
   visitComponents,
   visitDecorator,
   visitNgModules,

--- a/modules/router-store/schematics-core/utility/visitors.ts
+++ b/modules/router-store/schematics-core/utility/visitors.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { normalize, resolve } from '@angular-devkit/core';
 import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
@@ -15,6 +16,170 @@ export function visitTSSourceFiles<Result = void>(
   }
 
   return result;
+}
+
+export function visitTemplates(
+  tree: Tree,
+  visitor: (
+    template: {
+      fileName: string;
+      content: string;
+      inline: boolean;
+      start: number;
+    },
+    tree: Tree
+  ) => void
+): void {
+  visitTSSourceFiles(tree, source => {
+    visitComponents(source, (_, decoratorExpressionNode) => {
+      ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+        if (ts.isPropertyAssignment(n) && ts.isIdentifier(n.name)) {
+          if (
+            n.name.text === 'template' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            // Need to add an offset of one to the start because the template quotes are
+            // not part of the template content.
+            const templateStartIdx = n.initializer.getStart() + 1;
+            visitor(
+              {
+                fileName: source.fileName,
+                content: n.initializer.text,
+                inline: true,
+                start: templateStartIdx,
+              },
+              tree
+            );
+            return;
+          } else if (
+            n.name.text === 'templateUrl' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            const parts = normalize(source.fileName)
+              .split('/')
+              .slice(0, -1);
+            const templatePath = resolve(
+              normalize(parts.join('/')),
+              normalize(n.initializer.text)
+            );
+            if (!tree.exists(templatePath)) {
+              return;
+            }
+
+            const fileContent = tree.read(templatePath);
+            if (!fileContent) {
+              return;
+            }
+
+            visitor(
+              {
+                fileName: templatePath,
+                content: fileContent.toString(),
+                inline: false,
+                start: 0,
+              },
+              tree
+            );
+            return;
+          }
+        }
+
+        ts.forEachChild(n, findTemplates);
+      });
+    });
+  });
+}
+
+export function visitNgModuleImports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    importNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
+    ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+      if (
+        ts.isPropertyAssignment(n) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === 'imports' &&
+        ts.isArrayLiteralExpression(n.initializer)
+      ) {
+        callback(n, n.initializer.elements);
+        return;
+      }
+
+      ts.forEachChild(n, findTemplates);
+    });
+  });
+}
+
+export function visitComponents(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'Component', callback);
+}
+
+export function visitNgModules(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'NgModule', callback);
+}
+
+export function visitDecorator(
+  sourceFile: ts.SourceFile,
+  decoratorName: string,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  ts.forEachChild(sourceFile, function findClassDeclaration(node) {
+    if (!ts.isClassDeclaration(node)) {
+      ts.forEachChild(node, findClassDeclaration);
+    }
+
+    const classDeclarationNode = node as ts.ClassDeclaration;
+
+    if (
+      !classDeclarationNode.decorators ||
+      !classDeclarationNode.decorators.length
+    ) {
+      return;
+    }
+
+    const componentDecorator = classDeclarationNode.decorators.find(d => {
+      return (
+        ts.isCallExpression(d.expression) &&
+        ts.isIdentifier(d.expression.expression) &&
+        d.expression.expression.text === decoratorName
+      );
+    });
+
+    if (!componentDecorator) {
+      return;
+    }
+
+    const { expression } = componentDecorator;
+    if (!ts.isCallExpression(expression)) {
+      return;
+    }
+
+    const [arg] = expression.arguments;
+    if (!ts.isObjectLiteralExpression(arg)) {
+      return;
+    }
+
+    callback(classDeclarationNode, arg);
+  });
 }
 
 function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
@@ -41,32 +206,4 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
 
     yield* visit(directory.dir(path));
   }
-}
-
-export function visitNgModuleImports(
-  sourceFile: ts.SourceFile,
-  callback: (
-    importNode: ts.PropertyAssignment,
-    elementExpressions: ts.NodeArray<ts.Expression>
-  ) => void
-) {
-  ts.forEachChild(sourceFile, function findDecorator(node) {
-    if (!ts.isDecorator(node)) {
-      ts.forEachChild(node, findDecorator);
-      return;
-    }
-
-    ts.forEachChild(node, function findImportsNode(n) {
-      if (
-        ts.isPropertyAssignment(n) &&
-        ts.isArrayLiteralExpression(n.initializer) &&
-        ts.isIdentifier(n.name) &&
-        n.name.text === 'imports'
-      ) {
-        callback(n, n.initializer.elements);
-      }
-
-      ts.forEachChild(n, findImportsNode);
-    });
-  });
 }

--- a/modules/router-store/schematics-core/utility/visitors.ts
+++ b/modules/router-store/schematics-core/utility/visitors.ts
@@ -97,12 +97,33 @@ export function visitNgModuleImports(
     elementExpressions: ts.NodeArray<ts.Expression>
   ) => void
 ) {
+  visitNgModuleProperty(sourceFile, callback, 'imports');
+}
+
+export function visitNgModuleExports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    exportNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModuleProperty(sourceFile, callback, 'exports');
+}
+
+function visitNgModuleProperty(
+  sourceFile: ts.SourceFile,
+  callback: (
+    nodes: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void,
+  property: string
+) {
   visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
     ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
       if (
         ts.isPropertyAssignment(n) &&
         ts.isIdentifier(n.name) &&
-        n.name.text === 'imports' &&
+        n.name.text === property &&
         ts.isArrayLiteralExpression(n.initializer)
       ) {
         callback(n, n.initializer.elements);
@@ -113,7 +134,6 @@ export function visitNgModuleImports(
     });
   });
 }
-
 export function visitComponents(
   sourceFile: ts.SourceFile,
   callback: (

--- a/modules/schematics-core/index.ts
+++ b/modules/schematics-core/index.ts
@@ -81,4 +81,11 @@ export { addPackageToPackageJson } from './utility/package';
 
 export { platformVersion } from './utility/libs-version';
 
-export { visitTSSourceFiles, visitNgModuleImports } from './utility/visitors';
+export {
+  visitTSSourceFiles,
+  visitNgModuleImports,
+  visitComponents,
+  visitDecorator,
+  visitNgModules,
+  visitTemplates,
+} from './utility/visitors';

--- a/modules/schematics-core/index.ts
+++ b/modules/schematics-core/index.ts
@@ -84,6 +84,7 @@ export { platformVersion } from './utility/libs-version';
 export {
   visitTSSourceFiles,
   visitNgModuleImports,
+  visitNgModuleExports,
   visitComponents,
   visitDecorator,
   visitNgModules,

--- a/modules/schematics-core/utility/visitors.ts
+++ b/modules/schematics-core/utility/visitors.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { normalize, resolve } from '@angular-devkit/core';
 import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
@@ -15,6 +16,170 @@ export function visitTSSourceFiles<Result = void>(
   }
 
   return result;
+}
+
+export function visitTemplates(
+  tree: Tree,
+  visitor: (
+    template: {
+      fileName: string;
+      content: string;
+      inline: boolean;
+      start: number;
+    },
+    tree: Tree
+  ) => void
+): void {
+  visitTSSourceFiles(tree, source => {
+    visitComponents(source, (_, decoratorExpressionNode) => {
+      ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+        if (ts.isPropertyAssignment(n) && ts.isIdentifier(n.name)) {
+          if (
+            n.name.text === 'template' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            // Need to add an offset of one to the start because the template quotes are
+            // not part of the template content.
+            const templateStartIdx = n.initializer.getStart() + 1;
+            visitor(
+              {
+                fileName: source.fileName,
+                content: n.initializer.text,
+                inline: true,
+                start: templateStartIdx,
+              },
+              tree
+            );
+            return;
+          } else if (
+            n.name.text === 'templateUrl' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            const parts = normalize(source.fileName)
+              .split('/')
+              .slice(0, -1);
+            const templatePath = resolve(
+              normalize(parts.join('/')),
+              normalize(n.initializer.text)
+            );
+            if (!tree.exists(templatePath)) {
+              return;
+            }
+
+            const fileContent = tree.read(templatePath);
+            if (!fileContent) {
+              return;
+            }
+
+            visitor(
+              {
+                fileName: templatePath,
+                content: fileContent.toString(),
+                inline: false,
+                start: 0,
+              },
+              tree
+            );
+            return;
+          }
+        }
+
+        ts.forEachChild(n, findTemplates);
+      });
+    });
+  });
+}
+
+export function visitNgModuleImports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    importNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
+    ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+      if (
+        ts.isPropertyAssignment(n) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === 'imports' &&
+        ts.isArrayLiteralExpression(n.initializer)
+      ) {
+        callback(n, n.initializer.elements);
+        return;
+      }
+
+      ts.forEachChild(n, findTemplates);
+    });
+  });
+}
+
+export function visitComponents(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'Component', callback);
+}
+
+export function visitNgModules(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'NgModule', callback);
+}
+
+export function visitDecorator(
+  sourceFile: ts.SourceFile,
+  decoratorName: string,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  ts.forEachChild(sourceFile, function findClassDeclaration(node) {
+    if (!ts.isClassDeclaration(node)) {
+      ts.forEachChild(node, findClassDeclaration);
+    }
+
+    const classDeclarationNode = node as ts.ClassDeclaration;
+
+    if (
+      !classDeclarationNode.decorators ||
+      !classDeclarationNode.decorators.length
+    ) {
+      return;
+    }
+
+    const componentDecorator = classDeclarationNode.decorators.find(d => {
+      return (
+        ts.isCallExpression(d.expression) &&
+        ts.isIdentifier(d.expression.expression) &&
+        d.expression.expression.text === decoratorName
+      );
+    });
+
+    if (!componentDecorator) {
+      return;
+    }
+
+    const { expression } = componentDecorator;
+    if (!ts.isCallExpression(expression)) {
+      return;
+    }
+
+    const [arg] = expression.arguments;
+    if (!ts.isObjectLiteralExpression(arg)) {
+      return;
+    }
+
+    callback(classDeclarationNode, arg);
+  });
 }
 
 function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
@@ -41,32 +206,4 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
 
     yield* visit(directory.dir(path));
   }
-}
-
-export function visitNgModuleImports(
-  sourceFile: ts.SourceFile,
-  callback: (
-    importNode: ts.PropertyAssignment,
-    elementExpressions: ts.NodeArray<ts.Expression>
-  ) => void
-) {
-  ts.forEachChild(sourceFile, function findDecorator(node) {
-    if (!ts.isDecorator(node)) {
-      ts.forEachChild(node, findDecorator);
-      return;
-    }
-
-    ts.forEachChild(node, function findImportsNode(n) {
-      if (
-        ts.isPropertyAssignment(n) &&
-        ts.isArrayLiteralExpression(n.initializer) &&
-        ts.isIdentifier(n.name) &&
-        n.name.text === 'imports'
-      ) {
-        callback(n, n.initializer.elements);
-      }
-
-      ts.forEachChild(n, findImportsNode);
-    });
-  });
 }

--- a/modules/schematics-core/utility/visitors.ts
+++ b/modules/schematics-core/utility/visitors.ts
@@ -97,12 +97,33 @@ export function visitNgModuleImports(
     elementExpressions: ts.NodeArray<ts.Expression>
   ) => void
 ) {
+  visitNgModuleProperty(sourceFile, callback, 'imports');
+}
+
+export function visitNgModuleExports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    exportNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModuleProperty(sourceFile, callback, 'exports');
+}
+
+function visitNgModuleProperty(
+  sourceFile: ts.SourceFile,
+  callback: (
+    nodes: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void,
+  property: string
+) {
   visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
     ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
       if (
         ts.isPropertyAssignment(n) &&
         ts.isIdentifier(n.name) &&
-        n.name.text === 'imports' &&
+        n.name.text === property &&
         ts.isArrayLiteralExpression(n.initializer)
       ) {
         callback(n, n.initializer.elements);
@@ -113,7 +134,6 @@ export function visitNgModuleImports(
     });
   });
 }
-
 export function visitComponents(
   sourceFile: ts.SourceFile,
   callback: (

--- a/modules/schematics/collection.json
+++ b/modules/schematics/collection.json
@@ -43,6 +43,13 @@
       "description": "Add feature state"
     },
 
+    "ngrx-push-migration": {
+      "aliases": ["ngrxpush"],
+      "factory": "./src/ngrx-push-migration",
+      "schema": "./src/ngrx-push-migration/schema.json",
+      "description": "Migration to replace the `async` pipe with `ngrxPush`"
+    },
+
     "reducer": {
       "aliases": ["r"],
       "factory": "./src/reducer",

--- a/modules/schematics/schematics-core/index.ts
+++ b/modules/schematics/schematics-core/index.ts
@@ -81,4 +81,11 @@ export { addPackageToPackageJson } from './utility/package';
 
 export { platformVersion } from './utility/libs-version';
 
-export { visitTSSourceFiles, visitNgModuleImports } from './utility/visitors';
+export {
+  visitTSSourceFiles,
+  visitNgModuleImports,
+  visitComponents,
+  visitDecorator,
+  visitNgModules,
+  visitTemplates,
+} from './utility/visitors';

--- a/modules/schematics/schematics-core/index.ts
+++ b/modules/schematics/schematics-core/index.ts
@@ -84,6 +84,7 @@ export { platformVersion } from './utility/libs-version';
 export {
   visitTSSourceFiles,
   visitNgModuleImports,
+  visitNgModuleExports,
   visitComponents,
   visitDecorator,
   visitNgModules,

--- a/modules/schematics/schematics-core/utility/visitors.ts
+++ b/modules/schematics/schematics-core/utility/visitors.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { normalize, resolve } from '@angular-devkit/core';
 import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
@@ -15,6 +16,170 @@ export function visitTSSourceFiles<Result = void>(
   }
 
   return result;
+}
+
+export function visitTemplates(
+  tree: Tree,
+  visitor: (
+    template: {
+      fileName: string;
+      content: string;
+      inline: boolean;
+      start: number;
+    },
+    tree: Tree
+  ) => void
+): void {
+  visitTSSourceFiles(tree, source => {
+    visitComponents(source, (_, decoratorExpressionNode) => {
+      ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+        if (ts.isPropertyAssignment(n) && ts.isIdentifier(n.name)) {
+          if (
+            n.name.text === 'template' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            // Need to add an offset of one to the start because the template quotes are
+            // not part of the template content.
+            const templateStartIdx = n.initializer.getStart() + 1;
+            visitor(
+              {
+                fileName: source.fileName,
+                content: n.initializer.text,
+                inline: true,
+                start: templateStartIdx,
+              },
+              tree
+            );
+            return;
+          } else if (
+            n.name.text === 'templateUrl' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            const parts = normalize(source.fileName)
+              .split('/')
+              .slice(0, -1);
+            const templatePath = resolve(
+              normalize(parts.join('/')),
+              normalize(n.initializer.text)
+            );
+            if (!tree.exists(templatePath)) {
+              return;
+            }
+
+            const fileContent = tree.read(templatePath);
+            if (!fileContent) {
+              return;
+            }
+
+            visitor(
+              {
+                fileName: templatePath,
+                content: fileContent.toString(),
+                inline: false,
+                start: 0,
+              },
+              tree
+            );
+            return;
+          }
+        }
+
+        ts.forEachChild(n, findTemplates);
+      });
+    });
+  });
+}
+
+export function visitNgModuleImports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    importNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
+    ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+      if (
+        ts.isPropertyAssignment(n) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === 'imports' &&
+        ts.isArrayLiteralExpression(n.initializer)
+      ) {
+        callback(n, n.initializer.elements);
+        return;
+      }
+
+      ts.forEachChild(n, findTemplates);
+    });
+  });
+}
+
+export function visitComponents(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'Component', callback);
+}
+
+export function visitNgModules(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'NgModule', callback);
+}
+
+export function visitDecorator(
+  sourceFile: ts.SourceFile,
+  decoratorName: string,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  ts.forEachChild(sourceFile, function findClassDeclaration(node) {
+    if (!ts.isClassDeclaration(node)) {
+      ts.forEachChild(node, findClassDeclaration);
+    }
+
+    const classDeclarationNode = node as ts.ClassDeclaration;
+
+    if (
+      !classDeclarationNode.decorators ||
+      !classDeclarationNode.decorators.length
+    ) {
+      return;
+    }
+
+    const componentDecorator = classDeclarationNode.decorators.find(d => {
+      return (
+        ts.isCallExpression(d.expression) &&
+        ts.isIdentifier(d.expression.expression) &&
+        d.expression.expression.text === decoratorName
+      );
+    });
+
+    if (!componentDecorator) {
+      return;
+    }
+
+    const { expression } = componentDecorator;
+    if (!ts.isCallExpression(expression)) {
+      return;
+    }
+
+    const [arg] = expression.arguments;
+    if (!ts.isObjectLiteralExpression(arg)) {
+      return;
+    }
+
+    callback(classDeclarationNode, arg);
+  });
 }
 
 function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
@@ -41,32 +206,4 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
 
     yield* visit(directory.dir(path));
   }
-}
-
-export function visitNgModuleImports(
-  sourceFile: ts.SourceFile,
-  callback: (
-    importNode: ts.PropertyAssignment,
-    elementExpressions: ts.NodeArray<ts.Expression>
-  ) => void
-) {
-  ts.forEachChild(sourceFile, function findDecorator(node) {
-    if (!ts.isDecorator(node)) {
-      ts.forEachChild(node, findDecorator);
-      return;
-    }
-
-    ts.forEachChild(node, function findImportsNode(n) {
-      if (
-        ts.isPropertyAssignment(n) &&
-        ts.isArrayLiteralExpression(n.initializer) &&
-        ts.isIdentifier(n.name) &&
-        n.name.text === 'imports'
-      ) {
-        callback(n, n.initializer.elements);
-      }
-
-      ts.forEachChild(n, findImportsNode);
-    });
-  });
 }

--- a/modules/schematics/schematics-core/utility/visitors.ts
+++ b/modules/schematics/schematics-core/utility/visitors.ts
@@ -97,12 +97,33 @@ export function visitNgModuleImports(
     elementExpressions: ts.NodeArray<ts.Expression>
   ) => void
 ) {
+  visitNgModuleProperty(sourceFile, callback, 'imports');
+}
+
+export function visitNgModuleExports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    exportNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModuleProperty(sourceFile, callback, 'exports');
+}
+
+function visitNgModuleProperty(
+  sourceFile: ts.SourceFile,
+  callback: (
+    nodes: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void,
+  property: string
+) {
   visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
     ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
       if (
         ts.isPropertyAssignment(n) &&
         ts.isIdentifier(n.name) &&
-        n.name.text === 'imports' &&
+        n.name.text === property &&
         ts.isArrayLiteralExpression(n.initializer)
       ) {
         callback(n, n.initializer.elements);
@@ -113,7 +134,6 @@ export function visitNgModuleImports(
     });
   });
 }
-
 export function visitComponents(
   sourceFile: ts.SourceFile,
   callback: (

--- a/modules/schematics/src/ngrx-push-migration/index.spec.ts
+++ b/modules/schematics/src/ngrx-push-migration/index.spec.ts
@@ -1,0 +1,76 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { createWorkspace } from '../../../schematics-core/testing';
+
+describe('NgrxPush migration', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@ngrx/schematics',
+    path.join(__dirname, '../../collection.json')
+  );
+
+  let appTree: UnitTestTree;
+
+  const TEMPLATE = `
+    <span>promise|async</span> <!-- this will also get replaced -->
+    <span>One whitespace {{ greeting | async }}</span>
+    <span>No whitespace {{ greeting |async }}</span>
+    <span>Multiple whitespace {{ greeting |      async }}</span>
+  `;
+
+  beforeEach(async () => {
+    appTree = await createWorkspace(schematicRunner, appTree);
+  });
+
+  it('should replace an inline template', async () => {
+    appTree.create(
+      './sut.component.ts',
+      `@Component({
+        selector: 'sut',
+        template: \`${TEMPLATE}\`
+      })
+      export class SUTComponent { }`
+    );
+
+    const tree = await schematicRunner
+      .runSchematicAsync('ngrx-push-migration', {}, appTree)
+      .toPromise();
+
+    const actual = tree.readContent('./sut.component.ts');
+    expect(actual).not.toContain('async');
+    expect(actual).toContain('ngrxPush');
+  });
+
+  it('should replace a file template', async () => {
+    appTree.create(
+      './sut.component.ts',
+      `@Component({
+        selector: 'sut',
+        templateUrl: './sut.component.html'
+      })
+      export class SUTComponent { }`
+    );
+    appTree.create('./sut.component.html', TEMPLATE);
+
+    const tree = await schematicRunner
+      .runSchematicAsync('ngrx-push-migration', {}, appTree)
+      .toPromise();
+
+    const actual = tree.readContent('./sut.component.html');
+    expect(actual).not.toContain('async');
+    expect(actual).toContain('ngrxPush');
+  });
+
+  it('should not touch templates that are not referenced', async () => {
+    appTree.create('./sut.component.html', TEMPLATE);
+
+    const tree = await schematicRunner
+      .runSchematicAsync('ngrx-push-migration', {}, appTree)
+      .toPromise();
+
+    const actual = tree.readContent('./sut.component.html');
+    expect(actual).toBe(TEMPLATE);
+  });
+});

--- a/modules/schematics/src/ngrx-push-migration/index.spec.ts
+++ b/modules/schematics/src/ngrx-push-migration/index.spec.ts
@@ -13,64 +13,248 @@ describe('NgrxPush migration', () => {
 
   let appTree: UnitTestTree;
 
-  const TEMPLATE = `
+  beforeEach(async () => {
+    appTree = await createWorkspace(schematicRunner, appTree);
+  });
+
+  describe('migrateToNgrxPush', () => {
+    const TEMPLATE = `
     <span>promise|async</span> <!-- this will also get replaced -->
     <span>One whitespace {{ greeting | async }}</span>
     <span>No whitespace {{ greeting |async }}</span>
     <span>Multiple whitespace {{ greeting |      async }}</span>
   `;
 
-  beforeEach(async () => {
-    appTree = await createWorkspace(schematicRunner, appTree);
-  });
-
-  it('should replace an inline template', async () => {
-    appTree.create(
-      './sut.component.ts',
-      `@Component({
+    it('should replace an inline template', async () => {
+      appTree.create(
+        './sut.component.ts',
+        `@Component({
         selector: 'sut',
         template: \`${TEMPLATE}\`
       })
       export class SUTComponent { }`
-    );
+      );
 
-    const tree = await schematicRunner
-      .runSchematicAsync('ngrx-push-migration', {}, appTree)
-      .toPromise();
+      const tree = await schematicRunner
+        .runSchematicAsync('ngrx-push-migration', {}, appTree)
+        .toPromise();
 
-    const actual = tree.readContent('./sut.component.ts');
-    expect(actual).not.toContain('async');
-    expect(actual).toContain('ngrxPush');
-  });
+      const actual = tree.readContent('./sut.component.ts');
+      expect(actual).not.toContain('async');
+      expect(actual).toContain('ngrxPush');
+    });
 
-  it('should replace a file template', async () => {
-    appTree.create(
-      './sut.component.ts',
-      `@Component({
+    it('should replace a file template', async () => {
+      appTree.create(
+        './sut.component.ts',
+        `@Component({
         selector: 'sut',
         templateUrl: './sut.component.html'
       })
       export class SUTComponent { }`
-    );
-    appTree.create('./sut.component.html', TEMPLATE);
+      );
+      appTree.create('./sut.component.html', TEMPLATE);
 
-    const tree = await schematicRunner
-      .runSchematicAsync('ngrx-push-migration', {}, appTree)
-      .toPromise();
+      const tree = await schematicRunner
+        .runSchematicAsync('ngrx-push-migration', {}, appTree)
+        .toPromise();
 
-    const actual = tree.readContent('./sut.component.html');
-    expect(actual).not.toContain('async');
-    expect(actual).toContain('ngrxPush');
+      const actual = tree.readContent('./sut.component.html');
+      expect(actual).not.toContain('async');
+      expect(actual).toContain('ngrxPush');
+    });
+
+    it('should not touch templates that are not referenced', async () => {
+      appTree.create('./sut.component.html', TEMPLATE);
+
+      const tree = await schematicRunner
+        .runSchematicAsync('ngrx-push-migration', {}, appTree)
+        .toPromise();
+
+      const actual = tree.readContent('./sut.component.html');
+      expect(actual).toBe(TEMPLATE);
+    });
   });
 
-  it('should not touch templates that are not referenced', async () => {
-    appTree.create('./sut.component.html', TEMPLATE);
+  describe('importReactiveComponentModule', () => {
+    it('should import ReactiveComponentModule when BrowserModule is imported', async () => {
+      appTree.create(
+        './sut.module.ts',
+        `
+          import { BrowserModule } from '@angular/platform-browser';
+          import { NgModule } from '@angular/core';
 
-    const tree = await schematicRunner
-      .runSchematicAsync('ngrx-push-migration', {}, appTree)
-      .toPromise();
+          import { AppComponent } from './app.component';
 
-    const actual = tree.readContent('./sut.component.html');
-    expect(actual).toBe(TEMPLATE);
+          @NgModule({
+            declarations: [ AppComponent ],
+            imports: [ BrowserModule ],
+            providers: [],
+            bootstrap: [AppComponent]
+          })
+          export class AppModule { }
+      `
+      );
+      const tree = await schematicRunner
+        .runSchematicAsync('ngrx-push-migration', {}, appTree)
+        .toPromise();
+
+      const actual = tree.readContent('./sut.module.ts');
+      expect(actual).toMatch(
+        /imports: \[ BrowserModule, ReactiveComponentModule \],/
+      );
+      expect(actual).toMatch(
+        /import { ReactiveComponentModule } from '@ngrx\/component'/
+      );
+    });
+
+    it('should import ReactiveComponentModule when CommonModule is imported', async () => {
+      appTree.create(
+        './sut.module.ts',
+        `
+          import { CommonModule } from '@angular/common';
+          import { NgModule } from '@angular/core';
+
+          import { AppComponent } from './app.component';
+
+          @NgModule({
+            declarations: [ AppComponent ],
+            imports: [ CommonModule ],
+            providers: [],
+            bootstrap: [AppComponent]
+          })
+          export class AppModule { }
+      `
+      );
+      const tree = await schematicRunner
+        .runSchematicAsync('ngrx-push-migration', {}, appTree)
+        .toPromise();
+
+      const actual = tree.readContent('./sut.module.ts');
+      expect(actual).toMatch(
+        /imports: \[ CommonModule, ReactiveComponentModule \],/
+      );
+      expect(actual).toMatch(
+        /import { ReactiveComponentModule } from '@ngrx\/component'/
+      );
+    });
+
+    it("should not import ReactiveComponentModule when it doesn't need to", async () => {
+      appTree.create(
+        './sut.module.ts',
+        `
+          import { AppComponent } from './app.component';
+
+          @NgModule({
+            declarations: [ AppComponent ],
+            imports: [],
+            providers: [],
+          })
+          export class AppModule { }
+      `
+      );
+      const tree = await schematicRunner
+        .runSchematicAsync('ngrx-push-migration', {}, appTree)
+        .toPromise();
+
+      const actual = tree.readContent('./sut.module.ts');
+      expect(actual).not.toMatch(
+        /imports: \[ CommonModule, ReactiveComponentModule \],/
+      );
+      expect(actual).not.toMatch(
+        /import { ReactiveComponentModule } from '@ngrx\/component'/
+      );
+    });
+  });
+
+  describe('exportReactiveComponentModule', () => {
+    it('should export ReactiveComponentModule when BrowserModule is exported', async () => {
+      appTree.create(
+        './sut.module.ts',
+        `
+          import { BrowserModule } from '@angular/platform-browser';
+          import { NgModule } from '@angular/core';
+
+          import { AppComponent } from './app.component';
+
+          @NgModule({
+            declarations: [ AppComponent ],
+            exports: [ BrowserModule ],
+            providers: [],
+            bootstrap: [AppComponent]
+          })
+          export class AppModule { }
+      `
+      );
+      const tree = await schematicRunner
+        .runSchematicAsync('ngrx-push-migration', {}, appTree)
+        .toPromise();
+
+      const actual = tree.readContent('./sut.module.ts');
+      expect(actual).toMatch(
+        /exports: \[ BrowserModule, ReactiveComponentModule \],/
+      );
+      expect(actual).toMatch(
+        /import { ReactiveComponentModule } from '@ngrx\/component'/
+      );
+    });
+
+    it('should export ReactiveComponentModule when CommonModule is exported', async () => {
+      appTree.create(
+        './sut.module.ts',
+        `
+          import { CommonModule } from '@angular/common';
+          import { NgModule } from '@angular/core';
+
+          import { AppComponent } from './app.component';
+
+          @NgModule({
+            declarations: [ AppComponent ],
+            exports: [ CommonModule ],
+            providers: [],
+            bootstrap: [AppComponent]
+          })
+          export class AppModule { }
+      `
+      );
+      const tree = await schematicRunner
+        .runSchematicAsync('ngrx-push-migration', {}, appTree)
+        .toPromise();
+
+      const actual = tree.readContent('./sut.module.ts');
+      expect(actual).toMatch(
+        /exports: \[ CommonModule, ReactiveComponentModule \],/
+      );
+      expect(actual).toMatch(
+        /import { ReactiveComponentModule } from '@ngrx\/component'/
+      );
+    });
+
+    it("should not export ReactiveComponentModule when it doesn't need to", async () => {
+      appTree.create(
+        './sut.module.ts',
+        `
+          import { AppComponent } from './app.component';
+
+          @NgModule({
+            declarations: [ AppComponent ],
+            exports: [],
+            providers: [],
+          })
+          export class AppModule { }
+      `
+      );
+      const tree = await schematicRunner
+        .runSchematicAsync('ngrx-push-migration', {}, appTree)
+        .toPromise();
+
+      const actual = tree.readContent('./sut.module.ts');
+      expect(actual).not.toMatch(
+        /exports: \[ CommonModule, ReactiveComponentModule \],/
+      );
+      expect(actual).not.toMatch(
+        /import { ReactiveComponentModule } from '@ngrx\/component'/
+      );
+    });
   });
 });

--- a/modules/schematics/src/ngrx-push-migration/index.ts
+++ b/modules/schematics/src/ngrx-push-migration/index.ts
@@ -1,0 +1,35 @@
+import { Tree, Rule, chain } from '@angular-devkit/schematics';
+import {
+  commitChanges,
+  visitTemplates,
+  ReplaceChange,
+  Change,
+} from '@ngrx/schematics/schematics-core';
+
+const ASYNC_REGEXP = /\| {0,}async/g;
+
+export function migrateToCreators(): Rule {
+  return (host: Tree) =>
+    visitTemplates(host, template => {
+      let match: RegExpMatchArray | null;
+      let changes: Change[] = [];
+      while ((match = ASYNC_REGEXP.exec(template.content)) !== null) {
+        const m = match.toString();
+
+        changes.push(
+          new ReplaceChange(
+            template.fileName,
+            template.start + match.index!,
+            m,
+            m.replace('async', 'ngrxPush')
+          )
+        );
+      }
+
+      return commitChanges(host, template.fileName, changes);
+    });
+}
+
+export default function(): Rule {
+  return chain([migrateToCreators()]);
+}

--- a/modules/schematics/src/ngrx-push-migration/index.ts
+++ b/modules/schematics/src/ngrx-push-migration/index.ts
@@ -1,14 +1,29 @@
+import * as ts from 'typescript';
 import { Tree, Rule, chain } from '@angular-devkit/schematics';
 import {
   commitChanges,
   visitTemplates,
   ReplaceChange,
   Change,
+  visitTSSourceFiles,
+  visitNgModuleImports,
+  visitNgModuleExports,
+  addImportToModule,
+  addExportToModule,
 } from '@ngrx/schematics/schematics-core';
 
 const ASYNC_REGEXP = /\| {0,}async/g;
+const REACTIVE_MODULE = 'ReactiveComponentModule';
+const COMPONENT_MODULE = '@ngrx/component';
 
-export function migrateToCreators(): Rule {
+const reactiveModuleToFind = (node: ts.Node) =>
+  ts.isIdentifier(node) && node.text === REACTIVE_MODULE;
+
+const ngModulesToFind = (node: ts.Node) =>
+  ts.isIdentifier(node) &&
+  (node.text === 'CommonModule' || node.text === 'BrowserModule');
+
+export function migrateToNgrxPush(): Rule {
   return (host: Tree) =>
     visitTemplates(host, template => {
       let match: RegExpMatchArray | null;
@@ -30,6 +45,58 @@ export function migrateToCreators(): Rule {
     });
 }
 
+export function importReactiveComponentModule(): Rule {
+  return (host: Tree) => {
+    visitTSSourceFiles(host, sourceFile => {
+      let hasCommonModuleOrBrowserModule = false;
+      let hasReactiveComponentModule = false;
+
+      visitNgModuleImports(sourceFile, (_, importNodes) => {
+        hasCommonModuleOrBrowserModule = importNodes.some(ngModulesToFind);
+        hasReactiveComponentModule = importNodes.some(reactiveModuleToFind);
+      });
+
+      if (hasCommonModuleOrBrowserModule && !hasReactiveComponentModule) {
+        const changes: Change[] = addImportToModule(
+          sourceFile,
+          sourceFile.fileName,
+          REACTIVE_MODULE,
+          COMPONENT_MODULE
+        );
+        commitChanges(host, sourceFile.fileName, changes);
+      }
+    });
+  };
+}
+
+export function exportReactiveComponentModule(): Rule {
+  return (host: Tree) => {
+    visitTSSourceFiles(host, sourceFile => {
+      let hasCommonModuleOrBrowserModule = false;
+      let hasReactiveComponentModule = false;
+
+      visitNgModuleExports(sourceFile, (_, exportNodes) => {
+        hasCommonModuleOrBrowserModule = exportNodes.some(ngModulesToFind);
+        hasReactiveComponentModule = exportNodes.some(reactiveModuleToFind);
+      });
+
+      if (hasCommonModuleOrBrowserModule && !hasReactiveComponentModule) {
+        const changes: Change[] = addExportToModule(
+          sourceFile,
+          sourceFile.fileName,
+          REACTIVE_MODULE,
+          COMPONENT_MODULE
+        );
+        commitChanges(host, sourceFile.fileName, changes);
+      }
+    });
+  };
+}
+
 export default function(): Rule {
-  return chain([migrateToCreators()]);
+  return chain([
+    migrateToNgrxPush(),
+    importReactiveComponentModule(),
+    exportReactiveComponentModule(),
+  ]);
 }

--- a/modules/schematics/src/ngrx-push-migration/schema.json
+++ b/modules/schematics/src/ngrx-push-migration/schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsNgRxNgRxPushMigration",
+  "title": "NgRx Component NgRxPush Migration from async to ngrxPush",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/modules/schematics/src/ngrx-push-migration/schema.ts
+++ b/modules/schematics/src/ngrx-push-migration/schema.ts
@@ -1,0 +1,1 @@
+export interface Schema {}

--- a/modules/store-devtools/schematics-core/index.ts
+++ b/modules/store-devtools/schematics-core/index.ts
@@ -81,4 +81,11 @@ export { addPackageToPackageJson } from './utility/package';
 
 export { platformVersion } from './utility/libs-version';
 
-export { visitTSSourceFiles, visitNgModuleImports } from './utility/visitors';
+export {
+  visitTSSourceFiles,
+  visitNgModuleImports,
+  visitComponents,
+  visitDecorator,
+  visitNgModules,
+  visitTemplates,
+} from './utility/visitors';

--- a/modules/store-devtools/schematics-core/index.ts
+++ b/modules/store-devtools/schematics-core/index.ts
@@ -84,6 +84,7 @@ export { platformVersion } from './utility/libs-version';
 export {
   visitTSSourceFiles,
   visitNgModuleImports,
+  visitNgModuleExports,
   visitComponents,
   visitDecorator,
   visitNgModules,

--- a/modules/store-devtools/schematics-core/utility/visitors.ts
+++ b/modules/store-devtools/schematics-core/utility/visitors.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { normalize, resolve } from '@angular-devkit/core';
 import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
@@ -15,6 +16,170 @@ export function visitTSSourceFiles<Result = void>(
   }
 
   return result;
+}
+
+export function visitTemplates(
+  tree: Tree,
+  visitor: (
+    template: {
+      fileName: string;
+      content: string;
+      inline: boolean;
+      start: number;
+    },
+    tree: Tree
+  ) => void
+): void {
+  visitTSSourceFiles(tree, source => {
+    visitComponents(source, (_, decoratorExpressionNode) => {
+      ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+        if (ts.isPropertyAssignment(n) && ts.isIdentifier(n.name)) {
+          if (
+            n.name.text === 'template' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            // Need to add an offset of one to the start because the template quotes are
+            // not part of the template content.
+            const templateStartIdx = n.initializer.getStart() + 1;
+            visitor(
+              {
+                fileName: source.fileName,
+                content: n.initializer.text,
+                inline: true,
+                start: templateStartIdx,
+              },
+              tree
+            );
+            return;
+          } else if (
+            n.name.text === 'templateUrl' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            const parts = normalize(source.fileName)
+              .split('/')
+              .slice(0, -1);
+            const templatePath = resolve(
+              normalize(parts.join('/')),
+              normalize(n.initializer.text)
+            );
+            if (!tree.exists(templatePath)) {
+              return;
+            }
+
+            const fileContent = tree.read(templatePath);
+            if (!fileContent) {
+              return;
+            }
+
+            visitor(
+              {
+                fileName: templatePath,
+                content: fileContent.toString(),
+                inline: false,
+                start: 0,
+              },
+              tree
+            );
+            return;
+          }
+        }
+
+        ts.forEachChild(n, findTemplates);
+      });
+    });
+  });
+}
+
+export function visitNgModuleImports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    importNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
+    ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+      if (
+        ts.isPropertyAssignment(n) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === 'imports' &&
+        ts.isArrayLiteralExpression(n.initializer)
+      ) {
+        callback(n, n.initializer.elements);
+        return;
+      }
+
+      ts.forEachChild(n, findTemplates);
+    });
+  });
+}
+
+export function visitComponents(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'Component', callback);
+}
+
+export function visitNgModules(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'NgModule', callback);
+}
+
+export function visitDecorator(
+  sourceFile: ts.SourceFile,
+  decoratorName: string,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  ts.forEachChild(sourceFile, function findClassDeclaration(node) {
+    if (!ts.isClassDeclaration(node)) {
+      ts.forEachChild(node, findClassDeclaration);
+    }
+
+    const classDeclarationNode = node as ts.ClassDeclaration;
+
+    if (
+      !classDeclarationNode.decorators ||
+      !classDeclarationNode.decorators.length
+    ) {
+      return;
+    }
+
+    const componentDecorator = classDeclarationNode.decorators.find(d => {
+      return (
+        ts.isCallExpression(d.expression) &&
+        ts.isIdentifier(d.expression.expression) &&
+        d.expression.expression.text === decoratorName
+      );
+    });
+
+    if (!componentDecorator) {
+      return;
+    }
+
+    const { expression } = componentDecorator;
+    if (!ts.isCallExpression(expression)) {
+      return;
+    }
+
+    const [arg] = expression.arguments;
+    if (!ts.isObjectLiteralExpression(arg)) {
+      return;
+    }
+
+    callback(classDeclarationNode, arg);
+  });
 }
 
 function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
@@ -41,32 +206,4 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
 
     yield* visit(directory.dir(path));
   }
-}
-
-export function visitNgModuleImports(
-  sourceFile: ts.SourceFile,
-  callback: (
-    importNode: ts.PropertyAssignment,
-    elementExpressions: ts.NodeArray<ts.Expression>
-  ) => void
-) {
-  ts.forEachChild(sourceFile, function findDecorator(node) {
-    if (!ts.isDecorator(node)) {
-      ts.forEachChild(node, findDecorator);
-      return;
-    }
-
-    ts.forEachChild(node, function findImportsNode(n) {
-      if (
-        ts.isPropertyAssignment(n) &&
-        ts.isArrayLiteralExpression(n.initializer) &&
-        ts.isIdentifier(n.name) &&
-        n.name.text === 'imports'
-      ) {
-        callback(n, n.initializer.elements);
-      }
-
-      ts.forEachChild(n, findImportsNode);
-    });
-  });
 }

--- a/modules/store-devtools/schematics-core/utility/visitors.ts
+++ b/modules/store-devtools/schematics-core/utility/visitors.ts
@@ -97,12 +97,33 @@ export function visitNgModuleImports(
     elementExpressions: ts.NodeArray<ts.Expression>
   ) => void
 ) {
+  visitNgModuleProperty(sourceFile, callback, 'imports');
+}
+
+export function visitNgModuleExports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    exportNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModuleProperty(sourceFile, callback, 'exports');
+}
+
+function visitNgModuleProperty(
+  sourceFile: ts.SourceFile,
+  callback: (
+    nodes: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void,
+  property: string
+) {
   visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
     ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
       if (
         ts.isPropertyAssignment(n) &&
         ts.isIdentifier(n.name) &&
-        n.name.text === 'imports' &&
+        n.name.text === property &&
         ts.isArrayLiteralExpression(n.initializer)
       ) {
         callback(n, n.initializer.elements);
@@ -113,7 +134,6 @@ export function visitNgModuleImports(
     });
   });
 }
-
 export function visitComponents(
   sourceFile: ts.SourceFile,
   callback: (

--- a/modules/store/schematics-core/index.ts
+++ b/modules/store/schematics-core/index.ts
@@ -81,4 +81,11 @@ export { addPackageToPackageJson } from './utility/package';
 
 export { platformVersion } from './utility/libs-version';
 
-export { visitTSSourceFiles, visitNgModuleImports } from './utility/visitors';
+export {
+  visitTSSourceFiles,
+  visitNgModuleImports,
+  visitComponents,
+  visitDecorator,
+  visitNgModules,
+  visitTemplates,
+} from './utility/visitors';

--- a/modules/store/schematics-core/index.ts
+++ b/modules/store/schematics-core/index.ts
@@ -84,6 +84,7 @@ export { platformVersion } from './utility/libs-version';
 export {
   visitTSSourceFiles,
   visitNgModuleImports,
+  visitNgModuleExports,
   visitComponents,
   visitDecorator,
   visitNgModules,

--- a/modules/store/schematics-core/utility/visitors.ts
+++ b/modules/store/schematics-core/utility/visitors.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { normalize, resolve } from '@angular-devkit/core';
 import { Tree, DirEntry } from '@angular-devkit/schematics';
 
 export function visitTSSourceFiles<Result = void>(
@@ -15,6 +16,170 @@ export function visitTSSourceFiles<Result = void>(
   }
 
   return result;
+}
+
+export function visitTemplates(
+  tree: Tree,
+  visitor: (
+    template: {
+      fileName: string;
+      content: string;
+      inline: boolean;
+      start: number;
+    },
+    tree: Tree
+  ) => void
+): void {
+  visitTSSourceFiles(tree, source => {
+    visitComponents(source, (_, decoratorExpressionNode) => {
+      ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+        if (ts.isPropertyAssignment(n) && ts.isIdentifier(n.name)) {
+          if (
+            n.name.text === 'template' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            // Need to add an offset of one to the start because the template quotes are
+            // not part of the template content.
+            const templateStartIdx = n.initializer.getStart() + 1;
+            visitor(
+              {
+                fileName: source.fileName,
+                content: n.initializer.text,
+                inline: true,
+                start: templateStartIdx,
+              },
+              tree
+            );
+            return;
+          } else if (
+            n.name.text === 'templateUrl' &&
+            ts.isStringLiteralLike(n.initializer)
+          ) {
+            const parts = normalize(source.fileName)
+              .split('/')
+              .slice(0, -1);
+            const templatePath = resolve(
+              normalize(parts.join('/')),
+              normalize(n.initializer.text)
+            );
+            if (!tree.exists(templatePath)) {
+              return;
+            }
+
+            const fileContent = tree.read(templatePath);
+            if (!fileContent) {
+              return;
+            }
+
+            visitor(
+              {
+                fileName: templatePath,
+                content: fileContent.toString(),
+                inline: false,
+                start: 0,
+              },
+              tree
+            );
+            return;
+          }
+        }
+
+        ts.forEachChild(n, findTemplates);
+      });
+    });
+  });
+}
+
+export function visitNgModuleImports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    importNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
+    ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
+      if (
+        ts.isPropertyAssignment(n) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === 'imports' &&
+        ts.isArrayLiteralExpression(n.initializer)
+      ) {
+        callback(n, n.initializer.elements);
+        return;
+      }
+
+      ts.forEachChild(n, findTemplates);
+    });
+  });
+}
+
+export function visitComponents(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'Component', callback);
+}
+
+export function visitNgModules(
+  sourceFile: ts.SourceFile,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  visitDecorator(sourceFile, 'NgModule', callback);
+}
+
+export function visitDecorator(
+  sourceFile: ts.SourceFile,
+  decoratorName: string,
+  callback: (
+    classDeclarationNode: ts.ClassDeclaration,
+    decoratorExpressionNode: ts.ObjectLiteralExpression
+  ) => void
+) {
+  ts.forEachChild(sourceFile, function findClassDeclaration(node) {
+    if (!ts.isClassDeclaration(node)) {
+      ts.forEachChild(node, findClassDeclaration);
+    }
+
+    const classDeclarationNode = node as ts.ClassDeclaration;
+
+    if (
+      !classDeclarationNode.decorators ||
+      !classDeclarationNode.decorators.length
+    ) {
+      return;
+    }
+
+    const componentDecorator = classDeclarationNode.decorators.find(d => {
+      return (
+        ts.isCallExpression(d.expression) &&
+        ts.isIdentifier(d.expression.expression) &&
+        d.expression.expression.text === decoratorName
+      );
+    });
+
+    if (!componentDecorator) {
+      return;
+    }
+
+    const { expression } = componentDecorator;
+    if (!ts.isCallExpression(expression)) {
+      return;
+    }
+
+    const [arg] = expression.arguments;
+    if (!ts.isObjectLiteralExpression(arg)) {
+      return;
+    }
+
+    callback(classDeclarationNode, arg);
+  });
 }
 
 function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
@@ -41,32 +206,4 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
 
     yield* visit(directory.dir(path));
   }
-}
-
-export function visitNgModuleImports(
-  sourceFile: ts.SourceFile,
-  callback: (
-    importNode: ts.PropertyAssignment,
-    elementExpressions: ts.NodeArray<ts.Expression>
-  ) => void
-) {
-  ts.forEachChild(sourceFile, function findDecorator(node) {
-    if (!ts.isDecorator(node)) {
-      ts.forEachChild(node, findDecorator);
-      return;
-    }
-
-    ts.forEachChild(node, function findImportsNode(n) {
-      if (
-        ts.isPropertyAssignment(n) &&
-        ts.isArrayLiteralExpression(n.initializer) &&
-        ts.isIdentifier(n.name) &&
-        n.name.text === 'imports'
-      ) {
-        callback(n, n.initializer.elements);
-      }
-
-      ts.forEachChild(n, findImportsNode);
-    });
-  });
 }

--- a/modules/store/schematics-core/utility/visitors.ts
+++ b/modules/store/schematics-core/utility/visitors.ts
@@ -97,12 +97,33 @@ export function visitNgModuleImports(
     elementExpressions: ts.NodeArray<ts.Expression>
   ) => void
 ) {
+  visitNgModuleProperty(sourceFile, callback, 'imports');
+}
+
+export function visitNgModuleExports(
+  sourceFile: ts.SourceFile,
+  callback: (
+    exportNode: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void
+) {
+  visitNgModuleProperty(sourceFile, callback, 'exports');
+}
+
+function visitNgModuleProperty(
+  sourceFile: ts.SourceFile,
+  callback: (
+    nodes: ts.PropertyAssignment,
+    elementExpressions: ts.NodeArray<ts.Expression>
+  ) => void,
+  property: string
+) {
   visitNgModules(sourceFile, (_, decoratorExpressionNode) => {
     ts.forEachChild(decoratorExpressionNode, function findTemplates(n) {
       if (
         ts.isPropertyAssignment(n) &&
         ts.isIdentifier(n.name) &&
-        n.name.text === 'imports' &&
+        n.name.text === property &&
         ts.isArrayLiteralExpression(n.initializer)
       ) {
         callback(n, n.initializer.elements);
@@ -113,7 +134,6 @@ export function visitNgModuleImports(
     });
   });
 }
-
 export function visitComponents(
   sourceFile: ts.SourceFile,
   callback: (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes the first todo of #2450

## What is the new behavior?

This PR adds a `visitTemplates` method to schematics-core to find all templates (inline and as a file).
For the migration, it creates a  new  `ngrx-push-migration` schematic.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Implementation is inspired by angular material.


