### PR TITLE
fix(data): remove strict typing for optimistic false

### DIFF
--- a/modules/data/src/entity-services/entity-collection-service-base.ts
+++ b/modules/data/src/entity-services/entity-collection-service-base.ts
@@ -145,10 +145,6 @@ export class EntityCollectionServiceBase<
     entity: Partial<T>,
     options: EntityActionOptions & { isOptimistic: false }
   ): Observable<T>;
-  add(
-    entity: T,
-    options?: EntityActionOptions & { isOptimistic?: true }
-  ): Observable<T>;
   add(entity: T, options?: EntityActionOptions): Observable<T> {
     return this.dispatcher.add(entity, options);
   }


### PR DESCRIPTION
Additional overload for `.add()` on NgRx Data Service causes issue when passing in `boolean` to `isOptimistic`. Remove overload as it should not be needed. Resolves #2928

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Cannot add a pass through function with a parameter of `EntityActionOptions` as `boolean` is not assignable to `false`

Closes #2928

## What is the new behavior?

Looser typing allows passing `EntityActionOptions` through

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
