### PR TITLE
fix(component-store): add entry point for schematic

### DIFF
--- a/modules/component-store/package.json
+++ b/modules/component-store/package.json
@@ -25,6 +25,7 @@
     "@angular/core": "^10.0.0",
     "rxjs": "^6.5.3"
   },
+  "schematics": "./schematics/collection.json",
   "sideEffects": false,
   "ng-update": {
     "packageGroup": [


### PR DESCRIPTION
I've added the entry point for the schematics in the `package.json` as requested.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

   When running `ng add @ngrx/component-store` you will see a the error

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Closes #2682 

## What is the new behavior?

Because we've added the entrypoint we should not see the rror any more.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
