### PR TITLE
feat(store): add runtime check for action type uniqueness

### DIFF
--- a/modules/effects/spec/types/utils.ts
+++ b/modules/effects/spec/types/utils.ts
@@ -1,6 +1,6 @@
 export const compilerOptions = () => ({
   moduleResolution: 'node',
-  target: 'es2015',
+  target: 'es2017',
   baseUrl: '.',
   experimentalDecorators: true,
   paths: {

--- a/modules/router-store/spec/types/utils.ts
+++ b/modules/router-store/spec/types/utils.ts
@@ -1,6 +1,6 @@
 export const compilerOptions = () => ({
   moduleResolution: 'node',
-  target: 'es2015',
+  target: 'es2017',
   baseUrl: '.',
   experimentalDecorators: true,
   paths: {

--- a/modules/store/spec/runtime_checks.spec.ts
+++ b/modules/store/spec/runtime_checks.spec.ts
@@ -423,19 +423,6 @@ describe('ActionType uniqueness', () => {
     }).not.toThrowError();
   });
 
-  it('should not register action types if devMode is false', () => {
-    spyOn(ngCore, 'isDevMode').and.returnValue(false);
-
-    createAction('action 1');
-    createAction('action 1');
-
-    expect(REGISTERED_ACTION_TYPES).toEqual({});
-
-    expect(() => {
-      setupStore({ strictActionTypeUniqueness: false });
-    }).not.toThrowError();
-  });
-
   it('should not throw when disabled', () => {
     createAction('action 1');
     createAction('action 1');

--- a/modules/store/spec/runtime_checks.spec.ts
+++ b/modules/store/spec/runtime_checks.spec.ts
@@ -10,7 +10,10 @@ import {
 import { createActiveRuntimeChecks } from '../src/runtime_checks';
 import { RuntimeChecks, Action } from '../src/models';
 import * as metaReducers from '../src/meta-reducers';
-import { REGISTERED_ACTION_TYPES } from '../src/globals';
+import {
+  REGISTERED_ACTION_TYPES,
+  resetRegisteredActionTypes,
+} from '../src/globals';
 
 describe('Runtime checks:', () => {
   describe('createActiveRuntimeChecks:', () => {
@@ -399,7 +402,7 @@ describe('Runtime checks:', () => {
 
 describe('ActionType uniqueness', () => {
   beforeEach(() => {
-    REGISTERED_ACTION_TYPES.length = 0;
+    resetRegisteredActionTypes();
   });
 
   it('should throw when having no duplicate action types', () => {
@@ -407,7 +410,7 @@ describe('ActionType uniqueness', () => {
     createAction('action 1');
 
     expect(() => {
-      const store = setupStore({ strictActionTypeUniqueness: true });
+      setupStore({ strictActionTypeUniqueness: true });
     }).toThrowError(/Action types are registered more than once/);
   });
 
@@ -416,7 +419,7 @@ describe('ActionType uniqueness', () => {
     createAction('action 2');
 
     expect(() => {
-      const store = setupStore({ strictActionTypeUniqueness: true });
+      setupStore({ strictActionTypeUniqueness: true });
     }).not.toThrowError();
   });
 
@@ -426,18 +429,19 @@ describe('ActionType uniqueness', () => {
     createAction('action 1');
     createAction('action 1');
 
-    expect(REGISTERED_ACTION_TYPES.length).toBe(0);
+    expect(REGISTERED_ACTION_TYPES).toEqual({});
 
     expect(() => {
-      const store = setupStore({ strictActionTypeUniqueness: false });
+      setupStore({ strictActionTypeUniqueness: false });
     }).not.toThrowError();
   });
 
   it('should not throw when disabled', () => {
     createAction('action 1');
     createAction('action 1');
+
     expect(() => {
-      const store = setupStore({ strictActionTypeUniqueness: false });
+      setupStore({ strictActionTypeUniqueness: false });
     }).not.toThrowError();
   });
 });

--- a/modules/store/spec/runtime_checks.spec.ts
+++ b/modules/store/spec/runtime_checks.spec.ts
@@ -164,7 +164,7 @@ describe('Runtime checks:', () => {
       let logs: string[] = [];
       function metaReducerFactory(logMessage: string) {
         return function metaReducer(reducer: any) {
-          return function(state: any, action: any) {
+          return function (state: any, action: any) {
             logs.push(logMessage);
             return reducer(state, action);
           };
@@ -208,41 +208,32 @@ describe('Runtime checks:', () => {
   describe('State Serialization:', () => {
     const invalidAction = () => ({ type: ErrorTypes.UnserializableState });
 
-    it(
-      'should throw when enabled',
-      fakeAsync(() => {
-        const store = setupStore({ strictStateSerializability: true });
+    it('should throw when enabled', fakeAsync(() => {
+      const store = setupStore({ strictStateSerializability: true });
 
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).toThrowError(/Detected unserializable state/);
-      })
-    );
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).toThrowError(/Detected unserializable state/);
+    }));
 
-    it(
-      'should not throw when disabled',
-      fakeAsync(() => {
-        const store = setupStore({ strictStateSerializability: false });
+    it('should not throw when disabled', fakeAsync(() => {
+      const store = setupStore({ strictStateSerializability: false });
 
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).not.toThrow();
-      })
-    );
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).not.toThrow();
+    }));
 
-    it(
-      'should not throw for NgRx actions',
-      fakeAsync(() => {
-        const store = setupStore({ strictStateSerializability: true });
+    it('should not throw for NgRx actions', fakeAsync(() => {
+      const store = setupStore({ strictStateSerializability: true });
 
-        expect(() => {
-          store.dispatch(makeNgrxAction(invalidAction()));
-          flush();
-        }).not.toThrow();
-      })
-    );
+      expect(() => {
+        store.dispatch(makeNgrxAction(invalidAction()));
+        flush();
+      }).not.toThrow();
+    }));
   });
 
   describe('Action Serialization:', () => {
@@ -251,29 +242,23 @@ describe('Runtime checks:', () => {
       invalid: new Date(),
     });
 
-    it(
-      'should throw when enabled',
-      fakeAsync(() => {
-        const store = setupStore({ strictActionSerializability: true });
+    it('should throw when enabled', fakeAsync(() => {
+      const store = setupStore({ strictActionSerializability: true });
 
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).toThrowError(/Detected unserializable action/);
-      })
-    );
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).toThrowError(/Detected unserializable action/);
+    }));
 
-    it(
-      'should not throw when disabled',
-      fakeAsync(() => {
-        const store = setupStore({ strictActionSerializability: false });
+    it('should not throw when disabled', fakeAsync(() => {
+      const store = setupStore({ strictActionSerializability: false });
 
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).not.toThrow();
-      })
-    );
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).not.toThrow();
+    }));
   });
 
   describe('State Mutations', () => {
@@ -281,29 +266,23 @@ describe('Runtime checks:', () => {
       type: ErrorTypes.MutateState,
     });
 
-    it(
-      'should throw when enabled',
-      fakeAsync(() => {
-        const store = setupStore({ strictStateImmutability: true });
+    it('should throw when enabled', fakeAsync(() => {
+      const store = setupStore({ strictStateImmutability: true });
 
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).toThrowError(/Cannot add property/);
-      })
-    );
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).toThrowError(/Cannot add property/);
+    }));
 
-    it(
-      'should not throw when disabled',
-      fakeAsync(() => {
-        const store = setupStore({ strictStateImmutability: false });
+    it('should not throw when disabled', fakeAsync(() => {
+      const store = setupStore({ strictStateImmutability: false });
 
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).not.toThrow();
-      })
-    );
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).not.toThrow();
+    }));
   });
 
   describe('Action Mutations', () => {
@@ -312,100 +291,83 @@ describe('Runtime checks:', () => {
       foo: 'foo',
     });
 
-    it(
-      'should throw when enabled',
-      fakeAsync(() => {
-        const store = setupStore({ strictActionImmutability: true });
+    it('should throw when enabled', fakeAsync(() => {
+      const store = setupStore({ strictActionImmutability: true });
 
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).toThrowError(/Cannot assign to read only property/);
-      })
-    );
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).toThrowError(/Cannot assign to read only property/);
+    }));
 
-    it(
-      'should not throw when disabled',
-      fakeAsync(() => {
-        const store = setupStore({ strictActionImmutability: false });
+    it('should not throw when disabled', fakeAsync(() => {
+      const store = setupStore({ strictActionImmutability: false });
 
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).not.toThrow();
-      })
-    );
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).not.toThrow();
+    }));
 
-    it(
-      'should not throw for NgRx actions',
-      fakeAsync(() => {
-        const store = setupStore({ strictActionImmutability: true });
+    it('should not throw for NgRx actions', fakeAsync(() => {
+      const store = setupStore({ strictActionImmutability: true });
 
-        expect(() => {
-          store.dispatch(makeNgrxAction(invalidAction()));
-          flush();
-        }).not.toThrow();
-      })
-    );
+      expect(() => {
+        store.dispatch(makeNgrxAction(invalidAction()));
+        flush();
+      }).not.toThrow();
+    }));
   });
 
   describe('Action in NgZone', () => {
     const invalidAction = () => ({ type: ErrorTypes.OutOfNgZoneAction });
 
-    it(
-      'should throw when running outside ngZone',
-      fakeAsync(() => {
-        ngCore.NgZone.isInAngularZone = jasmine
-          .createSpy('isInAngularZone')
-          .and.returnValue(false);
-        const store = setupStore({ strictActionWithinNgZone: true });
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).toThrowError(
-          "Action 'Action triggered outside of NgZone' running outside NgZone. https://ngrx.io/guide/store/configuration/runtime-checks#strictactionwithinngzone"
-        );
-      })
-    );
+    it('should throw when running outside ngZone', fakeAsync(() => {
+      ngCore.NgZone.isInAngularZone = jasmine
+        .createSpy('isInAngularZone')
+        .and.returnValue(false);
+      const store = setupStore({ strictActionWithinNgZone: true });
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).toThrowError(
+        "Action 'Action triggered outside of NgZone' running outside NgZone. https://ngrx.io/guide/store/configuration/runtime-checks#strictactionwithinngzone"
+      );
+    }));
 
-    it(
-      'should not throw when running in ngZone',
-      fakeAsync(() => {
-        ngCore.NgZone.isInAngularZone = jasmine
-          .createSpy('isInAngularZone')
-          .and.returnValue(true);
-        const store = setupStore({ strictActionWithinNgZone: true });
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).not.toThrowError();
+    it('should not throw when running in ngZone', fakeAsync(() => {
+      ngCore.NgZone.isInAngularZone = jasmine
+        .createSpy('isInAngularZone')
+        .and.returnValue(true);
+      const store = setupStore({ strictActionWithinNgZone: true });
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).not.toThrowError();
 
-        expect(ngCore.NgZone.isInAngularZone).toHaveBeenCalled();
-      })
-    );
+      expect(ngCore.NgZone.isInAngularZone).toHaveBeenCalled();
+    }));
 
-    it(
-      'should not be called when disabled',
-      fakeAsync(() => {
-        const store = setupStore({ strictActionWithinNgZone: false });
-        ngCore.NgZone.isInAngularZone = jasmine.createSpy('isInAngularZone');
-        expect(() => {
-          store.dispatch(invalidAction());
-          flush();
-        }).not.toThrow();
+    it('should not be called when disabled', fakeAsync(() => {
+      const store = setupStore({ strictActionWithinNgZone: false });
+      ngCore.NgZone.isInAngularZone = jasmine.createSpy('isInAngularZone');
+      expect(() => {
+        store.dispatch(invalidAction());
+        flush();
+      }).not.toThrow();
 
-        expect(ngCore.NgZone.isInAngularZone).not.toHaveBeenCalled();
-      })
-    );
+      expect(ngCore.NgZone.isInAngularZone).not.toHaveBeenCalled();
+    }));
   });
 });
 
 describe('ActionType uniqueness', () => {
   beforeEach(() => {
+    // Clear before each test because action types are registered during tests
     resetRegisteredActionTypes();
   });
 
-  it('should throw when having no duplicate action types', () => {
+  it('should throw when having duplicate action types', () => {
     createAction('action 1');
     createAction('action 1');
 

--- a/modules/store/spec/types/utils.ts
+++ b/modules/store/spec/types/utils.ts
@@ -1,6 +1,6 @@
 export const compilerOptions = () => ({
   moduleResolution: 'node',
-  target: 'es2015',
+  target: 'es2017',
   baseUrl: '.',
   experimentalDecorators: true,
   paths: {

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -104,7 +104,7 @@ export function createAction<T extends string, C extends Creator>(
   config?: { _as: 'props' } | C
 ): ActionCreator<T> {
   if (isDevMode()) {
-    REGISTERED_ACTION_TYPES.push(type);
+    REGISTERED_ACTION_TYPES[type] = (REGISTERED_ACTION_TYPES[type] || 0) + 1;
   }
 
   if (typeof config === 'function') {

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -6,7 +6,6 @@ import {
   NotAllowedCheck,
   Props,
 } from './models';
-import { isDevMode } from '@angular/core';
 import { REGISTERED_ACTION_TYPES } from './globals';
 
 // Action creators taken from ts-action library and modified a bit to better
@@ -103,9 +102,7 @@ export function createAction<T extends string, C extends Creator>(
   type: T,
   config?: { _as: 'props' } | C
 ): ActionCreator<T> {
-  if (isDevMode()) {
-    REGISTERED_ACTION_TYPES[type] = (REGISTERED_ACTION_TYPES[type] || 0) + 1;
-  }
+  REGISTERED_ACTION_TYPES[type] = (REGISTERED_ACTION_TYPES[type] || 0) + 1;
 
   if (typeof config === 'function') {
     return defineType(type, (...args: any[]) => ({

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -6,6 +6,8 @@ import {
   NotAllowedCheck,
   Props,
 } from './models';
+import { isDevMode } from '@angular/core';
+import { REGISTERED_ACTION_TYPES } from './globals';
 
 // Action creators taken from ts-action library and modified a bit to better
 // fit current NgRx usage. Thank you Nicholas Jamieson (@cartant).
@@ -101,6 +103,10 @@ export function createAction<T extends string, C extends Creator>(
   type: T,
   config?: { _as: 'props' } | C
 ): ActionCreator<T> {
+  if (isDevMode()) {
+    REGISTERED_ACTION_TYPES.push(type);
+  }
+
   if (typeof config === 'function') {
     return defineType(type, (...args: any[]) => ({
       ...config(...args),

--- a/modules/store/src/globals.ts
+++ b/modules/store/src/globals.ts
@@ -1,1 +1,5 @@
-export let REGISTERED_ACTION_TYPES: string[] = [];
+export let REGISTERED_ACTION_TYPES: { [actionType: string]: number } = {};
+
+export function resetRegisteredActionTypes() {
+  REGISTERED_ACTION_TYPES = {};
+}

--- a/modules/store/src/globals.ts
+++ b/modules/store/src/globals.ts
@@ -1,0 +1,1 @@
+export let REGISTERED_ACTION_TYPES: string[] = [];

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -120,4 +120,9 @@ export interface RuntimeChecks {
    * Verifies that actions are dispatched within NgZone
    */
   strictActionWithinNgZone: boolean;
+
+  /**
+   * Verifies that action types are not registered more than once
+   */
+  strictActionTypeUniqueness: boolean;
 }

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -24,7 +24,7 @@ export interface ActionReducer<T, V extends Action = Action> {
 }
 
 export type ActionReducerMap<T, V extends Action = Action> = {
-  [p in keyof T]: ActionReducer<T[p], V>
+  [p in keyof T]: ActionReducer<T[p], V>;
 };
 
 export interface ActionReducerFactory<T, V extends Action = Action> {
@@ -75,7 +75,9 @@ export type Creator<
 
 export type NotAllowedCheck<T extends object> = T extends any[]
   ? ArraysAreNotAllowed
-  : T extends { type: any } ? TypePropertyIsNotAllowed : unknown;
+  : T extends { type: any }
+  ? TypePropertyIsNotAllowed
+  : unknown;
 
 /**
  * See `Creator`.
@@ -124,5 +126,5 @@ export interface RuntimeChecks {
   /**
    * Verifies that action types are not registered more than once
    */
-  strictActionTypeUniqueness: boolean;
+  strictActionTypeUniqueness?: boolean;
 }

--- a/modules/store/src/runtime_checks.ts
+++ b/modules/store/src/runtime_checks.ts
@@ -145,9 +145,9 @@ export function _actionTypeUniquenessCheck(config: RuntimeChecks) {
     return;
   }
 
-  const duplicates = REGISTERED_ACTION_TYPES.filter(
-    (type, index, arr) => arr.indexOf(type) !== index
-  );
+  const duplicates = Object.entries(REGISTERED_ACTION_TYPES)
+    .filter(([_type, registrations]) => registrations > 1)
+    .map(([type]) => type);
 
   if (duplicates.length) {
     throw new Error(

--- a/modules/store/src/runtime_checks.ts
+++ b/modules/store/src/runtime_checks.ts
@@ -44,10 +44,10 @@ export function createSerializationCheckMetaReducer({
   strictActionSerializability,
   strictStateSerializability,
 }: RuntimeChecks): MetaReducer {
-  return reducer =>
+  return (reducer) =>
     strictActionSerializability || strictStateSerializability
       ? serializationCheckMetaReducer(reducer, {
-          action: action =>
+          action: (action) =>
             strictActionSerializability && !ignoreNgrxAction(action),
           state: () => strictStateSerializability,
         })
@@ -58,10 +58,10 @@ export function createImmutabilityCheckMetaReducer({
   strictActionImmutability,
   strictStateImmutability,
 }: RuntimeChecks): MetaReducer {
-  return reducer =>
+  return (reducer) =>
     strictActionImmutability || strictStateImmutability
       ? immutabilityCheckMetaReducer(reducer, {
-          action: action =>
+          action: (action) =>
             strictActionImmutability && !ignoreNgrxAction(action),
           state: () => strictStateImmutability,
         })
@@ -75,10 +75,10 @@ function ignoreNgrxAction(action: Action) {
 export function createInNgZoneCheckMetaReducer({
   strictActionWithinNgZone,
 }: RuntimeChecks): MetaReducer {
-  return reducer =>
+  return (reducer) =>
     strictActionWithinNgZone
       ? inNgZoneAssertMetaReducer(reducer, {
-          action: action =>
+          action: (action) =>
             strictActionWithinNgZone && !ignoreNgrxAction(action),
         })
       : reducer;
@@ -140,19 +140,19 @@ export function _runtimeChecksFactory(
   return runtimeChecks;
 }
 
-export function _actionTypeUniquenessCheck(config: RuntimeChecks) {
+export function _actionTypeUniquenessCheck(config: RuntimeChecks): void {
   if (!config.strictActionTypeUniqueness) {
     return;
   }
 
   const duplicates = Object.entries(REGISTERED_ACTION_TYPES)
-    .filter(([_type, registrations]) => registrations > 1)
+    .filter(([, registrations]) => registrations > 1)
     .map(([type]) => type);
 
   if (duplicates.length) {
     throw new Error(
       `Action types are registered more than once, ${duplicates
-        .map(type => `"${type}"`)
+        .map((type) => `"${type}"`)
         .join(', ')}. ${RUNTIME_CHECK_URL}#strictactiontypeuniqueness`
     );
   }

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -37,6 +37,8 @@ import {
   USER_PROVIDED_META_REDUCERS,
   _RESOLVED_META_REDUCERS,
   _ROOT_STORE_GUARD,
+  _ACTIVE_RUNTIME_CHECKS,
+  _ACTION_TYPE_UNIQUENESS_CHECK,
 } from './tokens';
 import { ACTIONS_SUBJECT_PROVIDERS, ActionsSubject } from './actions_subject';
 import {
@@ -50,7 +52,10 @@ import {
 } from './scanned_actions_subject';
 import { STATE_PROVIDERS } from './state';
 import { STORE_PROVIDERS, Store } from './store';
-import { provideRuntimeChecks } from './runtime_checks';
+import {
+  provideRuntimeChecks,
+  checkForActionTypeUniqueness,
+} from './runtime_checks';
 
 @NgModule({})
 export class StoreRootModule {
@@ -61,7 +66,10 @@ export class StoreRootModule {
     store: Store<any>,
     @Optional()
     @Inject(_ROOT_STORE_GUARD)
-    guard: any
+    guard: any,
+    @Optional()
+    @Inject(_ACTION_TYPE_UNIQUENESS_CHECK)
+    actionCheck: any
   ) {}
 }
 
@@ -71,7 +79,10 @@ export class StoreFeatureModule implements OnDestroy {
     @Inject(_STORE_FEATURES) private features: StoreFeature<any, any>[],
     @Inject(FEATURE_REDUCERS) private featureReducers: ActionReducerMap<any>[],
     private reducerManager: ReducerManager,
-    root: StoreRootModule
+    root: StoreRootModule,
+    @Optional()
+    @Inject(_ACTION_TYPE_UNIQUENESS_CHECK)
+    actionCheck: any
   ) {
     const feats = features.map((feature, index) => {
       const featureReducerCollection = featureReducers.shift();
@@ -166,6 +177,7 @@ export class StoreModule {
         STATE_PROVIDERS,
         STORE_PROVIDERS,
         provideRuntimeChecks(config.runtimeChecks),
+        checkForActionTypeUniqueness(),
       ],
     };
   }
@@ -238,6 +250,7 @@ export class StoreModule {
           ],
           useFactory: _createFeatureReducers,
         },
+        checkForActionTypeUniqueness(),
       ],
     };
   }

--- a/modules/store/src/tokens.ts
+++ b/modules/store/src/tokens.ts
@@ -86,3 +86,7 @@ export const _USER_RUNTIME_CHECKS = new InjectionToken<RuntimeChecks>(
 export const _ACTIVE_RUNTIME_CHECKS = new InjectionToken<RuntimeChecks>(
   '@ngrx/store Internal Runtime Checks'
 );
+
+export const _ACTION_TYPE_UNIQUENESS_CHECK = new InjectionToken<void>(
+  '@ngrx/store Check if Action types are unique'
+);

--- a/projects/example-app/src/app/app.module.ts
+++ b/projects/example-app/src/app/app.module.ts
@@ -41,6 +41,7 @@ import { AppComponent } from '@example-app/core/containers';
         strictStateSerializability: true,
         strictActionSerializability: true,
         strictActionWithinNgZone: true,
+        strictActionTypeUniqueness: true,
       },
     }),
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features) 

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently there is no way to warn devs when there are multiple actions with the same action type.
I've seen that this might lead to some confusion and some debugging time to spot the cause of a bug. 

The most recent one, https://twitter.com/FabianGosebrink/status/1259043401724542978

The ngrx-tslint-rules has a TSLint rule to spot these, but not many people know that this exists.

What if we create a runtime check for it?

## What is the new behavior?

In the PR, you see that action types are registered in a global array while the action is instantiated with `createAction`. When a store module is loaded, we can perform a check to see if there are duplicates in this array, and throw an error if there are.

This new feature is by default disabled, but can be enabled with the `strictActionTypeUniqueness` runtime check flag.

Thoughts?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
