### PR TITLE
feat(data): Add DefaultDataServiceConfig to EntityDataModuleConfig

### DIFF
--- a/modules/data/spec/dataservices/default-data.service.spec.ts
+++ b/modules/data/spec/dataservices/default-data.service.spec.ts
@@ -42,7 +42,7 @@ describe('DefaultDataService', () => {
     httpClient = TestBed.inject(HttpClient);
     httpTestingController = TestBed.inject(HttpTestingController);
 
-    httpUrlGenerator = new DefaultHttpUrlGenerator(null as any);
+    httpUrlGenerator = new DefaultHttpUrlGenerator(null as any, null as any);
     httpUrlGenerator.registerHttpResourceUrls({
       Hero: {
         entityResourceUrl: heroUrl,
@@ -50,7 +50,7 @@ describe('DefaultDataService', () => {
       },
     });
 
-    service = new DefaultDataService('Hero', httpClient, httpUrlGenerator);
+    service = new DefaultDataService('Hero', httpClient, httpUrlGenerator, {});
   });
 
   afterEach(() => {
@@ -76,7 +76,7 @@ describe('DefaultDataService', () => {
 
     beforeEach(() => {
       // use test wrapper class to get to protected properties
-      service = new TestService('Hero', httpClient, httpUrlGenerator);
+      service = new TestService('Hero', httpClient, httpUrlGenerator, {});
     });
 
     it('has expected name', () => {
@@ -468,7 +468,7 @@ describe('DefaultDataServiceFactory', () => {
   let httpUrlGenerator: HttpUrlGenerator;
 
   beforeEach(() => {
-    httpUrlGenerator = new DefaultHttpUrlGenerator(null as any);
+    httpUrlGenerator = new DefaultHttpUrlGenerator(null as any, {});
     httpUrlGenerator.registerHttpResourceUrls({
       Hero: {
         entityResourceUrl: heroUrl,
@@ -486,13 +486,13 @@ describe('DefaultDataServiceFactory', () => {
 
   describe('(no config)', () => {
     it('can create factory', () => {
-      const factory = new DefaultDataServiceFactory(http, httpUrlGenerator);
+      const factory = new DefaultDataServiceFactory(http, httpUrlGenerator, {});
       const heroDS = factory.create<Hero>('Hero');
       expect(heroDS.name).toBe('Hero DefaultDataService');
     });
 
     it('should produce hero data service that gets all heroes with expected URL', () => {
-      const factory = new DefaultDataServiceFactory(http, httpUrlGenerator);
+      const factory = new DefaultDataServiceFactory(http, httpUrlGenerator, {});
       const heroDS = factory.create<Hero>('Hero');
       heroDS.getAll();
       expect(http.get).toHaveBeenCalledWith('api/heroes', undefined);

--- a/modules/data/spec/dataservices/entity-data.service.spec.ts
+++ b/modules/data/spec/dataservices/entity-data.service.spec.ts
@@ -14,6 +14,7 @@ import {
   EntityDataService,
   EntityCollectionDataService,
   QueryParams,
+  DefaultDataServiceConfig,
 } from '../../';
 
 // region Test Helpers
@@ -72,7 +73,7 @@ export class BazingaDataService
 }
 
 @NgModule({
-  providers: [BazingaDataService],
+  providers: [BazingaDataService, DefaultDataServiceConfig],
 })
 export class CustomDataServiceModule {
   constructor(

--- a/modules/data/src/dataservices/default-data-service-config.ts
+++ b/modules/data/src/dataservices/default-data-service-config.ts
@@ -4,23 +4,25 @@ import { EntityHttpResourceUrls } from './http-url-generator';
  * Optional configuration settings for an entity collection data service
  * such as the `DefaultDataService<T>`.
  */
-export abstract class DefaultDataServiceConfig {
+export class DefaultDataServiceConfig {
   /**
    * root path of the web api.  may also include protocol, domain, and port
    * for remote api, e.g.: `'https://api-domain.com:8000/api/v1'` (default: 'api')
    */
-  root?: string;
+  root?: string = 'api';
   /**
    * Known entity HttpResourceUrls.
    * HttpUrlGenerator will create these URLs for entity types not listed here.
    */
   entityHttpResourceUrls?: EntityHttpResourceUrls;
   /** Is a DELETE 404 really OK? (default: true) */
-  delete404OK?: boolean;
+  delete404OK?: boolean = true;
   /** Simulate GET latency in a demo (default: 0) */
-  getDelay?: number;
+  getDelay?: number = 0;
   /** Simulate save method (PUT/POST/DELETE) latency in a demo (default: 0) */
-  saveDelay?: number;
+  saveDelay?: number = 0;
   /** request timeout in MS (default: 0)*/
-  timeout?: number; //
+  timeout?: number = 0;
+  /** pluralize requests for single entities (default: true) */
+  pluralizeSingle?: boolean = true;
 }

--- a/modules/data/src/dataservices/default-data.service.ts
+++ b/modules/data/src/dataservices/default-data.service.ts
@@ -43,7 +43,7 @@ export class DefaultDataService<T> implements EntityCollectionDataService<T> {
     entityName: string,
     protected http: HttpClient,
     protected httpUrlGenerator: HttpUrlGenerator,
-    config?: DefaultDataServiceConfig
+    config: DefaultDataServiceConfig
   ) {
     this._name = `${entityName} DefaultDataService`;
     this.entityName = entityName;
@@ -53,7 +53,7 @@ export class DefaultDataService<T> implements EntityCollectionDataService<T> {
       getDelay = 0,
       saveDelay = 0,
       timeout: to = 0,
-    } = config || {};
+    } = config;
     this.delete404OK = delete404OK;
     this.entityUrl = httpUrlGenerator.entityResource(entityName, root);
     this.entitiesUrl = httpUrlGenerator.collectionResource(entityName, root);
@@ -204,9 +204,8 @@ export class DefaultDataServiceFactory {
   constructor(
     protected http: HttpClient,
     protected httpUrlGenerator: HttpUrlGenerator,
-    @Optional() protected config?: DefaultDataServiceConfig
+    protected config: DefaultDataServiceConfig
   ) {
-    config = config || {};
     httpUrlGenerator.registerHttpResourceUrls(config.entityHttpResourceUrls);
   }
 

--- a/modules/data/src/dataservices/http-url-generator.ts
+++ b/modules/data/src/dataservices/http-url-generator.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Pluralizer } from '../utils/interfaces';
+import { DefaultDataServiceConfig } from './default-data-service-config';
 
 /**
  * Known resource URLS for specific entity types.
@@ -68,7 +69,10 @@ export class DefaultHttpUrlGenerator implements HttpUrlGenerator {
    */
   protected knownHttpResourceUrls: EntityHttpResourceUrls = {};
 
-  constructor(private pluralizer: Pluralizer) {}
+  constructor(
+    private pluralizer: Pluralizer,
+    private defaultDataServiceConfig: DefaultDataServiceConfig
+  ) {}
 
   /**
    * Get or generate the entity and collection resource URLs for the given entity type name
@@ -82,11 +86,14 @@ export class DefaultHttpUrlGenerator implements HttpUrlGenerator {
     let resourceUrls = this.knownHttpResourceUrls[entityName];
     if (!resourceUrls) {
       const nRoot = normalizeRoot(root);
+      let pluralUrl = `${nRoot}/${this.pluralizer.pluralize(
+        entityName
+      )}/`.toLowerCase();
       resourceUrls = {
-        entityResourceUrl: `${nRoot}/${entityName}/`.toLowerCase(),
-        collectionResourceUrl: `${nRoot}/${this.pluralizer.pluralize(
-          entityName
-        )}/`.toLowerCase(),
+        entityResourceUrl: this.defaultDataServiceConfig.pluralizeSingle
+          ? pluralUrl
+          : `${nRoot}/${entityName}/`.toLowerCase(),
+        collectionResourceUrl: pluralUrl,
       };
       this.registerHttpResourceUrls({ [entityName]: resourceUrls });
     }

--- a/modules/data/src/entity-data-without-effects.module.ts
+++ b/modules/data/src/entity-data-without-effects.module.ts
@@ -49,6 +49,7 @@ import { EntitySelectors$Factory } from './selectors/entity-selectors$';
 import { EntityServicesBase } from './entity-services/entity-services-base';
 import { EntityServicesElements } from './entity-services/entity-services-elements';
 import { Logger, PLURAL_NAMES_TOKEN } from './utils/interfaces';
+import { DefaultDataServiceConfig } from './dataservices/default-data-service-config';
 
 export interface EntityDataModuleConfig {
   entityMetadata?: EntityMetadataMap;
@@ -60,6 +61,7 @@ export interface EntityDataModuleConfig {
   // Initial EntityCache state or a function that returns that state
   initialEntityCacheState?: EntityCache | (() => EntityCache);
   pluralNames?: { [name: string]: string };
+  dataServiceConfig?: DefaultDataServiceConfig;
 }
 
 /**

--- a/modules/data/src/entity-data.module.ts
+++ b/modules/data/src/entity-data.module.ts
@@ -32,6 +32,7 @@ import {
   EntityDataModuleConfig,
   EntityDataModuleWithoutEffects,
 } from './entity-data-without-effects.module';
+import { DefaultDataServiceConfig } from './dataservices/default-data-service-config';
 
 /**
  * entity-data main module includes effects and HTTP data services
@@ -89,6 +90,13 @@ export class EntityDataModule {
           provide: PLURAL_NAMES_TOKEN,
           multi: true,
           useValue: config.pluralNames ? config.pluralNames : {},
+        },
+        {
+          provide: DefaultDataServiceConfig,
+          useValue: {
+            ...new DefaultDataServiceConfig(),
+            ...config.dataServiceConfig,
+          } as DefaultDataServiceConfig,
         },
       ],
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,6 +283,11 @@
   dependencies:
     tslib "^2.0.0"
 
+"@angular/language-service@^10.0.0":
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-10.2.3.tgz#bb678c11822b9bf7ca007703a31dae090dc2c0ab"
+  integrity sha512-8rtNG3HjBdUMlKcakh6gDfFvYSS5X16ymbVR0i2L/Nc4d9HuqgKrIrsNY4We/jSBoAjo/CGS8AvbscMa8oW4Eg==
+
 "@angular/material@^10.0.0":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@angular/material/-/material-10.0.0.tgz#ecd83ade893b1501a9db5e2f98ab94015a9e7cee"


### PR DESCRIPTION
- add `dataServiceConfig` to `EntityDataModuleConfig`
- add `pluralizeSingle` attribute to `DefaultDataServiceConfig`, so users will be able to select to pluralize or not the request for single entities
- add `example-ngrx-data-app`

## PR Type

What kind of change does this PR introduce?

> Feature

## What is the current behavior?

Currently is not possible to pass a `dataServiceConfig` option to the `EntitDataModule.forRoot` method

## What is the new behavior?

This changes will make it possible to add `dataServiceConfig` options to the `EntitDataModule.forRoot` method, for example:

```ts

export const entityConfig: EntityDataModuleConfig = {
  entityMetadata,
  pluralNames,
  dataServiceConfig: {
    root: 'http://my-json-server.typicode.com/johnlindquist/json-server-heroes',
  },
};

@NgModule({
  declarations: [AppComponent, HeroesComponent, HeroFormComponent],
  imports: [
    BrowserModule,
    AppRoutingModule,
    HttpClientModule,
    StoreModule.forRoot({}, {}),
    EffectsModule.forRoot([]),
    EntityDataModule.forRoot(entityConfig),
    FormsModule,
  ],
  providers: [],
  bootstrap: [AppComponent],
})
export class AppModule {}
```

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
