### PR TITLE
fix(component-store): export EffectReturnFn interface

### DIFF
--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -22,7 +22,7 @@ import { debounceSync } from './debounceSync';
  * Return type of the effect, that behaves differently based on whether the
  * argument is passed to the callback.
  */
-interface EffectReturnFn<T> {
+export interface EffectReturnFn<T> {
   (): void;
   (t: T | Observable<T>): Subscription;
 }
@@ -36,7 +36,7 @@ export class ComponentStore<T extends object> {
   private readonly stateSubject$ = new ReplaySubject<T>(1);
   private isInitialized = false;
   // Needs to be after destroy$ is declared because it's used in select.
-  readonly state$: Observable<T> = this.select(s => s);
+  readonly state$: Observable<T> = this.select((s) => s);
 
   constructor(defaultState?: T) {
     // State can be initialized either through constructor, or initState or
@@ -80,14 +80,13 @@ export class ComponentStore<T extends object> {
         : of(observableOrValue);
       const subscription = observable$
         .pipe(
-          concatMap(
-            value =>
-              this.isInitialized
-                ? of(value).pipe(withLatestFrom(this.stateSubject$))
-                : // If state was not initialized, we'll throw an error.
-                  throwError(
-                    Error(`${this.constructor.name} has not been initialized`)
-                  )
+          concatMap((value) =>
+            this.isInitialized
+              ? of(value).pipe(withLatestFrom(this.stateSubject$))
+              : // If state was not initialized, we'll throw an error.
+                throwError(
+                  Error(`${this.constructor.name} has not been initialized`)
+                )
           ),
           takeUntil(this.destroy$)
         )
@@ -95,7 +94,7 @@ export class ComponentStore<T extends object> {
           next: ([value, currentState]) => {
             this.stateSubject$.next(updaterFn(currentState, value!));
           },
-          error: error => {
+          error: (error) => {
             initializationError = error;
             this.stateSubject$.error(error);
           },
@@ -211,7 +210,7 @@ export class ComponentStore<T extends object> {
       const observable$ = isObservable(observableOrValue)
         ? observableOrValue
         : of(observableOrValue);
-      return observable$.pipe(takeUntil(this.destroy$)).subscribe(value => {
+      return observable$.pipe(takeUntil(this.destroy$)).subscribe((value) => {
         // any new 👇 value is pushed into a stream
         origin$.next(value);
       });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Export `EffectReturnFn` as well, otherwise we get an error:
```sh
error TS4029: Public property 'effectName' of exported class has or is using name 'EffectReturnFn' from external module "path/to/ngrx/modules/component-store/src/component-store" but cannot be named
```

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
