### PR TITLE
fix(router-store): also handle routerNavigated action in reducer

### DIFF
--- a/modules/router-store/spec/integration.spec.ts
+++ b/modules/router-store/spec/integration.spec.ts
@@ -491,7 +491,7 @@ describe('integration spec', () => {
           { type: 'router', event: 'GuardsCheckEnd', url: '/next' },
           { type: 'router', event: 'ResolveStart', url: '/next' },
           { type: 'router', event: 'ResolveEnd', url: '/next' },
-          { type: 'store', state: null }, // ROUTER_NAVIGATED event in the store
+          { type: 'store', state: { url: '/next', navigationId: 2 } }, // ROUTER_NAVIGATED event in the store
           { type: 'action', action: ROUTER_NAVIGATED },
           { type: 'router', event: 'NavigationEnd', url: '/next' },
         ]);
@@ -699,7 +699,14 @@ describe('integration spec', () => {
           { type: 'router', event: 'GuardsCheckEnd', url: '/next' },
           { type: 'router', event: 'ResolveStart', url: '/next' },
           { type: 'router', event: 'ResolveEnd', url: '/next' },
-          { type: 'store', state: null }, // ROUTER_NAVIGATED event in the store
+          {
+            type: 'store',
+            state: {
+              url: '/next-custom',
+              navigationId: 2,
+              params: { test: 1 },
+            },
+          }, // ROUTER_NAVIGATED event in the store
           { type: 'action', action: ROUTER_NAVIGATED },
           { type: 'router', event: 'NavigationEnd', url: '/next' },
         ]);

--- a/modules/router-store/spec/router_store_module.spec.ts
+++ b/modules/router-store/spec/router_store_module.spec.ts
@@ -66,7 +66,7 @@ describe('Router Store Module', () => {
           storeRouterConnectingModule
         )).navigateIfNeeded.calls.allArgs();
 
-        expect(actual.length).toBe(1);
+        expect(actual.length).toBe(2);
         expect(actual[0]).toEqual(logs[0]);
         done();
       });
@@ -127,7 +127,7 @@ describe('Router Store Module', () => {
           storeRouterConnectingModule
         )).navigateIfNeeded.calls.allArgs();
 
-        expect(actual.length).toBe(1);
+        expect(actual.length).toBe(2);
         expect(actual[0]).toEqual(logs[0]);
         done();
       });

--- a/modules/router-store/src/reducer.ts
+++ b/modules/router-store/src/reducer.ts
@@ -2,6 +2,7 @@ import { Action } from '@ngrx/store';
 import {
   ROUTER_CANCEL,
   ROUTER_ERROR,
+  ROUTER_NAVIGATED,
   ROUTER_NAVIGATION,
   RouterAction,
 } from './actions';
@@ -27,6 +28,7 @@ export function routerReducer<
     case ROUTER_NAVIGATION:
     case ROUTER_ERROR:
     case ROUTER_CANCEL:
+    case ROUTER_NAVIGATED:
       return {
         state: routerAction.payload.routerState,
         navigationId: routerAction.payload.event.id,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

I wanted to use a Resolver to set a data field on a lazy-loaded route and then later on select the data (which we are mapping with a custom router serializer) from the store. I could trace that the custom serializer was called correctly two times (routerNavigation and routerNavigated actions), but the second serialization was not triggering a store modification. And only the second serialization was containing the data field I had on the lazy-loaded route.

tl;dr: the routerNavigated action has the serialized routerState as payload, but it is not persisted in the store.

## What is the new behavior?

routerNavigated actions are handled by the routerReducer.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No?
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

If you want, I can try to provide a minimal error example. Please tell.