### PR TITLE
docs(entity): Use setAll instead of addAll in Adapter Collection Meth…

### DIFF
--- a/projects/ngrx.io/content/guide/entity/adapter.md
+++ b/projects/ngrx.io/content/guide/entity/adapter.md
@@ -85,7 +85,7 @@ state if no changes were made.
 
 - `addOne`: Add one entity to the collection
 - `addMany`: Add multiple entities to the collection
-- `addAll`: Replace current collection with provided collection
+- `setAll`: Replace current collection with provided collection
 - `setOne`: Add or Replace one entity in the collection
 - `removeOne`: Remove one entity from the collection
 - `removeMany`: Remove multiple entities from the collection, by id or by predicate


### PR DESCRIPTION
It is indicated in the documentation that `addAll` has been deprecated in favor of `setAll`. In the "Adapter Collection Methods" section, `addAll` was still being used instead of `setAll`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?
No behavioral changes as this fix only affects documentation. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
