### PR TITLE
fix(schematics): use Angular default properties when not defined

### DIFF
--- a/modules/schematics/src/container/index.ts
+++ b/modules/schematics/src/container/index.ts
@@ -29,7 +29,7 @@ import {
 } from '@ngrx/schematics/schematics-core';
 import { Schema as ContainerOptions } from './schema';
 
-function addStateToComponent(options: ContainerOptions) {
+function addStateToComponent(options: Partial<ContainerOptions>) {
   return (host: Tree) => {
     if (!options.state && !options.stateInterface) {
       return host;
@@ -152,10 +152,15 @@ export default function(options: ContainerOptions): Rule {
       ]
     );
 
+    // Remove all undefined values to use the schematic defaults (in angular.json or the Angular schema)
+    (Object.keys(opts) as (keyof ContainerOptions)[]).forEach(
+      key => (opts[key] === undefined ? delete opts[key] : {})
+    );
+
     return chain([
       externalSchematic('@schematics/angular', 'component', {
         ...opts,
-        skipTests: true
+        skipTests: true,
       }),
       addStateToComponent(options),
       mergeWith(templateSource),

--- a/modules/schematics/src/container/schema.json
+++ b/modules/schematics/src/container/schema.json
@@ -27,13 +27,11 @@
     "inlineStyle": {
       "description": "Specifies if the style will be in the ts file.",
       "type": "boolean",
-      "default": false,
       "alias": "s"
     },
     "inlineTemplate": {
       "description": "Specifies if the template will be in the ts file.",
       "type": "boolean",
-      "default": false,
       "alias": "t"
     },
     "viewEncapsulation": {
@@ -46,7 +44,6 @@
       "description": "Specifies the change detection strategy.",
       "enum": ["Default", "OnPush"],
       "type": "string",
-      "default": "Default",
       "alias": "c"
     },
     "prefix": {
@@ -58,23 +55,19 @@
     "style": {
       "description":
         "The file extension or preprocessor to use for style files.",
-      "type": "string",
-      "default": "css"
+      "type": "string"
     },
     "skipTest": {
       "type": "boolean",
-      "description": "When true, does not create test files.",
-      "default": false
+      "description": "When true, does not create test files."
     },
     "flat": {
       "type": "boolean",
-      "description": "Flag to indicate if a dir is created.",
-      "default": false
+      "description": "Flag to indicate if a dir is created."
     },
     "skipImport": {
       "type": "boolean",
-      "description": "Flag to skip the module import.",
-      "default": false
+      "description": "Flag to skip the module import."
     },
     "selector": {
       "type": "string",
@@ -88,7 +81,6 @@
     },
     "export": {
       "type": "boolean",
-      "default": false,
       "description": "Specifies if declaring module exports the component."
     },
     "state": {

--- a/projects/ngrx.io/content/guide/schematics/index.md
+++ b/projects/ngrx.io/content/guide/schematics/index.md
@@ -4,7 +4,7 @@ Scaffolding library for Angular applications using NgRx libraries.
 
 Schematics provides Angular CLI commands for generating files when building new NgRx feature areas and expanding existing ones. Built on top of [`Schematics`](https://blog.angular.io/schematics-an-introduction-dc1dfbc2a2b2), this tool integrates with the [`Angular CLI`](https://cli.angular.io/).
 
-## Installation 
+## Installation
 
 Detailed installation instructions can be found on the [Installation](guide/schematics/install) page.
 
@@ -50,13 +50,3 @@ ng config cli.defaultCollection @ngrx/schematics
 ```
 
 The [collection schema](https://github.com/ngrx/platform/tree/master/modules/schematics/collection.json) also has aliases to the most common schematics used to generate files.
-
-The `@ngrx/schematics` extend the default `@schematics/angular` collection. If you want to set defaults for schematics such as generating components with scss file, you must change the schematics package name from `@schematics/angular` to `@ngrx/schematics` in `angular.json`:
-
-```json
-"schematics": {
-  "@ngrx/schematics:component": {
-    "style": "scss"
-  }
-}
-```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes [#1036(comment)](https://github.com/ngrx/platform/issues/1036#issuecomment-621728838)

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

By removing the default values in the schema, we can remove the undefined values before we pass them to the Angular component schematic. By doing this, Angular will replace the undefined values with the defaults set in `angular.json`. If no default value is provided in the `angular.json` file, it will use the defaults from the Angular schematic schema.

I tried to write a test for it but it seems like during the tests, the transformer isn't included. 