### PR TITLE
ci: dont lint in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       # Test
       - run:
           name: Run All Lint Checks
-          command: yarn nx run-many --target=lint --all --parallel
+          command: yarn nx run-many --target=lint --all
 
   lint-affected:
     <<: *run_in_node
@@ -252,7 +252,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "c9:c2:b4:5e:13:23:b6:6d:d8:29:3e:68:c6:40:9c:ec"
+            - 'c9:c2:b4:5e:13:23:b6:6d:d8:29:3e:68:c6:40:9c:ec'
       - checkout:
           path: ~/docs
       - restore_cache:
@@ -297,7 +297,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "c9:c2:b4:5e:13:23:b6:6d:d8:29:3e:68:c6:40:9c:ec"
+            - 'c9:c2:b4:5e:13:23:b6:6d:d8:29:3e:68:c6:40:9c:ec'
       - checkout
       - restore_cache:
           keys:
@@ -345,7 +345,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "c9:c2:b4:5e:13:23:b6:6d:d8:29:3e:68:c6:40:9c:ec"
+            - 'c9:c2:b4:5e:13:23:b6:6d:d8:29:3e:68:c6:40:9c:ec'
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - write_master_hash
       - run:
           name: Run Affected Lint Checks
-          command: yarn nx affected:lint --base=$(cat ~/project/master.txt) --head=$CIRCLE_SHA1 --parallel
+          command: yarn nx affected:lint --base=$(cat ~/project/master.txt) --head=$CIRCLE_SHA1
 
   # Enforce some static analysis invariants.
   # Note that generally, these should be checked only on the delta in each change,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

It seems like our CI has problem to run the linter in parallel. 
Locally, all linters are OK if I run them one by one.

```
> nx run data:lint 
Nx could not find process's output. Run the command without --parallel.

> nx run schematics:lint 
Nx could not find process's output. Run the command without --parallel.
```