### PR TITLE
feat(store): use provideMockStore outside of the TestBed

### DIFF
--- a/modules/store/testing/src/testing.ts
+++ b/modules/store/testing/src/testing.ts
@@ -1,6 +1,7 @@
 import {
   ExistingProvider,
   FactoryProvider,
+  Injector,
   ValueProvider,
 } from '@angular/core';
 import { MockState } from './mock_state';
@@ -28,12 +29,13 @@ export interface MockStoreConfig<T> {
  *
  * @param config `MockStoreConfig<T>` to provide the values for `INITIAL_STATE` and `MOCK_SELECTORS` tokens.
  * By default, `initialState` and `selectors` are not defined.
+ * @returns Mock store providers that can be used with both `TestBed.configureTestingModule` and `Injector.create`.
  *
  * @usageNotes
  *
  * **With `TestBed.configureTestingModule`**
  *
- * ```ts
+ * ```typescript
  * describe('Books Component', () => {
  *   let store: MockStore;
  *
@@ -57,7 +59,7 @@ export interface MockStoreConfig<T> {
  *
  * **With `Injector.create`**
  *
- * ```ts
+ * ```typescript
  * describe('Counter Component', () => {
  *   let injector: Injector;
  *   let store: MockStore;
@@ -78,28 +80,21 @@ export function provideMockStore<T = any>(
 ): (ValueProvider | ExistingProvider | FactoryProvider)[] {
   setNgrxMockEnvironment(true);
   return [
-    { provide: INITIAL_STATE, useValue: config.initialState || {} },
-    { provide: MOCK_SELECTORS, useValue: config.selectors },
     {
       provide: ActionsSubject,
       useFactory: () => new ActionsSubject(),
       deps: [],
     },
+    { provide: MockState, useFactory: () => new MockState<T>(), deps: [] },
     {
-      provide: MockState,
-      useFactory: () => new MockState<T>(),
-      deps: [],
-    },
-    {
-      provide: StateObservable,
-      useFactory: () => new MockState<T>(),
-      deps: [],
-    },
-    {
-      provide: ReducerManager,
+      provide: MockReducerManager,
       useFactory: () => new MockReducerManager(),
       deps: [],
     },
+    { provide: INITIAL_STATE, useValue: config.initialState || {} },
+    { provide: MOCK_SELECTORS, useValue: config.selectors },
+    { provide: StateObservable, useExisting: MockState },
+    { provide: ReducerManager, useExisting: MockReducerManager },
     {
       provide: MockStore,
       useFactory: mockStoreFactory,
@@ -129,6 +124,37 @@ function mockStoreFactory<T>(
     initialState,
     mockSelectors
   );
+}
+
+/**
+ * @description
+ * Creates mock store with all necessary dependencies outside of the `TestBed`.
+ *
+ * @param config `MockStoreConfig<T>` to provide the values for `INITIAL_STATE` and `MOCK_SELECTORS` tokens.
+ * By default, `initialState` and `selectors` are not defined.
+ * @returns `MockStore<T>`
+ *
+ * @usageNotes
+ *
+ * ```typescript
+ * describe('Books Effects', () => {
+ *   let store: MockStore;
+ *
+ *   beforeEach(() => {
+ *     store = getMockStore({
+ *       initialState: { books: { entities: ['Book 1', 'Book 2', 'Book 3'] } },
+ *       selectors: [
+ *         { selector: selectAllBooks, value: ['Book 1', 'Book 2'] },
+ *         { selector: selectVisibleBooks, value: ['Book 1'] },
+ *       ],
+ *     });
+ *   });
+ * });
+ * ```
+ */
+export function getMockStore<T>(config: MockStoreConfig<T> = {}): MockStore<T> {
+  const injector = Injector.create({ providers: provideMockStore(config) });
+  return injector.get(MockStore);
 }
 
 export { MockReducerManager } from './mock_reducer_manager';

--- a/modules/store/testing/src/testing.ts
+++ b/modules/store/testing/src/testing.ts
@@ -1,4 +1,8 @@
-import { Provider } from '@angular/core';
+import {
+  ExistingProvider,
+  FactoryProvider,
+  ValueProvider,
+} from '@angular/core';
 import { MockState } from './mock_state';
 import {
   ActionsSubject,
@@ -18,20 +22,113 @@ export interface MockStoreConfig<T> {
   selectors?: MockSelector[];
 }
 
+/**
+ * @description
+ * Creates mock store providers.
+ *
+ * @param config `MockStoreConfig<T>` to provide the values for `INITIAL_STATE` and `MOCK_SELECTORS` tokens.
+ * By default, `initialState` and `selectors` are not defined.
+ *
+ * @usageNotes
+ *
+ * **With `TestBed.configureTestingModule`**
+ *
+ * ```ts
+ * describe('Books Component', () => {
+ *   let store: MockStore;
+ *
+ *   beforeEach(() => {
+ *     TestBed.configureTestingModule({
+ *       providers: [
+ *         provideMockStore({
+ *           initialState: { books: { entities: [] } },
+ *           selectors: [
+ *             { selector: selectAllBooks, value: ['Book 1', 'Book 2'] },
+ *             { selector: selectVisibleBooks, value: ['Book 1'] },
+ *           ],
+ *         }),
+ *       ],
+ *     });
+ *
+ *     store = TestBed.inject(MockStore);
+ *   });
+ * });
+ * ```
+ *
+ * **With `Injector.create`**
+ *
+ * ```ts
+ * describe('Counter Component', () => {
+ *   let injector: Injector;
+ *   let store: MockStore;
+ *
+ *   beforeEach(() => {
+ *     injector = Injector.create({
+ *       providers: [
+ *         provideMockStore({ initialState: { counter: 0 } }),
+ *       ],
+ *     });
+ *     store = injector.get(MockStore);
+ *   });
+ * });
+ * ```
+ */
 export function provideMockStore<T = any>(
   config: MockStoreConfig<T> = {}
-): Provider[] {
+): (ValueProvider | ExistingProvider | FactoryProvider)[] {
   setNgrxMockEnvironment(true);
   return [
-    ActionsSubject,
-    MockState,
-    MockStore,
     { provide: INITIAL_STATE, useValue: config.initialState || {} },
     { provide: MOCK_SELECTORS, useValue: config.selectors },
-    { provide: StateObservable, useClass: MockState },
-    { provide: ReducerManager, useClass: MockReducerManager },
+    {
+      provide: ActionsSubject,
+      useFactory: () => new ActionsSubject(),
+      deps: [],
+    },
+    {
+      provide: MockState,
+      useFactory: () => new MockState<T>(),
+      deps: [],
+    },
+    {
+      provide: StateObservable,
+      useFactory: () => new MockState<T>(),
+      deps: [],
+    },
+    {
+      provide: ReducerManager,
+      useFactory: () => new MockReducerManager(),
+      deps: [],
+    },
+    {
+      provide: MockStore,
+      useFactory: mockStoreFactory,
+      deps: [
+        MockState,
+        ActionsSubject,
+        ReducerManager,
+        INITIAL_STATE,
+        MOCK_SELECTORS,
+      ],
+    },
     { provide: Store, useExisting: MockStore },
   ];
+}
+
+function mockStoreFactory<T>(
+  mockState: MockState<T>,
+  actionsSubject: ActionsSubject,
+  reducerManager: ReducerManager,
+  initialState: T,
+  mockSelectors: MockSelector[]
+): MockStore<T> {
+  return new MockStore(
+    mockState,
+    actionsSubject,
+    reducerManager,
+    initialState,
+    mockSelectors
+  );
 }
 
 export { MockReducerManager } from './mock_reducer_manager';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`provideMockStore` can only be used with `TestBed.configureTestingModule`.

Closes #2745

## What is the new behavior?

`provideMockStore` can be used with `TestBed.configureTestingModule` and `Injector.create`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
