### PR TITLE
build: fix module builds to include schematics files for ng-add

### DIFF
--- a/modules/component-store/ng-package.json
+++ b/modules/component-store/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/modules/component-store",
-  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files"],
+  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files/**/*"],
   "lib": {
     "entryFile": "index.ts"
   }

--- a/modules/component/ng-package.json
+++ b/modules/component/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/modules/component",
-  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files"],
+  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files/**/*"],
   "lib": {
     "entryFile": "index.ts"
   }

--- a/modules/data/ng-package.json
+++ b/modules/data/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/modules/data",
-  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files"],
+  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files/**/*"],
   "lib": {
     "entryFile": "index.ts",
     "umdModuleIds": {

--- a/modules/effects/ng-package.json
+++ b/modules/effects/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/modules/effects",
-  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files"],
+  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files/**/*"],
   "lib": {
     "entryFile": "index.ts",
     "umdModuleIds": {

--- a/modules/entity/ng-package.json
+++ b/modules/entity/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/modules/entity",
-  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files"],
+  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files/**/*"],
   "lib": {
     "entryFile": "index.ts",
     "umdModuleIds": {

--- a/modules/router-store/ng-package.json
+++ b/modules/router-store/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/modules/router-store",
-  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files"],
+  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files/**/*"],
   "lib": {
     "entryFile": "index.ts",
     "umdModuleIds": {

--- a/modules/store-devtools/ng-package.json
+++ b/modules/store-devtools/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/modules/store-devtools",
-  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files"],
+  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files/**/*"],
   "lib": {
     "entryFile": "index.ts",
     "umdModuleIds": {

--- a/modules/store/ng-package.json
+++ b/modules/store/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/modules/store",
-  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files"],
+  "assets": ["migrations/**/*.json", "schematics/**/*.json", "**/files/**/*"],
   "lib": {
     "entryFile": "index.ts"
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2998

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Originally when running `ng-add @ngrx/store --minimal false` or `ng-add @ngrx/effects --minimal false`, the package will run the `ng-add` schematics, but it would not generate newly created files that are defined in the `files/` folder. This was because after building the package, the `files/` folder was not being included in the output build. This change includes the files in the package build so that the `ng-add` schematics also generate the new files for each package
