### PR TITLE
refactor(store) used variadic tuple types for createSelector

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -118,393 +118,42 @@ export function defaultMemoize(
   return { memoized, reset, setResult, clearResult };
 }
 
-export function createSelector<State, S1, Result>(
-  s1: Selector<State, S1>,
-  projector: (s1: S1) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, Result>(
-  s1: SelectorWithProps<State, Props, S1>,
-  projector: (s1: S1, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-export function createSelector<State, S1, Result>(
-  selectors: [Selector<State, S1>],
-  projector: (s1: S1) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, Result>(
-  selectors: [SelectorWithProps<State, Props, S1>],
-  projector: (s1: S1, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
+type StateOfSelectors<S> = S extends Selector<infer State, any>[]
+  ? State
+  : never;
 
-export function createSelector<State, S1, S2, Result>(
-  s1: Selector<State, S1>,
-  s2: Selector<State, S2>,
-  projector: (s1: S1, s2: S2) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, Result>(
-  s1: SelectorWithProps<State, Props, S1>,
-  s2: SelectorWithProps<State, Props, S2>,
-  projector: (s1: S1, s2: S2, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-export function createSelector<State, S1, S2, Result>(
-  selectors: [Selector<State, S1>, Selector<State, S2>],
-  projector: (s1: S1, s2: S2) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, Result>(
-  selectors: [
-    SelectorWithProps<State, Props, S1>,
-    SelectorWithProps<State, Props, S2>
-  ],
-  projector: (s1: S1, s2: S2, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
+type ValueOfSelector<S> = S extends Selector<any, infer Value> ? Value : never;
 
-export function createSelector<State, S1, S2, S3, Result>(
-  s1: Selector<State, S1>,
-  s2: Selector<State, S2>,
-  s3: Selector<State, S3>,
-  projector: (s1: S1, s2: S2, s3: S3) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, S3, Result>(
-  s1: SelectorWithProps<State, Props, S1>,
-  s2: SelectorWithProps<State, Props, S2>,
-  s3: SelectorWithProps<State, Props, S3>,
-  projector: (s1: S1, s2: S2, s3: S3, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-export function createSelector<State, S1, S2, S3, Result>(
-  selectors: [Selector<State, S1>, Selector<State, S2>, Selector<State, S3>],
-  projector: (s1: S1, s2: S2, s3: S3) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, S3, Result>(
-  selectors: [
-    SelectorWithProps<State, Props, S1>,
-    SelectorWithProps<State, Props, S2>,
-    SelectorWithProps<State, Props, S3>
-  ],
-  projector: (s1: S1, s2: S2, s3: S3, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-
-export function createSelector<State, S1, S2, S3, S4, Result>(
-  s1: Selector<State, S1>,
-  s2: Selector<State, S2>,
-  s3: Selector<State, S3>,
-  s4: Selector<State, S4>,
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, S3, S4, Result>(
-  s1: SelectorWithProps<State, Props, S1>,
-  s2: SelectorWithProps<State, Props, S2>,
-  s3: SelectorWithProps<State, Props, S3>,
-  s4: SelectorWithProps<State, Props, S4>,
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-export function createSelector<State, S1, S2, S3, S4, Result>(
-  selectors: [
-    Selector<State, S1>,
-    Selector<State, S2>,
-    Selector<State, S3>,
-    Selector<State, S4>
-  ],
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, S3, S4, Result>(
-  selectors: [
-    SelectorWithProps<State, Props, S1>,
-    SelectorWithProps<State, Props, S2>,
-    SelectorWithProps<State, Props, S3>,
-    SelectorWithProps<State, Props, S4>
-  ],
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-
-export function createSelector<State, S1, S2, S3, S4, S5, Result>(
-  s1: Selector<State, S1>,
-  s2: Selector<State, S2>,
-  s3: Selector<State, S3>,
-  s4: Selector<State, S4>,
-  s5: Selector<State, S5>,
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, S3, S4, S5, Result>(
-  s1: SelectorWithProps<State, Props, S1>,
-  s2: SelectorWithProps<State, Props, S2>,
-  s3: SelectorWithProps<State, Props, S3>,
-  s4: SelectorWithProps<State, Props, S4>,
-  s5: SelectorWithProps<State, Props, S5>,
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-export function createSelector<State, S1, S2, S3, S4, S5, Result>(
-  selectors: [
-    Selector<State, S1>,
-    Selector<State, S2>,
-    Selector<State, S3>,
-    Selector<State, S4>,
-    Selector<State, S5>
-  ],
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, S3, S4, S5, Result>(
-  selectors: [
-    SelectorWithProps<State, Props, S1>,
-    SelectorWithProps<State, Props, S2>,
-    SelectorWithProps<State, Props, S3>,
-    SelectorWithProps<State, Props, S4>,
-    SelectorWithProps<State, Props, S5>
-  ],
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, props: Props) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-
-export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
-  s1: Selector<State, S1>,
-  s2: Selector<State, S2>,
-  s3: Selector<State, S3>,
-  s4: Selector<State, S4>,
-  s5: Selector<State, S5>,
-  s6: Selector<State, S6>,
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, S3, S4, S5, S6, Result>(
-  s1: SelectorWithProps<State, Props, S1>,
-  s2: SelectorWithProps<State, Props, S2>,
-  s3: SelectorWithProps<State, Props, S3>,
-  s4: SelectorWithProps<State, Props, S4>,
-  s5: SelectorWithProps<State, Props, S5>,
-  s6: SelectorWithProps<State, Props, S6>,
-  projector: (
-    s1: S1,
-    s2: S2,
-    s3: S3,
-    s4: S4,
-    s5: S5,
-    s6: S6,
-    props: Props
-  ) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
-  selectors: [
-    Selector<State, S1>,
-    Selector<State, S2>,
-    Selector<State, S3>,
-
-    Selector<State, S4>,
-    Selector<State, S5>,
-    Selector<State, S6>
-  ],
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<State, Props, S1, S2, S3, S4, S5, S6, Result>(
-  selectors: [
-    SelectorWithProps<State, Props, S1>,
-    SelectorWithProps<State, Props, S2>,
-    SelectorWithProps<State, Props, S3>,
-    SelectorWithProps<State, Props, S4>,
-    SelectorWithProps<State, Props, S5>,
-    SelectorWithProps<State, Props, S6>
-  ],
-  projector: (
-    s1: S1,
-    s2: S2,
-    s3: S3,
-    s4: S4,
-    s5: S5,
-    s6: S6,
-    props: Props
-  ) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-
-export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
-  s1: Selector<State, S1>,
-  s2: Selector<State, S2>,
-  s3: Selector<State, S3>,
-  s4: Selector<State, S4>,
-  s5: Selector<State, S5>,
-  s6: Selector<State, S6>,
-  s7: Selector<State, S7>,
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
-): MemoizedSelector<State, Result>;
+export function createSelector<S extends Selector<any, any>[], Result>(
+  ...args: [
+    ...S,
+    (...args: [...{ [i in keyof S]: ValueOfSelector<S[i]> }]) => Result
+  ]
+): MemoizedSelector<StateOfSelectors<S>, Result>;
 export function createSelector<
-  State,
+  S extends SelectorWithProps<any, any, any>[],
   Props,
-  S1,
-  S2,
-  S3,
-  S4,
-  S5,
-  S6,
-  S7,
   Result
 >(
-  s1: SelectorWithProps<State, Props, S1>,
-  s2: SelectorWithProps<State, Props, S2>,
-  s3: SelectorWithProps<State, Props, S3>,
-  s4: SelectorWithProps<State, Props, S4>,
-  s5: SelectorWithProps<State, Props, S5>,
-  s6: SelectorWithProps<State, Props, S6>,
-  s7: SelectorWithProps<State, Props, S7>,
-  projector: (
-    s1: S1,
-    s2: S2,
-    s3: S3,
-    s4: S4,
-    s5: S5,
-    s6: S6,
-    s7: S7,
-    props: Props
-  ) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
-  selectors: [
-    Selector<State, S1>,
-    Selector<State, S2>,
-    Selector<State, S3>,
-    Selector<State, S4>,
-    Selector<State, S5>,
-    Selector<State, S6>,
-    Selector<State, S7>
-  ],
-  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
-): MemoizedSelector<State, Result>;
+  ...args: [
+    ...S,
+    (...args: [...{ [i in keyof S]: ValueOfSelector<S[i]> }, Props]) => Result
+  ]
+): MemoizedSelectorWithProps<StateOfSelectors<S>, Props, Result>;
+export function createSelector<S extends Selector<any, any>[], Result>(
+  selectors: S,
+  projector: (...args: [...{ [i in keyof S]: ValueOfSelector<S[i]> }]) => Result
+): MemoizedSelector<StateOfSelectors<S>, Result>;
 export function createSelector<
-  State,
+  S extends MemoizedSelectorWithProps<any, any, any>[],
   Props,
-  S1,
-  S2,
-  S3,
-  S4,
-  S5,
-  S6,
-  S7,
   Result
 >(
-  selectors: [
-    SelectorWithProps<State, Props, S1>,
-    SelectorWithProps<State, Props, S2>,
-    SelectorWithProps<State, Props, S3>,
-    SelectorWithProps<State, Props, S4>,
-    SelectorWithProps<State, Props, S5>,
-    SelectorWithProps<State, Props, S6>,
-    SelectorWithProps<State, Props, S7>
-  ],
+  selectors: S,
   projector: (
-    s1: S1,
-    s2: S2,
-    s3: S3,
-    s4: S4,
-    s5: S5,
-    s6: S6,
-    s7: S7,
-    props: Props
+    ...args: [...{ [i in keyof S]: ValueOfSelector<S[i]> }, Props]
   ) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-
-export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
-  s1: Selector<State, S1>,
-  s2: Selector<State, S2>,
-  s3: Selector<State, S3>,
-  s4: Selector<State, S4>,
-  s5: Selector<State, S5>,
-  s6: Selector<State, S6>,
-  s7: Selector<State, S7>,
-  s8: Selector<State, S8>,
-  projector: (
-    s1: S1,
-    s2: S2,
-    s3: S3,
-    s4: S4,
-    s5: S5,
-    s6: S6,
-    s7: S7,
-    s8: S8
-  ) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<
-  State,
-  Props,
-  S1,
-  S2,
-  S3,
-  S4,
-  S5,
-  S6,
-  S7,
-  S8,
-  Result
->(
-  s1: SelectorWithProps<State, Props, S1>,
-  s2: SelectorWithProps<State, Props, S2>,
-  s3: SelectorWithProps<State, Props, S3>,
-  s4: SelectorWithProps<State, Props, S4>,
-  s5: SelectorWithProps<State, Props, S5>,
-  s6: SelectorWithProps<State, Props, S6>,
-  s7: SelectorWithProps<State, Props, S7>,
-  s8: SelectorWithProps<State, Props, S8>,
-  projector: (
-    s1: S1,
-    s2: S2,
-    s3: S3,
-    s4: S4,
-    s5: S5,
-    s6: S6,
-    s7: S7,
-    s8: S8,
-    props: Props
-  ) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
-export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
-  selectors: [
-    Selector<State, S1>,
-    Selector<State, S2>,
-    Selector<State, S3>,
-    Selector<State, S4>,
-    Selector<State, S5>,
-    Selector<State, S6>,
-    Selector<State, S7>,
-    Selector<State, S8>
-  ],
-  projector: (
-    s1: S1,
-    s2: S2,
-    s3: S3,
-    s4: S4,
-    s5: S5,
-    s6: S6,
-    s7: S7,
-    s8: S8
-  ) => Result
-): MemoizedSelector<State, Result>;
-export function createSelector<
-  State,
-  Props,
-  S1,
-  S2,
-  S3,
-  S4,
-  S5,
-  S6,
-  S7,
-  S8,
-  Result
->(
-  selectors: [
-    SelectorWithProps<State, Props, S1>,
-    SelectorWithProps<State, Props, S2>,
-    SelectorWithProps<State, Props, S3>,
-    SelectorWithProps<State, Props, S4>,
-    SelectorWithProps<State, Props, S5>,
-    SelectorWithProps<State, Props, S6>,
-    SelectorWithProps<State, Props, S7>,
-    SelectorWithProps<State, Props, S8>
-  ],
-  projector: (
-    s1: S1,
-    s2: S2,
-    s3: S3,
-    s4: S4,
-    s5: S5,
-    s6: S6,
-    s7: S7,
-    s8: S8,
-    props: Props
-  ) => Result
-): MemoizedSelectorWithProps<State, Props, Result>;
+): MemoizedSelectorWithProps<StateOfSelectors<S>, Props, Result>;
 
 export function createSelector(
   ...input: any[]

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "tsickle": "^0.37.0",
     "tslint": "~6.1.0",
     "tsutils": "2.27.2",
-    "typescript": "~4.0.5",
+    "typescript": "^4.2.1-rc",
     "uglify-js": "^3.1.9"
   },
   "collective": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16238,10 +16238,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.0.5, typescript@~4.0.5:
+typescript@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+
+typescript@^4.2.1-rc:
+  version "4.2.1-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.1-rc.tgz#57adcda3eda7a63226c7472e9f42b9aee1de2fcc"
+  integrity sha512-R2lWNtsP12ZLGMPl5r96nieXhMmWhfEMtmvUMKjix0smn1TD4wgHvKf3t4zz2spJnT8pktUptPQniKnTL1ZPJA==
 
 typescript@~3.7.2:
   version "3.7.5"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Technically this allows for typed selectors with more than 8 input selectors, so it's kinda a "feature" upgrade as well.
```

## What is the current behavior?

Types were manually created for set numbers of arguments.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Partially completes #2715 

## What is the new behavior?

`createSelector` stays strongly typed for an infinite number of arguments.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
