### PR TITLE
fix(store): add ESLint plugin to TS overrides when possible

### DIFF
--- a/modules/store/schematics/ng-add/index.spec.ts
+++ b/modules/store/schematics/ng-add/index.spec.ts
@@ -170,6 +170,80 @@ describe('Store ng-add Schematic', () => {
     });
   });
 
+  it('should register the NgRx ESLint Plugin in overrides when it supports TS', async () => {
+    const options = { ...defaultOptions };
+
+    // this is a trimmed down version of the default angular-eslint schematic
+    const initialConfig = {
+      overrides: [
+        {
+          files: ['*.ts'],
+          parserOptions: {
+            project: ['tsconfig.eslint.json'],
+            createDefaultProgram: true,
+          },
+          extends: [
+            'plugin:@angular-eslint/recommended',
+            'eslint:recommended',
+            'plugin:@typescript-eslint/recommended',
+            'plugin:@typescript-eslint/recommended-requiring-type-checking',
+            'plugin:@angular-eslint/template/process-inline-templates',
+            'plugin:prettier/recommended',
+          ],
+        },
+        {
+          files: ['*.html'],
+          extends: [
+            'plugin:@angular-eslint/template/recommended',
+            'plugin:prettier/recommended',
+          ],
+          rules: {},
+        },
+      ],
+    };
+    appTree.create('.eslintrc.json', JSON.stringify(initialConfig, null, 2));
+
+    const tree = await schematicRunner
+      .runSchematicAsync('ng-add', options, appTree)
+      .toPromise();
+
+    const packageContent = tree.readContent('package.json');
+    const packageJson = JSON.parse(packageContent);
+    expect(packageJson.devDependencies['eslint-plugin-ngrx']).toBeDefined();
+
+    const eslintContent = tree.readContent(`.eslintrc.json`);
+    const eslintJson = JSON.parse(eslintContent);
+    expect(eslintJson).toEqual({
+      overrides: [
+        {
+          files: ['*.ts'],
+          parserOptions: {
+            project: ['tsconfig.eslint.json'],
+            createDefaultProgram: true,
+          },
+          plugins: ['ngrx'],
+          extends: [
+            'plugin:@angular-eslint/recommended',
+            'eslint:recommended',
+            'plugin:@typescript-eslint/recommended',
+            'plugin:@typescript-eslint/recommended-requiring-type-checking',
+            'plugin:@angular-eslint/template/process-inline-templates',
+            'plugin:prettier/recommended',
+            'plugin:ngrx/recommended',
+          ],
+        },
+        {
+          files: ['*.html'],
+          extends: [
+            'plugin:@angular-eslint/template/recommended',
+            'plugin:prettier/recommended',
+          ],
+          rules: {},
+        },
+      ],
+    });
+  });
+
   it('should not register the NgRx ESLint Plugin when skipped', async () => {
     const options = { ...defaultOptions, skipESLintPlugin: true };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3031 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This change adds the ESLint Plugin configuration to the typescript overrides, instead of to the global configuration. This keeps our schematic more alligned with the Angular ESLint plugin.