### PR TITLE
fix(entity): Improve typing of EntityAdapter.getSelectors()

### DIFF
--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -1,3 +1,5 @@
+import { MemoizedSelector } from '@ngrx/store';
+
 export type Comparer<T> = (a: T, b: T) => number;
 
 export type IdSelectorStr<T> = (model: T) => string;
@@ -87,6 +89,13 @@ export interface EntitySelectors<T, V> {
   selectTotal: (state: V) => number;
 }
 
+export interface MemoizedEntitySelectors<T, V> {
+  selectIds: MemoizedSelector<V, string[] | number[]>;
+  selectEntities: MemoizedSelector<V, Dictionary<T>>;
+  selectAll: MemoizedSelector<V, T[]>;
+  selectTotal: MemoizedSelector<V, number>;
+}
+
 export interface EntityAdapter<T> extends EntityStateAdapter<T> {
   selectId: IdSelector<T>;
   sortComparer: false | Comparer<T>;
@@ -95,5 +104,5 @@ export interface EntityAdapter<T> extends EntityStateAdapter<T> {
   getSelectors(): EntitySelectors<T, EntityState<T>>;
   getSelectors<V>(
     selectState: (state: V) => EntityState<T>
-  ): EntitySelectors<T, V>;
+  ): MemoizedEntitySelectors<T, V>;
 }

--- a/modules/entity/src/state_selectors.ts
+++ b/modules/entity/src/state_selectors.ts
@@ -1,21 +1,26 @@
 import { createSelector } from '@ngrx/store';
-import { EntityState, EntitySelectors, Dictionary } from './models';
+import {
+  EntityState,
+  EntitySelectors,
+  Dictionary,
+  MemoizedEntitySelectors,
+} from './models';
 
 export function createSelectorsFactory<T>() {
   function getSelectors(): EntitySelectors<T, EntityState<T>>;
   function getSelectors<V>(
     selectState: (state: V) => EntityState<T>
-  ): EntitySelectors<T, V>;
-  function getSelectors(
-    selectState?: (state: any) => EntityState<T>
-  ): EntitySelectors<T, any> {
-    const selectIds = (state: any) => state.ids;
+  ): MemoizedEntitySelectors<T, V>;
+  function getSelectors<V>(
+    selectState?: (state: V) => EntityState<T>
+  ): EntitySelectors<T, EntityState<T>> | MemoizedEntitySelectors<T, V> {
+    const selectIds = (state: EntityState<T>) => state.ids;
     const selectEntities = (state: EntityState<T>) => state.entities;
     const selectAll = createSelector(
       selectIds,
       selectEntities,
-      (ids: T[], entities: Dictionary<T>): any =>
-        ids.map((id: any) => (entities as any)[id])
+      (ids: (string | number)[], entities: Dictionary<T>): T[] =>
+        ids.map((id) => entities[id] as T)
     );
 
     const selectTotal = createSelector(selectIds, (ids) => ids.length);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The typing for `EntityAdapter.getSelectors(stateSelector)` does not return memoized selectors.

Closes #2751

## What is the new behavior?

The typing for `EntityAdapter.getSelectors(stateSelector)` returns memoized selectors.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```