### PR TITLE
docs: fix filename on spec files

### DIFF
--- a/projects/ngrx.io/content/guide/store/testing.md
+++ b/projects/ngrx.io/content/guide/store/testing.md
@@ -110,7 +110,7 @@ The following example tests the `booksReducer` from the [walkthrough](guide/stor
 
 The `provideMockStore()` function can be also used with `Injector.create`:
 
-<code-example header="books.component.ts">
+<code-example header="books.component.spec.ts">
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { Injector } from '@angular/core';
 
@@ -132,7 +132,7 @@ describe('Books Component', () => {
 
 Another option to create the `MockStore` without `TestBed` is by calling the `getMockStore()` function:
 
-<code-example header="books.component.ts">
+<code-example header="books.component.spec.ts">
 import { MockStore, getMockStore } from '@ngrx/store/testing';
 
 describe('Books Component', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

Trivial fix to documentation only. 

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Two unit test files on the [NgRx store testing guide](https://ngrx.io/guide/store/testing#testing-without-testbed) page are labelled as `books.component.ts`.

Closes #

## What is the new behavior?
Labels on the relevant files are updated to `books.component.spec.ts`, reflective of the file content.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
