### PR TITLE
refactor(store-devtools): replace deprecated empty() function

### DIFF
--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { Action, UPDATE } from '@ngrx/store';
-import { empty, Observable, of } from 'rxjs';
+import { EMPTY, Observable, of } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -39,9 +39,9 @@ export const ExtensionActionTypes = {
   ACTION: 'ACTION',
 };
 
-export const REDUX_DEVTOOLS_EXTENSION = new InjectionToken<
-  ReduxDevtoolsExtension
->('@ngrx/store-devtools Redux Devtools Extension');
+export const REDUX_DEVTOOLS_EXTENSION = new InjectionToken<ReduxDevtoolsExtension>(
+  '@ngrx/store-devtools Redux Devtools Extension'
+);
 
 export interface ReduxDevtoolsExtensionConnection {
   subscribe(listener: (change: any) => void): void;
@@ -160,7 +160,7 @@ export class DevtoolsExtension {
 
   private createChangesObservable(): Observable<any> {
     if (!this.devtoolsExtension) {
-      return empty();
+      return EMPTY;
     }
 
     return new Observable((subscriber) => {


### PR DESCRIPTION
The deprecated function 'empty()' is replaced with 'EMPTY' object.

Closes #2891

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Closes #2891 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
