### PR TITLE
feat(component-store): remove queueScheduler

### DIFF
--- a/modules/component-store/spec/integration.spec.ts
+++ b/modules/component-store/spec/integration.spec.ts
@@ -70,6 +70,19 @@ describe('ComponentStore integration', () => {
       state.destroy();
     }));
 
+    it('updates the same property immediately', fakeAsync(() => {
+      state!.child.init();
+
+      state!.child.updateProp('new value'); // no flushing in between
+      state!.child.updateProp('yay!!!');
+      flushMicrotasks();
+
+      expect(state!.propChanges).toEqual(['yay!!!']);
+
+      // clear "Periodic timers in queue"
+      state.destroy();
+    }));
+
     it('stops observables when destroyed', fakeAsync(() => {
       state.child.init();
 

--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -7,8 +7,6 @@ import {
   throwError,
   combineLatest,
   Subject,
-  queueScheduler,
-  scheduled,
 } from 'rxjs';
 import {
   concatMap,
@@ -93,10 +91,7 @@ export class ComponentStore<T extends object> implements OnDestroy {
         .pipe(
           concatMap((value) =>
             this.isInitialized
-              ? // Push the value into queueScheduler
-                scheduled([value], queueScheduler).pipe(
-                  withLatestFrom(this.stateSubject$)
-                )
+              ? of(value).pipe(withLatestFrom(this.stateSubject$))
               : // If state was not initialized, we'll throw an error.
                 throwError(
                   Error(`${this.constructor.name} has not been initialized`)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

So one thing that I wasn't particularly happy is that "initialState" was always emitted (if it was set), even when we have `setState` to something else synchronously (or within the same macrotask).

Removing the `queueScheduler` "fixes" that.

Why it shouldn't matter for selectors? Selectors for both single values, like `select(state => state.prop)` and for combinations like `select(a$,b$, (a, b) => a + b)` are already using `debounceSync()` meaning their values would be emitted in the next microtask, so it shouldn't matter that updaters are pushing the updates synchronously (moreover, I think it's actually a preferred way).

So what do we have as a result?
What I think we have is that all the values are pushed to componentStore synchronously (with both `setState` and imperative `updater`) and update according to the order as they were provided/called, and then they are all emitted asynchronously through selectors (of both kinds).

What other changes we might need to do?
- we might need to push `effects` to `asapScheduler`? I'll experiment with that.
- exposing the imperative read from ComponentStore might be useful when the User wants to synchronously read the data from ComponentStore immediately after the *update*.

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
