### PR TITLE
build: don't include un-needed files in the distributed packages

### DIFF
--- a/modules/component-store/tsconfig-build.json
+++ b/modules/component-store/tsconfig-build.json
@@ -25,6 +25,7 @@
     "annotateForClosureCompiler": true,
     // Work around for issue: https://github.com/angular/angular/issues/22210
     "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@ngrx/component-store",
     "enableIvy": false

--- a/modules/data/tsconfig-build.json
+++ b/modules/data/tsconfig-build.json
@@ -25,6 +25,7 @@
     "annotateForClosureCompiler": true,
     // Work around for issue: https://github.com/angular/angular/issues/22210
     "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@ngrx/data",
     "enableIvy": false

--- a/modules/effects/testing/tsconfig-build.json
+++ b/modules/effects/testing/tsconfig-build.json
@@ -10,6 +10,7 @@
   "angularCompilerOptions": {
     // Work around for issue: https://github.com/angular/angular/issues/22210
     "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
     "enableIvy": false
   }
 }

--- a/modules/effects/tsconfig-build.json
+++ b/modules/effects/tsconfig-build.json
@@ -25,6 +25,7 @@
     "annotateForClosureCompiler": true,
     // Work around for issue: https://github.com/angular/angular/issues/22210
     "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@ngrx/effects",
     "enableIvy": false

--- a/modules/entity/tsconfig-build.json
+++ b/modules/entity/tsconfig-build.json
@@ -25,6 +25,7 @@
     "annotateForClosureCompiler": true,
     // Work around for issue: https://github.com/angular/angular/issues/22210
     "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@ngrx/entity",
     "enableIvy": false

--- a/modules/router-store/tsconfig-build.json
+++ b/modules/router-store/tsconfig-build.json
@@ -25,6 +25,7 @@
     "annotateForClosureCompiler": true,
     // Work around for issue: https://github.com/angular/angular/issues/22210
     "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@ngrx/router-store",
     "enableIvy": false

--- a/modules/store-devtools/tsconfig-build.json
+++ b/modules/store-devtools/tsconfig-build.json
@@ -25,6 +25,7 @@
     "annotateForClosureCompiler": true,
     // Work around for issue: https://github.com/angular/angular/issues/22210
     "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@ngrx/store-devtools",
     "enableIvy": false

--- a/modules/store/testing/tsconfig-build.json
+++ b/modules/store/testing/tsconfig-build.json
@@ -9,6 +9,7 @@
   "angularCompilerOptions": {
     // Work around for issue: https://github.com/angular/angular/issues/22210
     "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
     "enableIvy": false
   }
 }

--- a/modules/store/tsconfig-build.json
+++ b/modules/store/tsconfig-build.json
@@ -24,6 +24,7 @@
     "annotateForClosureCompiler": true,
     // Work around for issue: https://github.com/angular/angular/issues/22210
     "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@ngrx/store",
     "enableIvy": false


### PR DESCRIPTION
At the moment, redundant files are being included in the packages libraries ex: https://unpkg.com/browse/@ngrx/store@11.1.0/esm2015/testing/

This change updates the `tsconfig.json` of the all modules to enable `skipTemplateCodegen` with the recommended setting for libraries.

With this option enabled, ngfactories and ngsummaries which are not needed for libraries are not generated and hence the libraries size footprint in the node_modules directory is also smaller.

This is also the default value for the option when generating a library using Angular CLI https://github.com/angular/angular-cli/blob/e607d4482e761c3e556ccc6f4b870af350a5c86a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/tsconfig.lib.json#L15

More info about this option can be found here: https://angular.io/guide/angular-compiler-options#skiptemplatecodegen
