### PR TITLE
fix(push): fix return typing for observables to include undefined

### DIFF
--- a/modules/component/src/push/push.pipe.ts
+++ b/modules/component/src/push/push.pipe.ts
@@ -79,7 +79,7 @@ export class PushPipe<S> implements PipeTransform, OnDestroy {
 
   transform<T>(potentialObservable: null): null;
   transform<T>(potentialObservable: undefined): undefined;
-  transform<T>(potentialObservable: ObservableInput<T>): T;
+  transform<T>(potentialObservable: ObservableInput<T>): T | undefined;
   transform<T>(
     potentialObservable: ObservableInput<T> | null | undefined
   ): T | null | undefined {


### PR DESCRIPTION
ngrxPush typing considers `undefined` when the input type is an observable

Closes #2888

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2888 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Applications that have strict null checks might need to handle `undefined`.

## Other information
