### PR TITLE
fix(schematics): ng-add removes other workspace cli options

### DIFF
--- a/modules/schematics/src/ng-add/index.ts
+++ b/modules/schematics/src/ng-add/index.ts
@@ -1,25 +1,17 @@
-import {
-  Rule,
-  SchematicContext,
-  Tree,
-  chain,
-  noop,
-} from '@angular-devkit/schematics';
-import {
-  WorkspaceSchema,
-  getWorkspacePath,
-  getWorkspace,
-} from '../../schematics-core/utility/config';
-import { Schema as SchematicOptions } from './schema';
+import {chain, noop, Rule, SchematicContext, Tree,} from '@angular-devkit/schematics';
+import {getWorkspace, getWorkspacePath} from '../../schematics-core';
 
-function updateWorkspace<K extends keyof WorkspaceSchema>(
-  host: Tree,
-  key: K,
-  value: any
-) {
+import {Schema as SchematicOptions} from './schema';
+
+function updateWorkspaceCli(host: Tree, value: any) {
   const workspace = getWorkspace(host);
   const path = getWorkspacePath(host);
-  workspace[key] = value;
+
+  workspace['cli'] = {
+    ...workspace['cli'],
+    ...value
+  };
+
   host.overwrite(path, JSON.stringify(workspace, null, 2));
 }
 
@@ -28,7 +20,7 @@ function setAsDefaultSchematics() {
     defaultCollection: '@ngrx/schematics',
   };
   return (host: Tree) => {
-    updateWorkspace(host, 'cli', cli);
+    updateWorkspaceCli(host, cli);
     return host;
   };
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When ng-add is exectuted it removes other workspace cli options and includes only { defaultCollection: '@ngrx/schematics' } on it.

## What is the new behavior?
This fix adds { defaultCollection: '@ngrx/schematics' } to options and doesn't remove the current ones (other options may be ex: analytics).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
