### PR TITLE
fix(entity): remove ComparerStr

### DIFF
--- a/modules/data/spec/entity-metadata/entity-definition.spec.ts
+++ b/modules/data/spec/entity-metadata/entity-definition.spec.ts
@@ -10,7 +10,7 @@ interface NonIdClass {
   something: any;
 }
 
-const sorter = <T>(a: T, b: T) => 'foo';
+const sorter = <T>(a: T, b: T) => 1;
 
 const filter = <T>(entities: T[], pattern?: any) => entities;
 

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -1,7 +1,4 @@
-export type ComparerStr<T> = (a: T, b: T) => string;
-export type ComparerNum<T> = (a: T, b: T) => number;
-
-export type Comparer<T> = ComparerNum<T> | ComparerStr<T>;
+export type Comparer<T> = (a: T, b: T) => number;
 
 export type IdSelectorStr<T> = (model: T) => string;
 export type IdSelectorNum<T> = (model: T) => number;


### PR DESCRIPTION
The compare function is used in two places, neither of which expect it to be able to return a string:
The [first caller](https://github.com/ngrx/platform/blob/master/modules/entity/src/sorted_state_adapter.ts#L174) is the [Array prototype sort function](https://www.w3schools.com/js/js_array_sort.asp), and there it "should return a negative, zero, or positive value, depending on the arguments".
The [second caller](https://github.com/ngrx/platform/blob/master/modules/entity/src/sorted_state_adapter.ts#L187) does a numerical comparison with the result.

Even though an id can be a string, the result of a comparison shouldn't be.

This might be a breaking change.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

According to the typing, a sortComparer can return a string, but it would be a mistake to allow that. Even though an id can be a string, the result of a comparison shouldn't be.

Closes #

## What is the new behavior?

Remove the ComparerStr option for Comparar.

## Does this PR introduce a breaking change?

```
[x ] Yes
[ ] No
```

Functions that return a string instead of a number would not compile. The user would need to fix the comparer.

## Other information
