### PR TITLE
Added warning for router-store when using with ngrx-store-freeze

### DIFF
--- a/projects/ngrx.io/content/guide/router-store/index.md
+++ b/projects/ngrx.io/content/guide/router-store/index.md
@@ -28,3 +28,5 @@ import { AppComponent } from './app.component';
 })
 export class AppModule {}
 </code-example>
+
+> :warning: **@ngrx/router-store does not compatible with `ngrx-store-freeze`. Using together may cause unexpected behaviours**


### PR DESCRIPTION
router store and ngrx-store-freeze does not working together completely well. router store breaks reducers

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
