### PR TITLE
fix(data): make entity param partial when is not optimistic

### DIFF
--- a/modules/data/src/entity-services/entity-collection-service-base.ts
+++ b/modules/data/src/entity-services/entity-collection-service-base.ts
@@ -141,6 +141,10 @@ export class EntityCollectionServiceBase<
    * @returns Observable of the entity
    * after server reports successful save or the save error.
    */
+  add(
+    entity: Partial<T>,
+    options: Omit<EntityActionOptions, 'isOptimistic'> & { isOptimistic: true }
+  ): Observable<T>;
   add(entity: T, options?: EntityActionOptions): Observable<T> {
     return this.dispatcher.add(entity, options);
   }


### PR DESCRIPTION
- Make the entity: T parameter for the NgRx Data .add command partial when isOptimistic: false since in some cases the PK will be created on the server

Closes #2870

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently NgRx Data allows the primary key to not be passed into the .add() function for an entity but the typings do not allow for that as they expect `T`

Closes #2870

## What is the new behavior?

Change `T` to be `Partial<T>` so that functionality is represented in the types. The full object may not be available as create time if isOptimistic is false.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
