### PR TITLE
docs: make runtime checks' header sections consistent

### DIFF
--- a/projects/ngrx.io/content/guide/store/configuration/runtime-checks.md
+++ b/projects/ngrx.io/content/guide/store/configuration/runtime-checks.md
@@ -213,7 +213,7 @@ function callbackOutsideNgZone(){
 }
 ```
 
-## strictActionTypeUniqueness
+### strictActionTypeUniqueness
 
 The `strictActionTypeUniqueness` guards you against registering the same action type more than once.
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
A small inconsistent in runtime checks docs:

![Captura de Tela 2020-08-22 às 19 09 42](https://user-images.githubusercontent.com/11965907/90966648-33557300-e4ab-11ea-9e8b-2c5e171bb88c.png)


