### PR TITLE
refactor(schematics): replace deprecated `TestBed.get`

### DIFF
--- a/modules/effects/schematics/ng-add/files/__name@dasherize@if-flat__/__name@dasherize__.effects.spec.ts.template
+++ b/modules/effects/schematics/ng-add/files/__name@dasherize@if-flat__/__name@dasherize__.effects.spec.ts.template
@@ -16,7 +16,7 @@ describe('<%= classify(name) %>Effects', () => {
       ]
     });
 
-    effects = TestBed.get<<%= classify(name) %>Effects>(<%= classify(name) %>Effects);
+    effects = TestBed.inject(<%= classify(name) %>Effects);
   });
 
   it('should be created', () => {

--- a/modules/effects/schematics/ng-add/index.spec.ts
+++ b/modules/effects/schematics/ng-add/index.spec.ts
@@ -224,7 +224,7 @@ describe('Effects ng-add Schematic', () => {
     );
 
     expect(content).toMatch(
-      /effects = TestBed\.get<FooEffects>\(FooEffects\);/
+      /effects = TestBed\.inject\(FooEffects\);/
     );
   });
 });

--- a/modules/schematics/src/container/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/modules/schematics/src/container/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -20,7 +20,7 @@ describe('<%= classify(name) %>Component', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Component);
     component = fixture.componentInstance;
-    store = TestBed.get<Store>(Store);
+    store = TestBed.inject(Store);
 
     fixture.detectChanges();
   });

--- a/modules/schematics/src/container/index.spec.ts
+++ b/modules/schematics/src/container/index.spec.ts
@@ -140,7 +140,7 @@ describe('Container Schematic', () => {
     const content = tree.readContent(
       `${projectPath}/src/app/foo/foo.component.spec.ts`
     );
-    expect(content).toMatch(/store = TestBed\.get<Store>\(Store\);/);
+    expect(content).toMatch(/store = TestBed\.inject\(Store\);/);
   });
 
   it('should use StoreModule if integration test', async () => {

--- a/modules/schematics/src/container/integration-files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/modules/schematics/src/container/integration-files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -20,7 +20,7 @@ describe('<%= classify(name) %>Component', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Component);
     component = fixture.componentInstance;
-    store = TestBed.get<Store>(Store);
+    store = TestBed.inject(Store);
 
     spyOn(store, 'dispatch').and.callThrough();
     fixture.detectChanges();

--- a/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.spec.ts.template
+++ b/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.spec.ts.template
@@ -16,7 +16,7 @@ describe('<%= classify(name) %>Effects', () => {
       ]
     });
 
-    effects = TestBed.get<<%= classify(name) %>Effects>(<%= classify(name) %>Effects);
+    effects = TestBed.inject(<%= classify(name) %>Effects);
   });
 
   it('should be created', () => {

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -418,7 +418,7 @@ describe('Effect Schematic', () => {
     );
 
     expect(content).toMatch(
-      /effects = TestBed\.get<FooEffects>\(FooEffects\);/
+      /effects = TestBed\.inject\(FooEffects\);/
     );
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The deprecated `TestBed.get` method is used in generated test suites.

Closes #2498

## What is the new behavior?

The strongly typed `TestBed.inject` method is used in generated test suites.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Cc @timdeschryver 