### PR TITLE
docs(store): Add documentation for combineReducers

### DIFF
--- a/modules/store/src/utils.ts
+++ b/modules/store/src/utils.ts
@@ -26,61 +26,21 @@ export function combineReducers<T, V extends Action = Action>(
  *
  * **Example combining two feature reducers into one "root" reducer**
  *
- * Feature A:
  * ```ts
- * export const featureKey = 'featureA';
- * export interface State {
- *   counterA: number;
- * }
- * const initialState: State = {
- *   counterA: 0
- * };
- * export const featureAIncrement = createAction('[FeatureA] increment');
- * export const reducer = createReducer(
- *   initialState,
- *   on(featureAIncrement, state => ({ counterA: state.counterA + 1 }))
- * );
- * ```
- *
- * Feature B:
- * ```ts
- * export const featureKey = 'featureB';
- * export interface State {
- *   counterB: number;
- * }
- * const initialState: State = {
- *   counterB: 0
- * };
- * export const featureBIncrement = createAction('[FeatureB] increment');
- * export const reducer = createReducer(
- *   initialState,
- *   on(featureBIncrement, state => ({ counterB: state.counterB + 1 }))
- * );
- * ```
- *
- * Combining the feature reducers using `combineReducers`:
- * ```ts
- * import * as fromFeatureA from './featureA';
- * import * as fromFeatureB from './featureB';
- *
- * export interface State {
- *   [fromFeatureA.featureKey]: fromFeatureA.State;
- *   [fromFeatureB.featureKey]: fromFeatureB.State;
- * }
  * export const reducer = combineReducers({
- *   [fromFeatureA.featureKey]: fromFeatureA.reducer,
- *   [fromFeatureB.featureKey]: fromFeatureB.reducer
+ *   featureA: featureAReducer,
+ *   featureB: featureBReducer
  * });
  * ```
  *
  * You can also override the initial states of the sub-features:
  * ```ts
  * export const reducer = combineReducers({
- *   [fromFeatureA.featureKey]: fromFeatureA.reducer,
- *   [fromFeatureB.featureKey]: fromFeatureB.reducer
+ *   featureA: featureAReducer,
+ *   featureB: featureBReducer
  * }, {
- *   [fromFeatureA.featureKey]: { counterA: 13 },
- *   [fromFeatureB.featureKey]: { counterB: 37 }
+ *   featureA: { counterA: 13 },
+ *   featureB: { counterB: 37 }
  * });
  * ```
  */

--- a/modules/store/src/utils.ts
+++ b/modules/store/src/utils.ts
@@ -11,6 +11,79 @@ export function combineReducers<T, V extends Action = Action>(
   reducers: ActionReducerMap<T, V>,
   initialState?: Partial<T>
 ): ActionReducer<T, V>;
+/**
+ * @description
+ * Combines reducers for individual features into a single reducer.
+ *
+ * You can use this function to delegate handling of state transitions to multiple reducers, each acting on their
+ * own sub-state within the root state.
+ *
+ * @param reducers An object mapping keys of the root state to their corresponding feature reducer.
+ * @param initialState Provides a state value if the current state is `undefined`, as it is initially.
+ * @returns A reducer function.
+ *
+ * @usageNotes
+ *
+ * **Example combining two feature reducers into one "root" reducer**
+ *
+ * Feature A:
+ * ```ts
+ * export const featureKey = 'featureA';
+ * export interface State {
+ *   counterA: number;
+ * }
+ * const initialState: State = {
+ *   counterA: 0
+ * };
+ * export const featureAIncrement = createAction('[FeatureA] increment');
+ * export const reducer = createReducer(
+ *   initialState,
+ *   on(featureAIncrement, state => ({ counterA: state.counterA + 1 }))
+ * );
+ * ```
+ *
+ * Feature B:
+ * ```ts
+ * export const featureKey = 'featureB';
+ * export interface State {
+ *   counterB: number;
+ * }
+ * const initialState: State = {
+ *   counterB: 0
+ * };
+ * export const featureBIncrement = createAction('[FeatureB] increment');
+ * export const reducer = createReducer(
+ *   initialState,
+ *   on(featureBIncrement, state => ({ counterB: state.counterB + 1 }))
+ * );
+ * ```
+ *
+ * Combining the feature reducers using `combineReducers`:
+ * ```ts
+ * import * as fromFeatureA from './featureA';
+ * import * as fromFeatureB from './featureB';
+ *
+ * export interface State {
+ *   [fromFeatureA.featureKey]: fromFeatureA.State;
+ *   [fromFeatureB.featureKey]: fromFeatureB.State;
+ * }
+ * export const reducer = combineReducers({
+ *   [fromFeatureA.featureKey]: fromFeatureA.reducer,
+ *   [fromFeatureB.featureKey]: fromFeatureB.reducer
+ * });
+ * ```
+ *
+ * You can also override the initial states of the sub-features:
+ * ```ts
+ * export const reducer = combineReducers({
+ *   [fromFeatureA.featureKey]: fromFeatureA.reducer,
+ *   [fromFeatureB.featureKey]: fromFeatureB.reducer
+ * }, {
+ *   [fromFeatureA.featureKey]: { counterA: 13 },
+ *   [fromFeatureB.featureKey]: { counterB: 37 }
+ * });
+ * ```
+ */
 export function combineReducers(
   reducers: any,
   initialState: any = {}


### PR DESCRIPTION
Document the `combineReducers` function as it is not only used internally but can also be useful for
splitting reducers into multiple feature reducers.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `combineReducers` function is undocumented.

Closes #1179 


## What is the new behavior?

Added doc-comments to the `combineReducers` function, along with an example.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
