### PR TITLE
docs: font size, line-height, nav-rework

### DIFF
--- a/projects/ngrx.io/src/app/custom-elements/api/api-list.component.html
+++ b/projects/ngrx.io/src/app/custom-elements/api/api-list.component.html
@@ -15,8 +15,8 @@
   </aio-select>
 
   <div class="form-search">
-    <input #filter placeholder="Filter" (input)="setQuery($event.target.value)">
     <i class="material-icons">search</i>
+    <input #filter placeholder="Filter" (input)="setQuery($event.target.value)">
   </div>
 </div>
 

--- a/projects/ngrx.io/src/app/layout/footer/footer.component.html
+++ b/projects/ngrx.io/src/app/layout/footer/footer.component.html
@@ -1,23 +1,33 @@
-
-  <div class="grid-fluid">
-    <div class="footer-block" *ngFor="let node of nodes">
-      <h3>{{node.title}}</h3>
-      <ul>
-        <li *ngFor="let item of node.children">
-          <a class="link" [href]="item.url"
-            [title]="item.tooltip || item.title">{{ item.title }}</a>
-        </li>
-      </ul>
+<div class="grid-fluid">
+    <div
+        class="footer-block"
+        *ngFor="let node of nodes">
+        <h3>{{node.title}}</h3>
+        <ul>
+            <li *ngFor="let item of node.children">
+                <a
+                    class="link"
+                    [href]="item.url"
+                    [title]="item.tooltip || item.title">
+                    {{ item.title }}
+                </a>
+            </li>
+        </ul>
     </div>
-  </div>
+</div>
 
-  <p>
+<p>
     Powered by the Community ©2015-2019.
-    Code licensed under an <a href="license" title="License text" >MIT-style License</a>.
+    Code licensed under an
+    <a
+        href="license"
+        title="License text">
+        MIT-style License
+    </a>
+    .
     Documentation licensed under
-    <a href="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
-  </p>
-  <p>
-    Version {{versionInfo?.full}}.
-  </p>
-  <!-- TODO: twitter widget (but only on pages that use twitter) -->
+    <a href="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>
+    .
+</p>
+<p>Version {{versionInfo?.full}}.</p>
+<!-- TODO: twitter widget (but only on pages that use twitter) -->

--- a/projects/ngrx.io/src/app/layout/nav-item/nav-item.component.html
+++ b/projects/ngrx.io/src/app/layout/nav-item/nav-item.component.html
@@ -1,21 +1,21 @@
-<div *ngIf="!node.children">
+<div class="heading-container" *ngIf="!node.children">
   <a href="{{node.url}}" [ngClass]="classes" title="{{node.tooltip}}"
     class="vertical-menu-item">
     {{node.title}}
   </a>
 </div>
 
-<div *ngIf="node.children">
+<div class="heading-container" *ngIf="node.children">
   <a *ngIf="node.url != null" href="{{node.url}}" [ngClass]="classes" title="{{node.tooltip}}"
     (click)="headerClicked()" class="vertical-menu-item heading">
-    {{node.title}}
+    <span class="node-title">{{node.title}}</span>
     <mat-icon class="rotating-icon" svgIcon="keyboard_arrow_right"></mat-icon>
   </a>
 
   <button *ngIf="node.url == null" type="button" [ngClass]="classes" title="{{node.tooltip}}"
     (click)="headerClicked()" class="vertical-menu-item heading"
     [attr.aria-pressed]="isExpanded">
-    {{node.title}}
+    <span class="node-title">{{node.title}}</span>
     <mat-icon class="rotating-icon" svgIcon="keyboard_arrow_right"></mat-icon>
   </button>
 

--- a/projects/ngrx.io/src/app/layout/nav-item/nav-item.component.html
+++ b/projects/ngrx.io/src/app/layout/nav-item/nav-item.component.html
@@ -1,27 +1,54 @@
-<div class="heading-container" *ngIf="!node.children">
-  <a href="{{node.url}}" [ngClass]="classes" title="{{node.tooltip}}"
-    class="vertical-menu-item">
-    {{node.title}}
-  </a>
+<div
+    class="heading-container"
+    *ngIf="!node.children">
+    <a
+        href="{{node.url}}"
+        [ngClass]="classes"
+        title="{{node.tooltip}}"
+        class="vertical-menu-item">
+        {{node.title}}
+    </a>
 </div>
 
