### PR TITLE
feat(component-store): add imperative reads

### DIFF
--- a/modules/component-store/spec/component-store.spec.ts
+++ b/modules/component-store/spec/component-store.spec.ts
@@ -15,7 +15,6 @@ import {
   map,
   tap,
   finalize,
-  observeOn,
 } from 'rxjs/operators';
 
 describe('Component Store', () => {
@@ -1219,6 +1218,48 @@ describe('Component Store', () => {
 
         jest.advanceTimersByTime(20);
       });
+    });
+  });
+
+  describe('get', () => {
+    interface State {
+      value: string;
+    }
+
+    class ExposedGetComponentStore extends ComponentStore<State> {
+      get = super.get;
+    }
+
+    let componentStore: ExposedGetComponentStore;
+
+    it('throws an Error if called before the state is initialized', () => {
+      componentStore = new ExposedGetComponentStore();
+
+      expect(() => {
+        componentStore.get((state) => state.value);
+      }).toThrow(
+        new Error('ExposedGetComponentStore has not been initialized')
+      );
+    });
+
+    it('does not throw an Error when initialized', () => {
+      componentStore = new ExposedGetComponentStore();
+      componentStore.setState({ value: 'init' });
+
+      expect(() => {
+        componentStore.get((state) => state.value);
+      }).not.toThrow();
+    });
+
+    it('provides values from the state', () => {
+      componentStore = new ExposedGetComponentStore();
+      componentStore.setState({ value: 'init' });
+
+      expect(componentStore.get((state) => state.value)).toBe('init');
+
+      componentStore.updater((state, value: string) => ({ value }))('updated');
+
+      expect(componentStore.get((state) => state.value)).toBe('updated');
     });
   });
 });

--- a/modules/component-store/spec/component-store.spec.ts
+++ b/modules/component-store/spec/component-store.spec.ts
@@ -62,12 +62,24 @@ describe('Component Store', () => {
         const componentStore = new ComponentStore();
 
         m.expect(componentStore.state$).toBeObservable(
-          m.hot('#', {}, new Error('ComponentStore has not been initialized'))
+          m.hot(
+            '#',
+            {},
+            new Error(
+              'ComponentStore has not been initialized yet. ' +
+                'Please make sure it is initialized before updating/getting.'
+            )
+          )
         );
 
         expect(() => {
           componentStore.setState(() => ({ setState: 'new state' }));
-        }).toThrow(new Error('ComponentStore has not been initialized'));
+        }).toThrow(
+          new Error(
+            'ComponentStore has not been initialized yet. ' +
+              'Please make sure it is initialized before updating/getting.'
+          )
+        );
       })
     );
 
@@ -77,14 +89,26 @@ describe('Component Store', () => {
         const componentStore = new ComponentStore();
 
         m.expect(componentStore.state$).toBeObservable(
-          m.hot('#', {}, new Error('ComponentStore has not been initialized'))
+          m.hot(
+            '#',
+            {},
+            new Error(
+              'ComponentStore has not been initialized yet. ' +
+                'Please make sure it is initialized before updating/getting.'
+            )
+          )
         );
 
         expect(() => {
           componentStore.updater((state, value: object) => value)({
             updater: 'new state',
           });
-        }).toThrow(new Error('ComponentStore has not been initialized'));
+        }).toThrow(
+          new Error(
+            'ComponentStore has not been initialized yet. ' +
+              'Please make sure it is initialized before updating/getting.'
+          )
+        );
       })
     );
 
@@ -98,14 +122,26 @@ describe('Component Store', () => {
         });
 
         m.expect(componentStore.state$).toBeObservable(
-          m.hot('#', {}, new Error('ComponentStore has not been initialized'))
+          m.hot(
+            '#',
+            {},
+            new Error(
+              'ComponentStore has not been initialized yet. ' +
+                'Please make sure it is initialized before updating/getting.'
+            )
+          )
         );
 
         expect(() => {
           componentStore.updater<object>((state, value) => value)(
             syncronousObservable$
           );
-        }).toThrow(new Error('ComponentStore has not been initialized'));
+        }).toThrow(
+          new Error(
+            'ComponentStore has not been initialized yet. ' +
+              'Please make sure it is initialized before updating/getting.'
+          )
+        );
       })
     );
 
