### PR TITLE
docs(entity): use feature state for selectors

### DIFF
--- a/docs/entity/adapter.md
+++ b/docs/entity/adapter.md
@@ -265,27 +265,6 @@ export function reducer(state = initialState, action: UserActionsUnion): State {
   }
 }
 
-export const getSelectedUserId = (state: State) => state.selectedUserId;
-
-// get the selectors
-const {
-  selectIds,
-  selectEntities,
-  selectAll,
-  selectTotal,
-} = adapter.getSelectors();
-
-// select the array of user ids
-export const selectUserIds = selectIds;
-
-// select the dictionary of user entities
-export const selectUserEntities = selectEntities;
-
-// select the array of users
-export const selectAllUsers = selectAll;
-
-// select the total user count
-export const selectUserTotal = selectTotal;
 ```
 
 ### Entity Selectors
@@ -314,7 +293,34 @@ export const reducers: ActionReducerMap<State> = {
   users: fromUser.reducer,
 };
 
-export const selectUserState = createFeatureSelector<fromUser.State>('users');
+
+// get the feature state
+export const selectUserFeatureState = createFeatureSelector<State>('users');
+
+// pass the feature state to the user entity state
+expost const selectUserState = createSelector(selectUserFeatureState, (s: State) => s.users);
+
+export const getSelectedUserId = (state: fromUser.State) => state.selectedUserId;
+
+// pass the user entity state to the adapter and get the selectors
+const {
+  selectIds,
+  selectEntities,
+  selectAll,
+  selectTotal,
+} = fromUser.adapter.getSelectors(selectUserState);
+
+// select the array of user ids
+export const selectUserIds = selectIds;
+
+// select the dictionary of user entities
+export const selectUserEntities = selectEntities;
+
+// select the array of users
+export const selectAllUsers = selectAll;
+
+// select the total user count
+export const selectUserTotal = selectTotal;
 
 export const selectUserIds = createSelector(
   selectUserState,


### PR DESCRIPTION


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

In the current example, `adapter.getSelector()` is run first with empty parameters.
The feature state is defined later, using `createFeatureSelector<fromUser.State>`.
This is confusing and if using `StoreModule.forFeature`, the selectors won't work properly.

## What is the new behavior?

The new example distinguishes between feature state and entity state, and shows how to pass the feature state to the adapter when getting selectors.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

### Background:
I set up Entity using the example and I encountered this when I moved my global store to feature stores and my selectors stopped working.

These links helped me:
https://stackoverflow.com/questions/49966234/using-ngrx-entity-for-handling-collections-in-store-getselectors-not-working
https://stackoverflow.com/questions/50327196/selectall-from-ngrx-entity-doesnt-select-anything
