### PR TITLE
docs(ngrx.io): replace @example tag with @usageNotes and add ts code block

### DIFF
--- a/modules/data/src/entity-services/entity-services-base.ts
+++ b/modules/data/src/entity-services/entity-services-base.ts
@@ -17,7 +17,8 @@ import { EntityServicesElements } from './entity-services-elements';
  * Base/default class of a central registry of EntityCollectionServices for all entity types.
  * Create your own subclass to add app-specific members for an improved developer experience.
  *
- * @example
+ * @usageNotes
+ * ```ts
  * export class EntityServices extends EntityServicesBase {
  *   constructor(entityServicesElements: EntityServicesElements) {
  *     super(entityServicesElements);
@@ -32,6 +33,7 @@ import { EntityServicesElements } from './entity-services-elements';
  *     this.dispatch(new ClearCompanyAction(companyId));
  *   }
  * }
+ * ```
  */
 @Injectable()
 export class EntityServicesBase implements EntityServices {

--- a/modules/store/src/reducer_creator.ts
+++ b/modules/store/src/reducer_creator.ts
@@ -20,8 +20,10 @@ export interface OnReducer<S, C extends ActionCreator[]> {
  *
  * @returns an association of action types with a state change function.
  *
- * @example
+ * @usageNotes
+ * ```ts
  * on(AuthApiActions.loginSuccess, (state, { user }) => ({ ...state, user }))
+ * ```
  */
 export function on<
   Creators extends ActionCreator[],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently the wrong tag `@example` is used in the **entity-services-base.ts** and **reducer_creator.ts** doc comments. No code blocks are used for the code.

Relates to #2854, [comment, part 1](https://github.com/ngrx/platform/issues/2854#issuecomment-756303506)

## What is the new behavior?

Changed the tag to `@usageNotes` and added typescript code blocks around the code in doc comments.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
