### PR TITLE
docs(component-store): fix movies$ observable assignment

### DIFF
--- a/projects/ngrx.io/content/guide/component-store/index.md
+++ b/projects/ngrx.io/content/guide/component-store/index.md
@@ -34,7 +34,7 @@ ComponentStore can be initialized in 2 ways:
   providers: [ComponentStore],
 })
 export class MoviesPageComponent {
-  movies$: this.componentStore.state$.pipe(
+  movies$ = this.componentStore.state$.pipe(
     map(state => state.movies),
   );
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

No changes in the behaviour, just a tiny doc change. The assignment of the `movie$` observable was made as a type definition `movie$: this.store....`, but should be `movie$ = this.store...`.

## What is the new behavior?

The assignment is made as `movie$ = this.store...`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
