### PR TITLE
docs: make selector testing reset instruction more clear

### DIFF
--- a/projects/ngrx.io/content/guide/store/testing.md
+++ b/projects/ngrx.io/content/guide/store/testing.md
@@ -75,7 +75,7 @@ In this example based on the [walkthrough](guide/store/walkthrough), we mock the
 
 <div class="alert is-helpful">
 
-**Note:** `MockStore` will reset all of the mocked selectors after each test (in the `afterEach()` hook) by calling the `MockStore.resetSelectors()` method.
+**Note:** The mocked selectors will only be reset after each test if you call the `MockStore.resetSelectors()` method in the `afterEach()` hook.
 
 </div>
 


### PR DESCRIPTION
This method seems to have to be invoked manually to reset a selector, the existing verbiage seemed to imply it may be automatic (Am I incorrect?).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```