### PR TITLE
docs(component-store): fix to call `addMovie()` with not string but interface Movie

### DIFF
--- a/projects/ngrx.io/content/guide/component-store/write.md
+++ b/projects/ngrx.io/content/guide/component-store/write.md
@@ -47,7 +47,7 @@ export class MoviesPageComponent {
   constructor(private readonly moviesStore: MoviesStore) {}
 
   add(movie: string) {
-    this.moviesStore.addMovie(movie);
+    this.moviesStore.addMovie({ name: movie, id: generateId() });
   }
 }
 </code-example>


### PR DESCRIPTION
The argument type of `addMovie` method in `movies.store.ts` is Movie | Observable<Movie>.
But calls it with string in `movies-page.component.ts`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The argument type of `addMovie` method in `movies.store.ts` is `Movie | Observable<Movie>` ().
But calls it with string in `movies-page.component.ts`

## What is the new behavior?
calls `addMovie` method with interface `Movie`.
`Interface Movie` is not is not explicitly defined, but from https://ngrx.io/guide/component-store/read#select-method we can see that `interface Movie` has a name property and no other properties are referenced.
So it seems that `Interface Movie` only has name property as string.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
