### PR TITLE
refactor: assert value for RxJS v7 compatibility

### DIFF
--- a/modules/store/src/state.ts
+++ b/modules/store/src/state.ts
@@ -32,9 +32,10 @@ export class State<T> extends BehaviorSubject<any> implements OnDestroy {
     const actionsOnQueue$: Observable<Action> = actions$.pipe(
       observeOn(queueScheduler)
     );
-    const withLatestReducer$: Observable<
-      [Action, ActionReducer<any, Action>]
-    > = actionsOnQueue$.pipe(withLatestFrom(reducer$));
+    const withLatestReducer$: Observable<[
+      Action,
+      ActionReducer<any, Action>
+    ]> = actionsOnQueue$.pipe(withLatestFrom(reducer$));
 
     const seed: StateActionPair<T> = { state: initialState };
     const stateAndAction$: Observable<{
@@ -49,7 +50,7 @@ export class State<T> extends BehaviorSubject<any> implements OnDestroy {
 
     this.stateSubscription = stateAndAction$.subscribe(({ state, action }) => {
       this.next(state);
-      scannedActions.next(action);
+      scannedActions.next(action!);
     });
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Value of type `T|undefined` is passed as the next value of `ScannedActionsSubject`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Value is asserted to type `T`. See "other information" section for context.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
In RxJS v7, the type of `Subject.next()` will change from `next(value?: T)` to `next(value: T)` ([change](https://github.com/ReactiveX/rxjs/commit/33561526d2c893fdb2a7c5552a3c86806cb0e9a9#diff-54b18fdea0a03178c258be326d16f566L61)). No runtime behavior is affected, but this change will break NgRx users who build from source. This PR asserts the value to `T` so projects will build successfully.