### PR TITLE
fix(data): type overloaded add for is optimistic true | undefined

### DIFF
--- a/modules/data/src/entity-services/entity-collection-service-base.ts
+++ b/modules/data/src/entity-services/entity-collection-service-base.ts
@@ -143,7 +143,11 @@ export class EntityCollectionServiceBase<
    */
   add(
     entity: Partial<T>,
-    options: Omit<EntityActionOptions, 'isOptimistic'> & { isOptimistic: true }
+    options: EntityActionOptions & { isOptimistic: false }
+  ): Observable<T>;
+  add(
+    entity: T,
+    options?: EntityActionOptions & { isOptimistic?: true }
   ): Observable<T>;
   add(entity: T, options?: EntityActionOptions): Observable<T> {
     return this.dispatcher.add(entity, options);


### PR DESCRIPTION
TypeScript only recognizes the overloads as method signatures when being overloaded not the actual implementation, added overload for the case where isOptimistic is true or undefined (default for entity).

This will allow for the following:

`.add(entityWithoutId, { isOptimistic: false })`
`.add(entityWithId, { isOptimistic: true })`
`.add(entityWithId, { // any other options with whatever settings and no explicit value for isOptimistic })`
`.add(entityWithId)`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Resolves this comment https://github.com/ngrx/platform/pull/2899#issuecomment-770305634
