### PR TITLE
docs: fix 'empty object as a props type' migration guide

### DIFF
--- a/projects/ngrx.io/content/guide/migration/v11.md
+++ b/projects/ngrx.io/content/guide/migration/v11.md
@@ -25,18 +25,26 @@ Version 11 has the minimum version requirements:
 
 #### Stricter `props` for `createAction`
 
-`createAction` doesn't allow an empty object anymore.
+`createAction` doesn't allow `{}` as a `props` type anymore, because `{}` is compatible with primitive types.
 
 BEFORE:
 
 ```ts
 const customerPageLoaded = createAction('[Customer Page] Loaded', props<{}>());
+
+customerPageLoaded({}); // ✔️
+customerPageLoaded({ foo: 'bar' }); // ✔️
+customerPageLoaded(0); // 👈 no error
+customerPageLoaded(false); // 👈 no error
 ```
 
 AFTER:
 
 ```ts
-const customerPageLoaded = createAction('[Customer Page] Loaded');
+const customerPageLoaded = createAction(
+  '[Customer Page] Loaded',
+  props<Record<string, unknown>>(),
+);
 ```
 
 ### @ngrx/entity


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

```typescript
const customerPageLoaded = createAction('[Customer Page] Loaded', props<{}>());
```

should not be changed to:

```typescript
const customerPageLoaded = createAction('[Customer Page] Loaded');
```

but to:

```typescript
const customerPageLoaded = createAction('[Customer Page] Loaded', props<Record<string, unknown>>());
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```