### PR TITLE
fix(schematics): add schematics to devDependencies

### DIFF
--- a/modules/schematics/package.json
+++ b/modules/schematics/package.json
@@ -21,6 +21,9 @@
   },
   "homepage": "https://github.com/ngrx/platform#readme",
   "schematics": "./collection.json",
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "ng-update": {
     "packageGroup": [
       "@ngrx/store",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, when you run `ng add @ngrx/schematics` the package will be added to `dependencies`.

## What is the new behavior?


This change, adds the `@ngrx/schematics` package to the  `devDependencies`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

[Schematics docs](https://angular.io/guide/schematics-for-libraries#define-dependency-type)