### PR TITLE
docs(entity): Call setAll instead of deprecated addAll

### DIFF
--- a/docs/entity/adapter.md
+++ b/docs/entity/adapter.md
@@ -252,7 +252,7 @@ export function reducer(state = initialState, action: UserActionsUnion): State {
     }
 
     case UserActionTypes.LOAD_USERS: {
-      return adapter.addAll(action.payload.users, state);
+      return adapter.setAll(action.payload.users, state);
     }
 
     case UserActionTypes.CLEAR_USERS: {

--- a/docs/entity/adapter.md
+++ b/docs/entity/adapter.md
@@ -252,7 +252,7 @@ export function reducer(state = initialState, action: UserActionsUnion): State {
     }
 
     case UserActionTypes.LOAD_USERS: {
-      return adapter.setAll(action.payload.users, state);
+      return adapter.addAll(action.payload.users, state);
     }
 
     case UserActionTypes.CLEAR_USERS: {

--- a/projects/ngrx.io/content/guide/entity/adapter.md
+++ b/projects/ngrx.io/content/guide/entity/adapter.md
@@ -181,7 +181,7 @@ const userReducer = createReducer(
     return adapter.removeMany(predicate, state);
   }),
   on(UserActions.loadUsers, (state, { users }) => {
-    return adapter.addAll(users, state);
+    return adapter.setAll(users, state);
   }),
   on(UserActions.clearUsers, state => {
     return adapter.removeAll({ ...state, selectedUserId: null });


### PR DESCRIPTION
It is indicated in the documentation that `addAll` has been deprecated in favor of `setAll`. In the reducer switch/case example, `addAll` was still being used instead of `setAll`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?
No behavioral changes as this fix only affects documentation. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