-<div class="heading-container" *ngIf="node.children">
-  <a *ngIf="node.url != null" href="{{node.url}}" [ngClass]="classes" title="{{node.tooltip}}"
-    (click)="headerClicked()" class="vertical-menu-item heading">
-    <span class="node-title">{{node.title}}</span>
-    <mat-icon class="rotating-icon" svgIcon="keyboard_arrow_right"></mat-icon>
-  </a>
+<div
+    class="heading-container"
+    *ngIf="node.children">
+    <a
+        *ngIf="node.url != null"
+        href="{{node.url}}"
+        [ngClass]="classes"
+        title="{{node.tooltip}}"
+        (click)="headerClicked()"
+        class="vertical-menu-item heading">
+        <span class="node-title">{{node.title}}</span>
+        <mat-icon
+            class="rotating-icon"
+            svgIcon="keyboard_arrow_right"></mat-icon>
+    </a>
 
-  <button *ngIf="node.url == null" type="button" [ngClass]="classes" title="{{node.tooltip}}"
-    (click)="headerClicked()" class="vertical-menu-item heading"
-    [attr.aria-pressed]="isExpanded">
-    <span class="node-title">{{node.title}}</span>
-    <mat-icon class="rotating-icon" svgIcon="keyboard_arrow_right"></mat-icon>
-  </button>
+    <button
+        *ngIf="node.url == null"
+        type="button"
+        [ngClass]="classes"
+        title="{{node.tooltip}}"
+        (click)="headerClicked()"
+        class="vertical-menu-item heading"
+        [attr.aria-pressed]="isExpanded">
+        <span class="node-title">{{node.title}}</span>
+        <mat-icon
+            class="rotating-icon"
+            svgIcon="keyboard_arrow_right"></mat-icon>
+    </button>
 
-  <div class="heading-children" [ngClass]="classes">
-    <aio-nav-item *ngFor="let node of nodeChildren" [level]="level + 1" [isWide]="isWide"
-    [isParentExpanded]="isExpanded"
-    [node]="node" [selectedNodes]="selectedNodes"></aio-nav-item>
-  </div>
+    <div
+        class="heading-children"
+        [ngClass]="classes">
+        <aio-nav-item
+            *ngFor="let node of nodeChildren"
+            [level]="level + 1"
+            [isWide]="isWide"
+            [isParentExpanded]="isExpanded"
+            [node]="node"
+            [selectedNodes]="selectedNodes"></aio-nav-item>
+    </div>
 </div>

