### PR TITLE
docs(effects): incorrect behavior of command & steps below

### DIFF
--- a/projects/ngrx.io/content/guide/effects/install.md
+++ b/projects/ngrx.io/content/guide/effects/install.md
@@ -21,7 +21,7 @@ yarn add @ngrx/effects
 If your project is using the Angular CLI 6+ then you can install the Effects to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
 
 ```sh
-ng add @ngrx/effects@latest
+ng add @ngrx/effects@latest --minimal false
 ```
 
 ### Optional `ng add` flags


### PR DESCRIPTION
## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Incorrect behavior described below. It's not creating ``app.effects.ts`` and ``app.effects.spec.ts``.
