### PR TITLE
fix(store): added noop for all methods in MockReducerManager

### DIFF
--- a/modules/store/testing/src/mock_reducer_manager.ts
+++ b/modules/store/testing/src/mock_reducer_manager.ts
@@ -17,4 +17,28 @@ export class MockReducerManager extends BehaviorSubject<
   addFeatures(feature: any) {
     /* noop */
   }
+
+  removeFeature(feature: any) {
+    /* noop */
+  }
+
+  removeFeatures(features: any) {
+    /* noop */
+  }
+
+  addReducer(key: any, reducer: any) {
+    /* noop */
+  }
+
+  addReducers(reducers: any) {
+    /* noop */
+  }
+
+  removeReducer(featureKey: any) {
+    /* noop */
+  }
+
+  removeReducers(featureKeys: any) {
+    /* noop */
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

It is currently not possible to use provideMockStore if the component has a dependency to a module which uses the following imports:
- removeFeature
- removeFeatures
- addReducer
- addReducers
- removeReducer
- removeReducers

Currently crashes with something like
`TypeError: reducerManager.addReducer is not a function`

Closes https://github.com/ngrx/platform/issues/2776

## What is the new behavior?

Add `noop` for `removeFeature`, `removeFeatures`, `addReducer`, `addReducers`, `removeReducer`, `removeReducers`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
