### PR TITLE
feat(effects): use provideMockActions outside of the TestBed

### DIFF
--- a/modules/effects/testing/spec/mock_actions.spec.ts
+++ b/modules/effects/testing/spec/mock_actions.spec.ts
@@ -1,0 +1,59 @@
+import { of } from 'rxjs';
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Actions } from '@ngrx/effects';
+import { Injector } from '@angular/core';
+
+describe('Mock Actions', () => {
+  describe('with TestBed', () => {
+    it('should provide Actions from source', (done) => {
+      TestBed.configureTestingModule({
+        providers: [provideMockActions(of({ type: 'foo' }))],
+      });
+
+      const actions$ = TestBed.inject(Actions);
+      actions$.subscribe((action) => {
+        expect(action.type).toBe('foo');
+        done();
+      });
+    });
+
+    it('should provide Actions from factory', (done) => {
+      TestBed.configureTestingModule({
+        providers: [provideMockActions(() => of({ type: 'bar' }))],
+      });
+
+      const actions$ = TestBed.inject(Actions);
+      actions$.subscribe((action) => {
+        expect(action.type).toBe('bar');
+        done();
+      });
+    });
+  });
+
+  describe('with Injector', () => {
+    it('should provide Actions from source', (done) => {
+      const injector = Injector.create({
+        providers: [provideMockActions(of({ type: 'foo' }))],
+      });
+
+      const actions$ = injector.get(Actions);
+      actions$.subscribe((action) => {
+        expect(action.type).toBe('foo');
+        done();
+      });
+    });
+
+    it('should provide Actions from factory', (done) => {
+      const injector = Injector.create({
+        providers: [provideMockActions(() => of({ type: 'bar' }))],
+      });
+
+      const actions$ = injector.get(Actions);
+      actions$.subscribe((action) => {
+        expect(action.type).toBe('bar');
+        done();
+      });
+    });
+  });
+});

--- a/modules/effects/testing/src/testing.ts
+++ b/modules/effects/testing/src/testing.ts
@@ -1,12 +1,71 @@
-import { Provider } from '@angular/core';
+import { FactoryProvider } from '@angular/core';
 import { Actions } from '@ngrx/effects';
 import { defer, Observable } from 'rxjs';
 
-export function provideMockActions(source: Observable<any>): Provider;
-export function provideMockActions(factory: () => Observable<any>): Provider;
+/**
+ * @description
+ * Creates mock actions provider.
+ *
+ * @param source Actions' source
+ */
+export function provideMockActions(source: Observable<any>): FactoryProvider;
+/**
+ * @description
+ * Creates mock actions provider.
+ *
+ * @param factory Actions' source creation function
+ *
+ * @usageNotes
+ *
+ * **With `TestBed.configureTestingModule`**
+ *
+ * ```ts
+ * describe('Books Effects', () => {
+ *   let actions$: Observable<any>;
+ *   let effects: BooksEffects;
+ *
+ *   beforeEach(() => {
+ *     TestBed.configureTestingModule({
+ *       providers: [
+ *         provideMockActions(() => actions$),
+ *         BooksEffects,
+ *       ],
+ *     });
+ *
+ *     actions$ = TestBed.inject(Actions);
+ *     effects = TestBed.inject(BooksEffects);
+ *   });
+ * });
+ * ```
+ *
+ * **With `Injector.create`**
+ *
+ * ```ts
+ * describe('Counter Effects', () => {
+ *   let injector: Injector;
+ *   let actions$: Observable<any>;
+ *   let effects: CounterEffects;
+ *
+ *   beforeEach(() => {
+ *     injector = Injector.create({
+ *       providers: [
+ *         provideMockActions(() => actions$),
+ *         CounterEffects,
+ *       ],
+ *     });
+ *
+ *     actions$ = injector.get(Actions);
+ *     effects = injector.get(CounterEffects);
+ *   });
+ * });
+ * ```
+ */
+export function provideMockActions(
+  factory: () => Observable<any>
+): FactoryProvider;
 export function provideMockActions(
   factoryOrSource: (() => Observable<any>) | Observable<any>
-): Provider {
+): FactoryProvider {
   return {
     provide: Actions,
     useFactory: (): Observable<any> => {
@@ -16,5 +75,6 @@ export function provideMockActions(
 
       return new Actions(factoryOrSource);
     },
+    deps: [],
   };
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`provideMockActions` can be used with `TestBed.configureTestingModule`

## What is the new behavior?

`provideMockActions` can be used with `TestBed.configureTestingModule` and `Injector.create`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This feature is similar to: https://github.com/ngrx/platform/pull/2759