--- a/projects/ngrx.io/src/styles/0-base/_typography.scss
+++ b/projects/ngrx.io/src/styles/0-base/_typography.scss
@@ -1,15 +1,18 @@
+@import '../mixins';
+
 body {
+  @include typescale-default;
   font-family: $main-font;
   margin: 0;
   color: $darkgray;
-  font-size: 14px;
+
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 h1 {
   display: inline-block;
-  font-size: 24px;
+  @include typescale-display;
   font-weight: 500;
   margin: 8px 0px;
 
@@ -19,37 +22,37 @@ h1 {
 }
 
 h2 {
-  font-size: 22px;
+  @include typescale-xlarge;
   font-weight: 500;
   margin: 32px 0px 24px;
   clear: both;
 }
 
 h3 {
-  font-size: 20px;
-  font-weight: 400;
+  @include typescale-large;
+  font-weight: 500;
   margin: 24px 0px 12px;
   clear: both;
 }
 
 h4 {
-  font-size: 18px;
-  font-weight: 400;
+  @include typescale-default;
+  font-weight: 500;
   margin: 8px 0px;
   clear: both;
 }
 
 h5 {
-  font-size: 16px;
-  font-weight: 500;
+  @include typescale-default;
+  font-weight: 400;
   margin: 8px 0px;
   clear: both;
 }
 
 h6 {
   color: $mediumgray;
-  font-size: 16px;
-  font-weight: 500;
+  @include typescale-default;
+  font-weight: 400;
   margin: 8px 0px;
   clear: both;
 }
@@ -69,8 +72,7 @@ h2, h3, h4, h5, h6 {
 }
 
 p, ol, ul, ol, li, input, a  {
-  font-size: 14px;
-  line-height: 24px;
+  @include typescale-default;
   letter-spacing: 0.30px;
   font-weight: 400;
   & > em {
@@ -93,7 +95,7 @@ a {
 }
 
 .app-toolbar a {
-  font-size: 16px;
+  @include typescale-large;
   font-weight: 400;
   color: $white;
   font-family: $main-font;
@@ -133,13 +135,13 @@ td {
 }
 
 th {
-  font-size: 16px;
+  @include typescale-default;
   font-weight: 500;
   padding: 13px 32px;
   text-align: left;
 }
 
-p > code, li > code, td > code, th > c ode {
+p > code, li > code, td > code, th > code {
   font-family: $code-font;
   font-size: 85%;
   color: $darkgray;

--- a/projects/ngrx.io/src/styles/1-layouts/_api-pages.scss
+++ b/projects/ngrx.io/src/styles/1-layouts/_api-pages.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 .api-body {
 
     max-width: 1200px;
@@ -7,7 +9,7 @@
 
         th {
             text-transform: none;
-            font-size: 16px;
+            @include typescale-default;
             font-weight: bold;
         }
 

--- a/projects/ngrx.io/src/styles/1-layouts/_footer.scss
+++ b/projects/ngrx.io/src/styles/1-layouts/_footer.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 footer {
   position: relative;
   line-height: 24px;
@@ -35,7 +37,7 @@ footer {
     cursor: pointer;
   }
   h3 {
-    font-size: 16px;
+    @include typescale-default;
     text-transform: uppercase;
     font-weight: 400;
     margin: 0 0 16px;
@@ -84,12 +86,12 @@ footer {
 
   @media (max-width: 700px) {
     h3 {
-      font-size: 110%;
+      @include typescale-large;
     }
   }
   @media (max-width: 600px) {
     h3 {
-      font-size: 100%;
+      @include typescale-default;
     }
   }
 }

--- a/projects/ngrx.io/src/styles/1-layouts/_homepage.scss
+++ b/projects/ngrx.io/src/styles/1-layouts/_homepage.scss
@@ -1,4 +1,6 @@
 aio-shell.page-home {
+  line-height: initial;
+
   aio-doc-viewer {
     display: block;
     width: 100vw;

--- a/projects/ngrx.io/src/styles/1-layouts/_sidenav.scss
+++ b/projects/ngrx.io/src/styles/1-layouts/_sidenav.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 // Disable sidenav animations for the initial render.
 .starting.mat-drawer-transition .mat-drawer-content {
   transition: none;
@@ -6,7 +8,7 @@
 aio-nav-menu {
   display: block;
   margin: 0 auto;
-  font-size: 13px;
+  @include typescale-small;
   ul, a {
     padding: 0;
     margin: 0;
@@ -52,18 +54,25 @@ mat-sidenav-container div.mat-sidenav-content {
   height: auto;
 }
 
+.heading-container {
+  display: flex;
+  flex-direction: column;
+}
+
 .vertical-menu-item {
   box-sizing: border-box;
   color: $darkgray;
   cursor: pointer;
-  display: block;
+  flex: 1;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
   max-width: 260px;
   overflow-wrap: break-word;
   padding-top: 4px;
   padding-bottom: 4px;
   text-decoration: none;
   text-align: left;
-  width: 93%;
   word-wrap: break-word;
 
   &:hover {
@@ -76,11 +85,12 @@ mat-sidenav-container div.mat-sidenav-content {
     outline: $accentblue auto 2px;
   }
 
+  .node-title {
+    flex: 1;
+  }
+
   //icons _within_ nav
   .mat-icon {
-    position: absolute;
-    top: 0;
-    right: 0;
     margin: 4px;
   }
 }
@@ -93,9 +103,6 @@ button.vertical-menu-item {
   border: none;
   background-color: transparent;
   margin-right: 0;
-  padding-left: 6px;
-  padding-top: 8px;
-  padding-bottom: 10px;
 }
 
 .heading {
@@ -130,7 +137,7 @@ button.vertical-menu-item {
 
 .level-1 {
   font-family: $main-font;
-  font-size: 14px;
+  @include typescale-default;
   font-weight: 400;
   margin-left: 14px;
   transition: background-color 0.2s;
@@ -139,7 +146,7 @@ button.vertical-menu-item {
 .level-2 {
   color: $mediumgray;
   font-family: $main-font;
-  font-size: 14px;
+  @include typescale-default;
   font-weight: 400;
   margin-left: 12px;
   text-transform: none;
@@ -148,8 +155,15 @@ button.vertical-menu-item {
 .level-3 {
   color: $mediumgray;
   font-family: $main-font;
-  font-size: 14px;
+  @include typescale-default;
   margin-left: 10px;
+}
+
+.level-4 {
+  color: $mediumgray;
+  font-family: $main-font;
+  @include typescale-default;
+  margin-left: 8px;
 }
 
 .level-1.expanded .mat-icon, .level-2.expanded .mat-icon {
@@ -187,7 +201,7 @@ mat-sidenav .doc-version {
 
     option {
       font-family: $main-font;
-      font-size: 14px;
+      @include typescale-default;
     }
   }
 }

--- a/projects/ngrx.io/src/styles/2-modules/_alert.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_alert.scss
@@ -1,7 +1,9 @@
+@import '../mixins';
+
 .alert {
     padding: 16px;
     margin: 24px 0px;
-    font-size: 14px;
+    @include typescale-default;
     color: $darkgray;
     width: 100%;
     box-sizing: border-box;

--- a/projects/ngrx.io/src/styles/2-modules/_api-list.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_api-list.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 /* API EDIT ICON */
 #api {
   .api-filter .material-icons {
@@ -70,7 +72,7 @@ aio-api-list {
     box-sizing: border-box;
     border: 1px solid $white;
     color: $purple-600;
-    font-size: 16px;
+    @include typescale-default;
     height: 32px;
     line-height: 32px;
     outline: none;
@@ -80,19 +82,19 @@ aio-api-list {
     // PLACEHOLDER TEXT
     &::-webkit-input-placeholder { /* Chrome/Opera/Safari */
       color: $purple-grey-100;
-      font-size: 14px;
+      @include typescale-small;
     }
     &::-moz-placeholder { /* Firefox 19+ */
       color: $purple-grey-100;
-      font-size: 14px;
+      @include typescale-small;
     }
     &:-ms-input-placeholder { /* IE 10+ */
       color: $purple-grey-100;
-      font-size: 14px;
+      @include typescale-small;
     }
     &:-moz-placeholder { /* Firefox 18- */
       color: $purple-grey-100;
-      font-size: 14px;
+      @include typescale-small;
     }
 
     &:focus {
@@ -103,7 +105,7 @@ aio-api-list {
 
   .material-icons {
     color: $purple-grey-100;
-    font-size: 20px;
+    @include typescale-large;
     left: 8px;
     position: absolute;
     top: 6px;
@@ -288,7 +290,7 @@ p {
 }
 
 .api-doc-code {
-  font-size: 14px;
+  @include typescale-default;
   color: #1a2326;
 
   // the last .pln (white space) creates additional spacing between sections of the api doc. Remove it.

--- a/projects/ngrx.io/src/styles/2-modules/_api-list.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_api-list.scss
@@ -106,9 +106,11 @@ aio-api-list {
   .material-icons {
     color: $purple-grey-100;
     @include typescale-large;
+    // must match input line-height;
+    line-height: 32px;
+    height: 100%;
     left: 8px;
     position: absolute;
-    top: 6px;
     z-index: $layer-1;
   }
 }
@@ -152,10 +154,6 @@ aio-api-list {
     .symbol {
       margin-right: 8px;
     }
-  }
-
-  .form-search {
-    float: left;
   }
 }
 

--- a/projects/ngrx.io/src/styles/2-modules/_api-pages.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_api-pages.scss
@@ -1,9 +1,11 @@
+@import '../mixins';
+
 .github-links {
   float: right;
   .material-icons {
     border-radius: 4px;
     padding: 4px;
-    font-size: 20px;
+    @include typescale-large;
     &:hover {
       background-color: $mist;
     }
@@ -54,7 +56,7 @@
     }
 
     h4 {
-      font-size: 14px;
+      @include typescale-small;
       font-weight: bold;
       margin-top: 12px;
     }
@@ -62,7 +64,7 @@
 
   .api-heading {
     padding: 5px 0;
-    font-size: 16px;
+    @include typescale-default;
     font-weight: bold;
   }
 
@@ -71,7 +73,7 @@
   }
 
   .properties-table {
-    font-size: 14px;
+    @include typescale-small;
 
     thead th {
       &:nth-child(1) {
@@ -85,7 +87,7 @@
 
   .parameters-table {
     margin-top: 0;
-    font-size: 14px;
+    @include typescale-small;
     td:nth-child(1) {
       width: 20%;
     }

--- a/projects/ngrx.io/src/styles/2-modules/_buttons.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_buttons.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 /* Button Styles */
 
 .button,
@@ -5,7 +7,7 @@ a.button.mat-button {
   display: inline-block;
   line-height: 32px;
   padding: 0px 16px;
-  font-size: 14px;
+  @include typescale-default;
   font-weight: 400;
   border-radius: 3px;
   text-decoration: none;
@@ -15,19 +17,19 @@ a.button.mat-button {
 
   // SIZES
   &.button-small {
-    font-size: 12px;
+    @include typescale-small;
     line-height: 24px;
     padding: 0px 8px;
   }
 
   &.button-large {
-    font-size: 15px;
+    @include typescale-default;
     line-height: 48px;
     padding: 0px 24px;
   }
 
   &.button-x-large {
-    font-size: 16px;
+    @include typescale-large;
     line-height: 56px;
     padding: 0px 24px;
   }
@@ -100,10 +102,10 @@ a.button.mat-button {
 
 a.filter-button {
   width: 140px;
-  font-size: 14px;
+  @include typescale-default;
+  line-height: 48px;
   padding: 0px 16px;
   margin: 8px;
-  line-height: 48px;
   border: 2px solid $purple;
   border-radius: 4px;
 

--- a/projects/ngrx.io/src/styles/2-modules/_callout.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_callout.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 .callout {
   @extend .alert;
   padding: 0px;
@@ -17,7 +19,7 @@
   p {
     padding: 16px;
     margin: 0px;
-    font-size: 14px;
+    @include typescale-default;
   }
 
   &.is-critical {

--- a/projects/ngrx.io/src/styles/2-modules/_card.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_card.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 .card-container {
     display: flex;
     flex-direction: row;
@@ -36,8 +38,7 @@
 
   section {
     color: $darkgray;
-    font-size: 20px;
-    line-height: 24px;
+    @include typescale-large;
     margin: 0;
     padding: 32px 0 24px;
     text-transform: none;
@@ -46,8 +47,7 @@
 
   p {
     color: $darkgray;
-    font-size: 13px;
-    line-height: 24px;
+    @include typescale-small;
     padding: 0 16px;
     margin: 0;
     text-align: center;
@@ -66,7 +66,7 @@
 
     a {
       color: $mediumgray;
-      font-size: 13px;
+      @include typescale-small;
     }
   }
   .card-footer.center {

--- a/projects/ngrx.io/src/styles/2-modules/_code.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_code.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 code-example, code-tabs {
     clear: both;
     display: block;
@@ -48,7 +50,7 @@ code-example header {
   background-color: $purple;
   border-radius: 5px 5px 0 0;
   color: $offwhite;
-  font-size: 16px;
+  @include typescale-default;
   padding: 8px 16px;
 }
 

--- a/projects/ngrx.io/src/styles/2-modules/_details.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_details.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 /*
  * General styling to make detail/summary tags look a bit more material
  * To get the best out of it you should structure your usage like this:
@@ -14,7 +16,7 @@
 
 summary {
   cursor: pointer;
-  font-size: 16px;
+  @include typescale-default;
   position: relative;
   padding: 16px 24px;
   color: $black;
@@ -28,7 +30,7 @@ summary {
   &::before {
     content: '\E5CE'; // See https://material.io/icons/#ic_expand_less
     font-family: 'Material Icons';
-    font-size: 24px;
+    @include typescale-xlarge;
     -webkit-font-smoothing: antialiased;
     @include rotate(0deg); // We will rotate 180 degrees when details is open
     float: right;

--- a/projects/ngrx.io/src/styles/2-modules/_edit-page-cta.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_edit-page-cta.scss
@@ -1,6 +1,8 @@
+@import '../mixins';
+
 .edit-page-cta {
     font-weight: 400;
-    font-size: 14px;
+    @include typescale-default;
     color: $purple;
     text-align: right;
     margin-right: 32px;

--- a/projects/ngrx.io/src/styles/2-modules/_features.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_features.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 // FEATURES MARKETING PAGE SPECIFIC STYLES
 
 .feature-section {
@@ -12,7 +14,7 @@
   }
 
   .feature-title {
-    font-size: 16px;
+    @include typescale-default;
     font-weight: 500;
     margin: 8px 0px;
     clear: both;
@@ -28,8 +30,8 @@
 
     .feature {
       max-width: 300px;
-      margin: 0 16px;  
-      
+      margin: 0 16px;
+
       @media (max-width: 768px) {
         max-width: 100%;
       }

--- a/projects/ngrx.io/src/styles/2-modules/_label.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_label.scss
@@ -1,8 +1,10 @@
+@import '../mixins';
+
 label.raised, .api-header label {
     border-radius: 4px;
     padding: 4px 16px;
     display: inline;
-    font-size: 14px;
+    @include typescale-default;
     color: white;
     margin-right: 8px;
     font-weight: 500;
@@ -29,7 +31,7 @@ label.raised, .api-header label {
     }
 
     &.property-type-label {
-        font-size: 12px;
+      @include typescale-small;
         background-color: $darkgray;
         color: $white;
         text-transform: none;
@@ -40,7 +42,7 @@ label.raised, .api-header label {
 
     // The API badges should be a little smaller
     padding: 2px 10px;
-    font-size: 12px;
+    @include typescale-small;
 
     @media screen and (max-width: 600px) {
         margin: 4px 0;

--- a/projects/ngrx.io/src/styles/2-modules/_notification.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_notification.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 $notificationHeight: 56px;
 
 // we need to override some of the toolbar styling
@@ -59,7 +61,7 @@ aio-notification {
       border-radius: 15px;
       text-transform: uppercase;
       padding: 0 10px;
-      font-size: 12px;
+      @include typescale-small;
       @media (max-width: 780px) {
         display: none;
       }

--- a/projects/ngrx.io/src/styles/2-modules/_search-results.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_search-results.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 aio-search-results {
     z-index: 10;
 }
@@ -54,7 +56,7 @@ aio-search-results.embedded .search-results {
     height: 100%;
 
     h3 {
-        font-size: 16px;
+      @include typescale-large;
         font-weight: 400;
         margin: 10px 0px 5px;
         text-transform: uppercase;
@@ -70,7 +72,7 @@ aio-search-results.embedded .search-results {
     }
 
     a {
-        font-size: 14px;
+      @include typescale-default;
         color: $lightgray;
         text-decoration: none;
         font-weight: normal;

--- a/projects/ngrx.io/src/styles/2-modules/_select-menu.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_select-menu.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 /* SELECT MENU */
 
 .form-select-menu {
@@ -10,10 +12,10 @@
   box-sizing: border-box;
   border: 1px solid $white;
   color: $purple-grey-600;
-  font-size: 12px;
+  @include typescale-small;
+  line-height: 32px;
   font-weight: 400;
   height: 32px;
-  line-height: 32px;
   outline: none;
   padding: 0 16px;
   text-align: left;
@@ -46,7 +48,7 @@
 
   li {
     cursor: pointer;
-    font-size: 14px;
+    @include typescale-default;
     line-height: 32px;
     margin: 0;
     padding: 0 16px 0 40px;

--- a/projects/ngrx.io/src/styles/2-modules/_table.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_table.scss
@@ -1,3 +1,5 @@
+@import '../mixins';
+
 table {
   margin: 24px 0px;
   box-shadow: 0 2px 2px rgba($black, 0.24), 0 0 2px rgba($black, 0.12);
@@ -25,12 +27,12 @@ table {
       background: rgba($lightgray, 0.2);
       border-bottom: 1px solid $lightgray;
       color: $darkgray;
-      font-size: 12px;
+      @include typescale-small;
+      line-height: 28px;
       font-weight: 500;
       padding: 8px 24px;
       text-align: left;
       text-transform: uppercase;
-      line-height: 28px;
     }
   }
 

--- a/projects/ngrx.io/src/styles/_mixins.scss
+++ b/projects/ngrx.io/src/styles/_mixins.scss
@@ -73,3 +73,28 @@
     text-decoration: none;
   }
 }
+
+@mixin typescale-display {
+  font-size: 26px;
+  line-height: 32px;
+}
+
+@mixin typescale-xlarge {
+  font-size: 24px;
+  line-height: 30px;
+}
+
+@mixin typescale-large {
+  font-size: 20px;
+  line-height: 28px;
+}
+
+@mixin typescale-default {
+  font-size: 16px;
+  line-height: 24px;
+}
+
+@mixin typescale-small {
+  font-size: 14px;
+  line-height: 20px;
+}

--- a/projects/ngrx.io/src/styles/_ngrx.scss
+++ b/projects/ngrx.io/src/styles/_ngrx.scss
@@ -1,3 +1,5 @@
+@import './mixins';
+
 $dull-magenta: (
   50: #f6e7f9,
   100: #eac3f1,
@@ -94,7 +96,7 @@ aio-shell.page-home {
       }
     }
   }
-  
+
   pre .nocode {
     background-color: none;
     color: #000;

--- a/projects/ngrx.io/src/styles/main.scss
+++ b/projects/ngrx.io/src/styles/main.scss
@@ -1,13 +1,14 @@
 // import global themes
 @import '~@angular/material/theming';
+
+// import global mixins
+@import './mixins';
+
 @import './ngrx';
 @import './ngrx-io-theme';
 
 // import global variables
 @import './constants';
-
-// import global mixins
-@import './mixins';
 
 // import directories
 @import './0-base/base-dir';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- increate the default font size from 14 to 16px
- ensure that we have the appropriate `line-height` that accompanies the corresponding `font-size` through mixins
- switch the nav-bar to use flexbox instead of %-based and pixel-adjusted alignments.

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior? What is the new behavior?

On the LEFT is a new look, on the RIGHT is the current look.

* Home page looks **the same** (except for the footer):

<img width="1792" alt="Screen Shot 2020-09-10 at 2 06 35 PM" src="https://user-images.githubusercontent.com/2830407/92783264-9ed88500-f373-11ea-958f-2bc51330df29.png">

<img width="1792" alt="Screen Shot 2020-09-10 at 2 06 56 PM" src="https://user-images.githubusercontent.com/2830407/92783399-bc0d5380-f373-11ea-8434-72092c03af8a.png">


* left Nav items are now **bigger** (the right side mini nav stays the same)


<img width="1791" alt="Screen Shot 2020-09-10 at 2 07 50 PM" src="https://user-images.githubusercontent.com/2830407/92783593-e9f29800-f373-11ea-9668-b9e8270c17af.png">


* 4-the level items (like State -> ngrx/component-store -> Architecture -> Read) are now:
   - same color as 3-rd level items
   - indented further


<img width="1788" alt="Screen Shot 2020-09-10 at 2 09 00 PM" src="https://user-images.githubusercontent.com/2830407/92783958-376f0500-f374-11ea-99af-8abe7fe9197c.png">


* Font sizes for text and headers is increased


<img width="1789" alt="Screen Shot 2020-09-10 at 2 10 10 PM" src="https://user-images.githubusercontent.com/2830407/92784088-51a8e300-f374-11ea-80b3-a6cb1ea21750.png">


* Alerts are bigger


<img width="1790" alt="Screen Shot 2020-09-10 at 2 10 26 PM" src="https://user-images.githubusercontent.com/2830407/92784217-769d5600-f374-11ea-90fa-7227c780fdb8.png">


* Callouts are bigger


<img width="1784" alt="Screen Shot 2020-09-10 at 2 10 53 PM" src="https://user-images.githubusercontent.com/2830407/92784287-87e66280-f374-11ea-8ae4-f6f39d952cd0.png">


* Code snippets have the same size "pane headers", but the code font is increased


<img width="1791" alt="Screen Shot 2020-09-10 at 2 11 08 PM" src="https://user-images.githubusercontent.com/2830407/92784610-b8c69780-f374-11ea-90e6-a7b669c6e0e1.png">


* Header 4 is same size (as previously and as a new font-size) but it's bolder


<img width="1792" alt="Screen Shot 2020-09-10 at 2 11 53 PM" src="https://user-images.githubusercontent.com/2830407/92784746-d85dc000-f374-11ea-9e6b-5a09873f3948.png">


* Footer has bigger font


<img width="1792" alt="Screen Shot 2020-09-10 at 2 16 22 PM" src="https://user-images.githubusercontent.com/2830407/92784966-07743180-f375-11ea-8236-a0ba75d49680.png">


* ZOOMED to 150% page **maintains proper proportions now**:


<img width="1773" alt="Screen Shot 2020-09-10 at 2 30 54 PM" src="https://user-images.githubusercontent.com/2830407/92785460-6fc31300-f375-11ea-9653-8eb5d69f133e.png">


* API fonts got a bit bigger:


<img width="1778" alt="Screen Shot 2020-09-10 at 2 52 21 PM" src="https://user-images.githubusercontent.com/2830407/92785488-7782b780-f375-11ea-8cef-a526e59e5752.png">

<img width="1785" alt="Screen Shot 2020-09-10 at 2 52 43 PM" src="https://user-images.githubusercontent.com/2830407/92785518-7ce00200-f375-11ea-80a7-14f02ac7debb.png">



<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
