### PR TITLE
fix(component): remove ? from LetViewContext props to prevent 'possiblly undefined' error in strict mode

### DIFF
--- a/modules/component/src/let/let.directive.ts
+++ b/modules/component/src/let/let.directive.ts
@@ -15,13 +15,13 @@ import { createRender } from '../core/cd-aware/creator_render';
 
 export interface LetViewContext<T> {
   // to enable `let` syntax we have to use $implicit (var; let v = var)
-  $implicit?: T;
+  $implicit: T;
   // to enable `as` syntax we have to assign the directives selector (var as v)
-  ngrxLet?: T;
+  ngrxLet: T;
   // set context var complete to true (var$; let e = $error)
-  $error?: boolean;
+  $error: boolean;
   // set context var complete to true (var$; let c = $complete)
-  $complete?: boolean;
+  $complete: boolean;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Following code:

```typescript
@Component({
  selector: 'my-app',
  template: `
    <p *ngrxLet="foo$; let f">Hello foo$ '{{ f.bar }}'</p>
  `,
})
export class AppComponent {
  foo$ = of({ bar: 'baz' });
}
```

will throw this error in strict mode:

```
ERROR in src/app/app.component.ts:7:48 - error TS2532: Object is possibly 'undefined'.

7     <p *ngrxLet="foo$; let f">Hello foo$ '{{ f.bar }}'</p>
                                                 ~~~
```
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2755 

## What is the new behavior?

'Possibily `undefined`' error no longer exists in strict mode.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
