### PR TITLE
feat(store): add object-style StoreModule.forFeature overload

### DIFF
--- a/modules/store/spec/modules.spec.ts
+++ b/modules/store/spec/modules.spec.ts
@@ -216,4 +216,34 @@ describe(`Store Modules`, () => {
       });
     });
   });
+
+  describe(`: Slice-Like paramter`, () => {
+    @NgModule({
+      imports: [
+        StoreModule.forFeature({ name: 'a', reducer: featureAReducer }),
+      ],
+    })
+    class FeatureAModule {}
+
+    @NgModule({
+      imports: [StoreModule.forRoot({}), FeatureAModule],
+    })
+    class RootModule {}
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [RootModule],
+      });
+
+      store = TestBed.inject(Store);
+    });
+
+    it('should set up a feature state', () => {
+      store.pipe(take(1)).subscribe((state: State) => {
+        expect(state).toEqual({
+          a: 5,
+        } as State);
+      });
+    });
+  });
 });

--- a/modules/store/spec/modules.spec.ts
+++ b/modules/store/spec/modules.spec.ts
@@ -217,7 +217,7 @@ describe(`Store Modules`, () => {
     });
   });
 
-  describe(`: Slice-Like paramter`, () => {
+  describe(`: With slice object`, () => {
     @NgModule({
       imports: [
         StoreModule.forFeature({ name: 'a', reducer: featureAReducer }),

--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -55,5 +55,6 @@ export {
   StoreFeatureModule,
   RootStoreConfig,
   StoreConfig,
+  FeatureSlice,
 } from './store_module';
 export { On, on, createReducer } from './reducer_creator';

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -114,6 +114,14 @@ export interface RootStoreConfig<T, V extends Action = Action>
   runtimeChecks?: Partial<RuntimeChecks>;
 }
 
+/**
+ * A pair of reducer and name for the feature.
+ */
+export interface FeatureSlice<T, V extends Action = Action> {
+  name: string;
+  reducer: ActionReducer<T, V> | InjectionToken<ActionReducer<T, V>>;
+}
+
 @NgModule({})
 export class StoreModule {
   static forRoot<T, V extends Action = Action>(
@@ -192,15 +200,36 @@ export class StoreModule {
     reducer: ActionReducer<T, V> | InjectionToken<ActionReducer<T, V>>,
     config?: StoreConfig<T, V> | InjectionToken<StoreConfig<T, V>>
   ): ModuleWithProviders<StoreFeatureModule>;
+  static forFeature<T, V extends Action = Action>(
+    slice: FeatureSlice<T, V>,
+    config?: StoreConfig<T, V> | InjectionToken<StoreConfig<T, V>>
+  ): ModuleWithProviders<StoreFeatureModule>;
   static forFeature(
-    featureName: string,
-    reducers:
+    featureNameOrSlice: string | FeatureSlice<any, any>,
+    reducersOrConfig?:
       | ActionReducerMap<any, any>
       | InjectionToken<ActionReducerMap<any, any>>
       | ActionReducer<any, any>
-      | InjectionToken<ActionReducer<any, any>>,
+      | InjectionToken<ActionReducer<any, any>>
+      | StoreConfig<any, any>
+      | InjectionToken<StoreConfig<any, any>>,
     config: StoreConfig<any, any> | InjectionToken<StoreConfig<any, any>> = {}
   ): ModuleWithProviders<StoreFeatureModule> {
+    let featureName: string;
+    let reducers:
+      | ActionReducerMap<any, any>
+      | InjectionToken<ActionReducerMap<any, any>>
+      | ActionReducer<any, any>
+      | InjectionToken<ActionReducer<any, any>>;
+    if (typeof featureNameOrSlice === 'string') {
+      featureName = featureNameOrSlice;
+      reducers = reducersOrConfig as any;
+    } else {
+      featureName = featureNameOrSlice.name;
+      reducers = featureNameOrSlice.reducer;
+      config = (reducersOrConfig as any) ?? {};
+    }
+
     return {
       ngModule: StoreFeatureModule,
       providers: [

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -115,11 +115,11 @@ export interface RootStoreConfig<T, V extends Action = Action>
 }
 
 /**
- * A pair of reducer and name for the feature.
+ * An object with the name and the reducer for the feature.
  */
 export interface FeatureSlice<T, V extends Action = Action> {
   name: string;
-  reducer: ActionReducer<T, V> | InjectionToken<ActionReducer<T, V>>;
+  reducer: ActionReducer<T, V>;
 }
 
 @NgModule({})


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2809 

## What is the new behavior?

Adding a new overload for `StoreModule.forFeature()`;

```ts
  static forFeature<T, V extends Action = Action>(
    slice: FeatureSlice<T, V>,
    config?: StoreConfig<T, V> | InjectionToken<StoreConfig<T, V>>
  ): ModuleWithProviders<StoreFeatureModule>;
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I think my code is not elegant because added overload has a very different shape. I'd like to be commented on codes.
