### PR TITLE
revert "feat(router-store): add selectParamFromRouterState selector"

### DIFF
--- a/modules/router-store/spec/router_selectors.spec.ts
+++ b/modules/router-store/spec/router_selectors.spec.ts
@@ -18,13 +18,9 @@ const mockData = {
       },
       fragment: null,
       firstChild: {
-        params: {
-          p: 'first-occurrence',
-        },
+        params: {},
         paramMap: {
-          params: {
-            p: 'first-occurrence',
-          },
+          params: {},
         },
         data: {},
         url: [
@@ -46,12 +42,10 @@ const mockData = {
         firstChild: {
           params: {
             id: 'etyDDwAAQBAJ',
-            p: 'second-occurrence',
           },
           paramMap: {
             params: {
               id: 'etyDDwAAQBAJ',
-              p: 'second-occurrence',
             },
           },
           data: {
@@ -185,15 +179,6 @@ describe('Router State Selectors', () => {
 
       expect(result).toEqual(
         state.router.state.root.firstChild.firstChild.params.id
-      );
-    });
-
-    it('should create a selector for selecting the first occurrence of a specific route param', () => {
-      const result = selectors.selectParamFromRouterState('p')(state);
-
-      expect(result).toEqual(state.router.state.root.firstChild.params.p);
-      expect(result).not.toEqual(
-        state.router.state.root.firstChild.firstChild.params.p
       );
     });
 

--- a/modules/router-store/src/models.ts
+++ b/modules/router-store/src/models.ts
@@ -8,9 +8,6 @@ export interface RouterStateSelectors<V> {
   selectQueryParam: (param: string) => MemoizedSelector<V, string | undefined>;
   selectRouteParams: MemoizedSelector<V, Params>;
   selectRouteParam: (param: string) => MemoizedSelector<V, string | undefined>;
-  selectParamFromRouterState: (
-    param: string
-  ) => MemoizedSelector<V, string | undefined>;
   selectRouteData: MemoizedSelector<V, Data>;
   selectUrl: MemoizedSelector<V, string>;
 }

--- a/modules/router-store/src/router_selectors.ts
+++ b/modules/router-store/src/router_selectors.ts
@@ -41,21 +41,6 @@ export function getSelectors<V>(
   );
   const selectRouteParam = (param: string) =>
     createSelector(selectRouteParams, (params) => params && params[param]);
-  const selectParamFromRouterState = (param: string) =>
-    createSelector(selectRouterState, (routerState) => {
-      let paramValue: string | undefined;
-      let route = routerState?.root;
-
-      while (route?.firstChild) {
-        route = route.firstChild;
-        if (route?.params?.[param]) {
-          paramValue = route.params[param];
-          break;
-        }
-      }
-
-      return paramValue;
-    });
   const selectRouteData = createSelector(
     selectCurrentRoute,
     (route) => route && route.data
@@ -72,7 +57,6 @@ export function getSelectors<V>(
     selectQueryParam,
     selectRouteParams,
     selectRouteParam,
-    selectParamFromRouterState,
     selectRouteData,
     selectUrl,
   };

--- a/projects/ngrx.io/content/guide/router-store/selectors.md
+++ b/projects/ngrx.io/content/guide/router-store/selectors.md
@@ -25,15 +25,14 @@ export const selectRouter = createFeatureSelector<
 >('router');
 
 export const {
-  selectCurrentRoute,         // select the current route
-  selectFragment,             // select the current route fragment
-  selectQueryParams,          // select the current route query params
-  selectQueryParam,           // factory function to select a query param
-  selectRouteParams,          // select the current route params
-  selectRouteParam,           // factory function to select a route param
-  selectParamFromRouterState, // factory function to select the first occurrence of a route param
-  selectRouteData,            // select the current route data
-  selectUrl,                  // select the current url
+  selectCurrentRoute,   // select the current route
+  selectFragment,       // select the current route fragment
+  selectQueryParams,    // select the current route query params
+  selectQueryParam,     // factory function to select a query param
+  selectRouteParams,    // select the current route params
+  selectRouteParam,     // factory function to select a route param
+  selectRouteData,      // select the current route data
+  selectUrl,            // select the current url
 } = fromRouter.getSelectors(selectRouter);
 
 export const selectSelectedCarId = selectQueryParam('carId');


### PR DESCRIPTION
Reverts ngrx/platform#2771

After some discussion with @alex-okrushko, we will revert this new behavior in favor of a different selector named `selectAllRouteParams` that will gather all route params from the route tree. It will use a "last one wins" strategy, in that if two route parameters have the same name, such as `:id`, the value will be the last occurrence of that parameter name's value. This behavior is different from the Angular Router where a route parameter can have the same name through the hierarchy of defined routes, but as this should be used a more global selector we will document this expected behavior.

cc: @markostanimirovic 