### PR TITLE
feat(component-store): allow more than 4 selects

### DIFF
--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -36,6 +36,16 @@ export const INITIAL_STATE_TOKEN = new InjectionToken(
   '@ngrx/component-store Initial State'
 );
 
+export type SelectorResults<Selectors> = {
+  [Key in keyof Selectors]: Selectors[Key] extends Observable<infer U>
+    ? U
+    : Selectors;
+};
+export type SelectorProjector<
+  Selectors extends Observable<unknown>[],
+  Result
+> = (...args: SelectorResults<Selectors>) => Result;
+
 @Injectable()
 export class ComponentStore<T extends object> implements OnDestroy {
   // Should be used only in ngOnDestroy.
@@ -196,46 +206,34 @@ export class ComponentStore<T extends object> implements OnDestroy {
   /**
    * Creates a selector.
    *
-   * This supports combining up to 4 selectors. More could be added as needed.
-   *
    * @param projector A pure projection function that takes the current state and
    *   returns some new slice/projection of that state.
    * @param config SelectConfig that changes the behavior of selector, including
    *   the debouncing of the values until the state is settled.
    * @return An observable of the projector results.
    */
-  select<R>(projector: (s: T) => R, config?: SelectConfig): Observable<R>;
-  select<R, S1>(
-    s1: Observable<S1>,
-    projector: (s1: S1) => R,
+  select<Result>(
+    projector: (s: T) => Result,
     config?: SelectConfig
-  ): Observable<R>;
-  select<R, S1, S2>(
-    s1: Observable<S1>,
-    s2: Observable<S2>,
-    projector: (s1: S1, s2: S2) => R,
-    config?: SelectConfig
-  ): Observable<R>;
-  select<R, S1, S2, S3>(
-    s1: Observable<S1>,
-    s2: Observable<S2>,
-    s3: Observable<S3>,
-    projector: (s1: S1, s2: S2, s3: S3) => R,
-    config?: SelectConfig
-  ): Observable<R>;
-  select<R, S1, S2, S3, S4>(
-    s1: Observable<S1>,
-    s2: Observable<S2>,
-    s3: Observable<S3>,
-    s4: Observable<S4>,
-    projector: (s1: S1, s2: S2, s3: S3, s4: S4) => R,
-    config?: SelectConfig
-  ): Observable<R>;
+  ): Observable<Result>;
+  select<Selectors extends Observable<unknown>[], Result>(
+    ...args: [
+      ...selectors: Selectors,
+      projector: SelectorProjector<Selectors, Result>
+    ]
+  ): Observable<Result>;
+  select<Selectors extends Observable<unknown>[], Result>(
+    ...args: [
+      ...selectors: Selectors,
+      projector: SelectorProjector<Selectors, Result>,
+      config: SelectConfig
+    ]
+  ): Observable<Result>;
   select<
-    O extends Array<Observable<unknown> | SelectConfig | ProjectorFn>,
-    R,
-    ProjectorFn = (...a: unknown[]) => R
-  >(...args: O): Observable<R> {
+    Selectors extends Array<Observable<unknown> | SelectConfig | ProjectorFn>,
+    Result,
+    ProjectorFn = (...a: unknown[]) => Result
+  >(...args: Selectors): Observable<Result> {
     const { observables, projector, config } = processSelectorArgs(args);
 
     let observable$: Observable<unknown>;
@@ -253,7 +251,7 @@ export class ComponentStore<T extends object> implements OnDestroy {
         map((projectorArgs) => projector(...projectorArgs))
       );
     }
-    return (observable$ as Observable<R>).pipe(
+    return (observable$ as Observable<Result>).pipe(
       distinctUntilChanged(),
       shareReplay({
         refCount: true,
@@ -276,9 +274,9 @@ export class ComponentStore<T extends object> implements OnDestroy {
     // This type quickly became part of effect 'API'
     ProvidedType = void,
     // The actual origin$ type, which could be unknown, when not specified
-    OriginType extends Observable<ProvidedType> | unknown = Observable<
-      ProvidedType
-    >,
+    OriginType extends
+      | Observable<ProvidedType>
+      | unknown = Observable<ProvidedType>,
     // Unwrapped actual type of the origin$ Observable, after default was applied
     ObservableType = OriginType extends Observable<infer A> ? A : never,
     // Return either an empty callback or a function requiring specific types as inputs


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2840

## What is the new behavior?

Component Store's `select` method now uses variadic tuples types to allow an N number of inputs.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
