### PR TITLE
docs(data): fix compilation errors in example

### DIFF
--- a/projects/ngrx.io/content/guide/data/extension-points.md
+++ b/projects/ngrx.io/content/guide/data/extension-points.md
@@ -182,8 +182,8 @@ import {
 
 @Injectable()
 export class PluralHttpUrlGenerator extends DefaultHttpUrlGenerator {
-  constructor(private pluralizer: Pluralizer) {
-    super(pluralizer);
+  constructor(private myPluralizer: Pluralizer) {
+    super(myPluralizer);
   }
 
   protected getResourceUrls(
@@ -193,7 +193,7 @@ export class PluralHttpUrlGenerator extends DefaultHttpUrlGenerator {
     let resourceUrls = this.knownHttpResourceUrls[entityName];
     if (!resourceUrls) {
       const nRoot = normalizeRoot(root);
-      const url = `${nRoot}/${this.pluralizzer.pluralize(
+      const url = `${nRoot}/${this.myPluralizer.pluralize(
         entityName
       )}/`.toLowerCase();
       resourceUrls = {


### PR DESCRIPTION
The example code for "Replace the HttpUrlGenerator" has two errors:

1. `pluralizer` is misspelled as `pluralizzer` once
2. `pluralizer` needs to be something else to avoid conflicting with the private `pluralizer` property in the parent.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Compilation errors in a documentation example

Closes #

## What is the new behavior?
Pasting the code into a project does not introduce a compilation error.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
