### PR TITLE
feat(router-store): Add urlAfterRedirects to Minimal

### DIFF
--- a/modules/router-store/spec/utils.ts
+++ b/modules/router-store/spec/utils.ts
@@ -42,6 +42,11 @@ export function createTestModule(
           loadChildren: 'test',
           canLoad: ['CanLoadNext'],
         },
+        {
+          path: 'redirect',
+          pathMatch: 'full',
+          redirectTo: 'next',
+        },
       ]),
       StoreRouterConnectingModule.forRoot(opts.config),
     ],

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -327,7 +327,13 @@ export class StoreRouterConnectingModule {
           event:
             this.config.routerState === RouterState.Full
               ? payload.event
-              : { id: payload.event.id, url: payload.event.url },
+              : {
+                  id: payload.event.id,
+                  url: payload.event.url,
+                  // safe, as it will just be `undefined` for non-NavigationEnd router events
+                  urlAfterRedirects: (payload.event as NavigationEnd)
+                    .urlAfterRedirects,
+                },
         },
       });
     } finally {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Even if the developer is using `RouterState.Minimal` we should be providing the `urlAfterRedirects` property, that exists on `NavigationEnd` Router even.
Is got broken when the default implementation was switched from `Full` to `Minimal`, however our `Minimal` should still cover this case.

Also, fix the router tests - with just `async () =>` they were not testing the assertions within `subscribe(...)` 😳 
Discovered that, because I first try to fail the test, before making sure that new code passes.

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
