### PR TITLE
fix(router-store): ignore trailing slash when comparing routes

### DIFF
--- a/modules/router-store/spec/integration.spec.ts
+++ b/modules/router-store/spec/integration.spec.ts
@@ -18,6 +18,7 @@ import {
   ROUTER_NAVIGATED,
   ROUTER_NAVIGATION,
   ROUTER_REQUEST,
+  routerNavigationAction,
   RouterAction,
   routerReducer,
   RouterReducerState,
@@ -167,6 +168,32 @@ describe('integration spec', () => {
 
         done();
       });
+  });
+
+  it('should ignore routing actions for the URL that is currently open', async () => {
+    createTestModule({
+      reducers: { router: routerReducer },
+    });
+
+    const router = TestBed.inject(Router);
+    const store = TestBed.inject(Store);
+    const navigateByUrlSpy = jest.spyOn(router, 'navigateByUrl');
+
+    await router.navigateByUrl('/');
+
+    const SAME_URL_WITHOUT_SLASH = '';
+
+    store.dispatch(
+      routerNavigationAction({
+        payload: {
+          routerState: { url: SAME_URL_WITHOUT_SLASH, root: {} as any },
+          event: { id: 123 } as any,
+        },
+      })
+    );
+
+    //                         Navigates only ONCE 👇
+    expect(navigateByUrlSpy.mock.calls.length).toBe(1);
   });
 
   it('should support rolling back if navigation gets canceled (navigation initialized through router)', (done: any) => {
@@ -573,7 +600,7 @@ describe('integration spec', () => {
 
       expect(log).toEqual([
         { type: 'store', state: null }, // initial state
-        { type: 'store', state: null }, // ROUTER_REQEST event in the store
+        { type: 'store', state: null }, // ROUTER_REQUEST event in the store
         { type: 'action', action: ROUTER_REQUEST },
         { type: 'router', event: 'NavigationStart', url: '/load' },
         { type: 'store', state: { url: '', navigationId: 1 } },

--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -219,7 +219,7 @@ export class StoreRouterConnectingModule {
     }
 
     const url = routerStoreState.state.url;
-    if (this.router.url !== url) {
+    if (!isSameUrl(this.router.url, url)) {
       this.storeState = storeState;
       this.trigger = RouterTrigger.STORE;
       this.router.navigateByUrl(url).catch((error) => {
@@ -346,4 +346,18 @@ export class StoreRouterConnectingModule {
     this.storeState = null;
     this.routerState = null;
   }
+}
+
+/**
+ * Check if the URLs are matching. Accounts for the possibility of trailing "/" in url.
+ */
+function isSameUrl(first: string, second: string): boolean {
+  return stripTrailingSlash(first) === stripTrailingSlash(second);
+}
+
+function stripTrailingSlash(text: string): string {
+  if (text.length > 0 && text[text.length - 1] === '/') {
+    return text.substring(0, text.length - 1);
+  }
+  return text;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Ignore trailing slash (`/`) when comparing URLs in the `navigateIfNeed` method of the `router-store`.

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

proceeds with re-navigation, which can lead to infinite loop if there's a guard on `/` or `` path (root).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2829 

## What is the new behavior?

Doesn't navigate if the changes in Store lead to the URL being the same as the current one (previously only the exact match would've prevented it).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
