### PR TITLE
docs(router-store): add missing imports and export route selectors

### DIFF
--- a/projects/ngrx.io/content/guide/router-store/selectors.md
+++ b/projects/ngrx.io/content/guide/router-store/selectors.md
@@ -13,6 +13,7 @@ Usage:
 
 ```ts
 import * as fromRouter from '@ngrx/router-store';
+import { createSelector, createFeatureSelector } from '@ngrx/store';
 
 export interface State {
   router: fromRouter.RouterReducerState<any>;
@@ -23,7 +24,7 @@ export const selectRouter = createFeatureSelector<
   fromRouter.RouterReducerState<any>
 >('router');
 
-const {
+export const {
   selectCurrentRoute,   // select the current route
   selectQueryParams,    // select the current route query params
   selectQueryParam,     // factory function to select a query param


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When I copied and pasted the documentation sample for router selectors, I noticed some imports were missing. I also believe the `fromRouter.getSelectors` selectors such as `selectRouteParams` should be exported.

## What is the new behavior?

Copying and pasting the example now includes the right imports (aside from `selectCarEntities`, which isn't defined in the file). Selectors provided by `fromRouter.getSelectors` are now exported.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```