### PR TITLE
perf(router-store): optimize selectQueryParams, selectQueryParam and selectFragment selectors

### DIFF
--- a/modules/router-store/spec/router_selectors.spec.ts
+++ b/modules/router-store/spec/router_selectors.spec.ts
@@ -12,11 +12,15 @@ const mockData = {
       url: [],
       outlet: 'primary',
       routeConfig: null,
-      queryParams: {},
-      queryParamMap: {
-        params: {},
+      queryParams: {
+        ref: 'ngrx.io',
       },
-      fragment: null,
+      queryParamMap: {
+        params: {
+          ref: 'ngrx.io',
+        },
+      },
+      fragment: 'test-fragment',
       firstChild: {
         params: {},
         paramMap: {
@@ -34,10 +38,12 @@ const mockData = {
           path: 'login',
         },
         queryParams: {
-          id: 3,
+          ref: 'ngrx.io',
         },
         queryParamMap: {
-          params: {},
+          params: {
+            ref: 'ngrx.io',
+          },
         },
         firstChild: {
           params: {
@@ -72,7 +78,7 @@ const mockData = {
           fragment: 'test-fragment',
           children: [],
         },
-        fragment: null,
+        fragment: 'test-fragment',
         children: [],
       },
       children: [
@@ -92,10 +98,15 @@ const mockData = {
           routeConfig: {
             path: 'login',
           },
-          queryParams: {},
-          queryParamMap: {
-            params: {},
+          queryParams: {
+            ref: 'ngrx.io',
           },
+          queryParamMap: {
+            params: {
+              ref: 'ngrx.io',
+            },
+          },
+          fragment: 'test-fragment',
           children: [],
         },
       ],
@@ -104,6 +115,7 @@ const mockData = {
   },
   navigationId: 1,
 };
+
 describe('Router State Selectors', () => {
   describe('Composed Selectors', () => {
     interface State {
@@ -145,25 +157,19 @@ describe('Router State Selectors', () => {
     it('should create a selector for selecting the fragment', () => {
       const result = selectors.selectFragment(state);
 
-      expect(result).toEqual(
-        state.router.state.root.firstChild.firstChild.fragment
-      );
+      expect(result).toEqual(state.router.state.root.fragment);
     });
 
     it('should create a selector for selecting the query params', () => {
       const result = selectors.selectQueryParams(state);
 
-      expect(result).toEqual(
-        state.router.state.root.firstChild.firstChild.queryParams
-      );
+      expect(result).toEqual(state.router.state.root.queryParams);
     });
 
     it('should create a selector for selecting a specific query param', () => {
       const result = selectors.selectQueryParam('ref')(state);
 
-      expect(result).toEqual(
-        state.router.state.root.firstChild.firstChild.queryParams.ref
-      );
+      expect(result).toEqual(state.router.state.root.queryParams.ref);
     });
 
     it('should create a selector for selecting the route params', () => {

--- a/modules/router-store/src/router_selectors.ts
+++ b/modules/router-store/src/router_selectors.ts
@@ -4,33 +4,31 @@ import { RouterReducerState } from './reducer';
 
 export function getSelectors<V>(
   selectState: (state: V) => RouterReducerState<any>
-): RouterStateSelectors<V>;
-export function getSelectors<V>(
-  selectState: (state: V) => RouterReducerState<any>
 ): RouterStateSelectors<V> {
   const selectRouterState = createSelector(
     selectState,
     (router) => router && router.state
   );
-  const selectCurrentRoute = createSelector(
+  const selectRootRoute = createSelector(
     selectRouterState,
-    (routerState) => {
-      if (!routerState) {
-        return undefined;
-      }
-      let route = routerState.root;
-      while (route.firstChild) {
-        route = route.firstChild;
-      }
-      return route;
-    }
+    (routerState) => routerState && routerState.root
   );
+  const selectCurrentRoute = createSelector(selectRootRoute, (rootRoute) => {
+    if (!rootRoute) {
+      return undefined;
+    }
+    let route = rootRoute;
+    while (route.firstChild) {
+      route = route.firstChild;
+    }
+    return route;
+  });
   const selectFragment = createSelector(
-    selectCurrentRoute,
+    selectRootRoute,
     (route) => route && route.fragment
   );
   const selectQueryParams = createSelector(
-    selectCurrentRoute,
+    selectRootRoute,
     (route) => route && route.queryParams
   );
   const selectQueryParam = (param: string) =>

--- a/projects/ngrx.io/content/guide/migration/v11.md
+++ b/projects/ngrx.io/content/guide/migration/v11.md
@@ -58,3 +58,63 @@ The new method name `setAll` describes the intention better.
 ```ts
 adapter.setAll(action.entities, state);
 ```
+
+### @ngrx/router-store
+
+#### Optimized `selectQueryParams`, `selectQueryParam` and `selectFragment` selectors
+
+They select query parameters/fragment from the root router state node instead of the last router state node.
+
+BEFORE:
+
+```ts
+const queryParams$ = this.store.select(selectQueryParams);
+const fragment$ = this.store.select(selectFragment);
+
+/*
+router state:
+{
+  root: {
+    queryParams: {
+      search: 'foo',
+    },
+    fragment: 'bar',
+    firstChild: {
+      queryParams: {
+        search: 'foo', 👈 query parameters are selected from here
+      },
+      fragment: 'bar', 👈 fragment is selected from here
+      firstChild: undefined,
+    },
+  },
+  url: '/books?search=foo#bar',
+}
+*/
+```
+
+AFTER:
+
+```ts
+const queryParams$ = this.store.select(selectQueryParams);
+const fragment$ = this.store.select(selectFragment);
+
+/*
+router state:
+{
+  root: {
+    queryParams: {
+      search: 'foo', 👈 query parameters are selected from here
+    },
+    fragment: 'bar', 👈 fragment is selected from here
+    firstChild: {
+      queryParams: {
+        search: 'foo',
+      },
+      fragment: 'bar',
+      firstChild: undefined,
+    },
+  },
+  url: '/books?search=foo#bar',
+}
+*/
+```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Performance improvement
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`selectQueryParams` - returns query params from the last router state node
`selectQueryParam` - returns a query param from the last router state node
`selectFragment` - returns the fragment from the last router state node

## What is the new behavior?

Optional chaining is introduced for all selectors.

`selectQueryParams` - returns query params from `routerState.root`
`selectQueryParam` - returns a query param from `routerState.root`
`selectFragment` - returns the fragment from `routerState.root`

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Actually, this can be a breaking change in test files (for `selectQueryParams`, `selectQueryParam` and `selectFragment` selectors) if mock router state is defined in the wrong way. But when it is used with Angular router, there are no breaking changes.