@@ -122,7 +158,14 @@ describe('Component Store', () => {
         let subscription: Subscription | undefined;
 
         m.expect(componentStore.state$).toBeObservable(
-          m.hot('-#', {}, new Error('ComponentStore has not been initialized'))
+          m.hot(
+            '-#',
+            {},
+            new Error(
+              'ComponentStore has not been initialized yet. ' +
+                'Please make sure it is initialized before updating/getting.'
+            )
+          )
         );
 
         expect(() => {
@@ -1238,7 +1281,10 @@ describe('Component Store', () => {
       expect(() => {
         componentStore.get((state) => state.value);
       }).toThrow(
-        new Error('ExposedGetComponentStore has not been initialized')
+        new Error(
+          'ExposedGetComponentStore has not been initialized yet. ' +
+            'Please make sure it is initialized before updating/getting.'
+        )
       );
     });
 
@@ -1260,6 +1306,17 @@ describe('Component Store', () => {
       componentStore.updater((state, value: string) => ({ value }))('updated');
 
       expect(componentStore.get((state) => state.value)).toBe('updated');
+    });
+
+    it('provides the entire state when projector fn is not provided', () => {
+      componentStore = new ExposedGetComponentStore();
+      componentStore.setState({ value: 'init' });
+
+      expect(componentStore.get()).toEqual({ value: 'init' });
+
+      componentStore.updater((state, value: string) => ({ value }))('updated');
+
+      expect(componentStore.get()).toEqual({ value: 'updated' });
     });
   });
 });

--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -17,6 +17,7 @@ import {
   map,
   distinctUntilChanged,
   shareReplay,
+  take,
 } from 'rxjs/operators';
 import { debounceSync } from './debounce-sync';
 import {
@@ -51,6 +52,7 @@ export class ComponentStore<T extends object> implements OnDestroy {
 
   private readonly stateSubject$ = new ReplaySubject<T>(1);
   private isInitialized = false;
+  private notInitializedErrorMessage = `${this.constructor.name} has not been initialized`;
   // Needs to be after destroy$ is declared because it's used in select.
   readonly state$: Observable<T> = this.select((s) => s);
 
@@ -102,9 +104,7 @@ export class ComponentStore<T extends object> implements OnDestroy {
                   withLatestFrom(this.stateSubject$)
                 )
               : // If state was not initialized, we'll throw an error.
-                throwError(
-                  new Error(`${this.constructor.name} has not been initialized`)
-                )
+                throwError(new Error(this.notInitializedErrorMessage))
           ),
           takeUntil(this.destroy$)
         )
@@ -150,6 +150,17 @@ export class ComponentStore<T extends object> implements OnDestroy {
     } else {
       this.updater(stateOrUpdaterFn as (state: T) => T)();
     }
+  }
+
+  protected get<R>(projector: (s: T) => R): R {
+    if (!this.isInitialized) {
+      throw new Error(this.notInitializedErrorMessage);
+    }
+    let value: R;
+    this.stateSubject$.pipe(take(1)).subscribe((state) => {
+      value = projector(state);
+    });
+    return value!;
   }
 
   /**

--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -52,7 +52,9 @@ export class ComponentStore<T extends object> implements OnDestroy {
 
   private readonly stateSubject$ = new ReplaySubject<T>(1);
   private isInitialized = false;
-  private notInitializedErrorMessage = `${this.constructor.name} has not been initialized`;
+  private notInitializedErrorMessage =
+    `${this.constructor.name} has not been initialized yet. ` +
+    `Please make sure it is initialized before updating/getting.`;
   // Needs to be after destroy$ is declared because it's used in select.
   readonly state$: Observable<T> = this.select((s) => s);
 
@@ -152,13 +154,16 @@ export class ComponentStore<T extends object> implements OnDestroy {
     }
   }
 
-  protected get<R>(projector: (s: T) => R): R {
+  protected get(): T;
+  protected get<R>(projector: (s: T) => R): R;
+  protected get<R>(projector?: (s: T) => R): R | T {
     if (!this.isInitialized) {
       throw new Error(this.notInitializedErrorMessage);
     }
-    let value: R;
+    let value: R | T;
+
     this.stateSubject$.pipe(take(1)).subscribe((state) => {
-      value = projector(state);
+      value = projector ? projector(state) : state;
     });
     return value!;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Add ability to read from `ComponentStore` imperatively.
It is set as `protected` to encourage its usage to be limited within a `*Store` that extends `ComponentStore` - and would contain all the business logic needed. Moreover, it's recommended to use `get` only within `effects`.

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
