### PR TITLE
docs(ngrx.io): fix ultimatecourses link

### DIFF
--- a/projects/ngrx.io/content/marketing/resources.json
+++ b/projects/ngrx.io/content/marketing/resources.json
@@ -173,7 +173,7 @@
           "ultimate-courses-ngrxstore-effects": {
             "title": "Ultimate Angular (Todd Motto)",
             "desc": "NGRX Store + Effects",
-            "url": "https://ultimatecourses.com/angular/ngrx-store-effects",
+            "url": "https://ultimatecourses.com/learn/ngrx-store-effects",
             "rev": true
           },
           "pluralsight-getting-started": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

The link to the ultimatecourses NgRX course was broken.

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The link to the ultimatecourses NgRX course is broken.

Closes #2860.

## What is the new behavior?

The link is fixed, pointing to https://ultimatecourses.com/learn/ngrx-store-effects.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
