### PR TITLE
fix(effects): add support for Proxy objects in Effects

### DIFF
--- a/modules/effects/spec/effect_creator.spec.ts
+++ b/modules/effects/spec/effect_creator.spec.ts
@@ -85,6 +85,14 @@ describe('createEffect()', () => {
       const fakeCreateEffect: any = () => {};
       class Fixture {
         a = fakeCreateEffect(() => of({ type: 'A' }));
+        b = new Proxy(
+          {},
+          {
+            get(_, prop) {
+              return () => Promise.resolve('bob');
+            },
+          }
+        );
       }
 
       const mock = new Fixture();

--- a/modules/effects/src/effect_creator.ts
+++ b/modules/effects/src/effect_creator.ts
@@ -77,11 +77,16 @@ export function getCreateEffectMetadata<
   const propertyNames = Object.getOwnPropertyNames(instance) as Array<keyof T>;
 
   const metadata: EffectMetadata<T>[] = propertyNames
-    .filter(
-      (propertyName) =>
+    .filter((propertyName) => {
+      if (
         instance[propertyName] &&
         instance[propertyName].hasOwnProperty(CREATE_EFFECT_METADATA_KEY)
-    )
+      ) {
+        const property = instance[propertyName] as any;
+        return property[CREATE_EFFECT_METADATA_KEY].hasOwnProperty('dispatch');
+      }
+      return false;
+    })
     .map((propertyName) => {
       const metaData = (instance[propertyName] as any)[
         CREATE_EFFECT_METADATA_KEY

--- a/modules/effects/src/effect_creator.ts
+++ b/modules/effects/src/effect_creator.ts
@@ -82,6 +82,9 @@ export function getCreateEffectMetadata<
         instance[propertyName] &&
         instance[propertyName].hasOwnProperty(CREATE_EFFECT_METADATA_KEY)
       ) {
+        // If the property type has overridden `hasOwnProperty` we need to ensure
+        // that the metadata is valid (containing a `dispatch`property)
+        // https://github.com/ngrx/platform/issues/2975
         const property = instance[propertyName] as any;
         return property[CREATE_EFFECT_METADATA_KEY].hasOwnProperty('dispatch');
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Right now `mergeEffects` fails with an error when a `Proxy` object is injected in an `Effect`s class.

Closes #2975 

## What is the new behavior?

With this extra condition `Proxy` will be filtered out.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I don't fully understand how the commit message should be formed and if there should be any documentation changes. I hope you can help with that.