### PR TITLE
docs(effects): update test without TestBed example

### DIFF
--- a/projects/ngrx.io/content/guide/effects/testing.md
+++ b/projects/ngrx.io/content/guide/effects/testing.md
@@ -307,12 +307,16 @@ it('should get customers', () => {
 })
 </code-example>
 
-For an Effect with store interaction, it's possible to create an Observable `Store`.
+For an Effect with store interaction, use `getMockStore` to create a new instance of `MockStore`.
 
 <code-example header="my.effects.spec.ts">
 it('should get customers', () => {
-  // create the store, this can be just an Observable
-  const store = of({}) as Store&lt;Action&gt;;
+  // create the store, and provide selectors.
+  const store = getMockStore({
+      selectors: [
+        { selector: selectCustomers, value: { Bob: { name: 'Bob' } } }
+      ]
+  });
 
   // instead of using `provideMockActions`,
   // define the actions stream by creating a new `Actions` instance
@@ -322,13 +326,8 @@ it('should get customers', () => {
     })
   );
 
-  // mock the selector
-  selectCustomers.setResult({
-    Bob: { name: 'Bob' },
-  });
-
   // create the effect
-  const effects = new CustomersEffects(store, actions, customersServiceSpy);
+  const effects = new CustomersEffects(store as Store, actions, customersServiceSpy);
 
   // there is no output, because Bob is already in the Store state
   const expected = hot('----');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The current example that we're using in "Testing Effects without using TestBed" does not work if the effect uses the `store.select` method (`select` doesn't exist on the Observable created with `of`). This PR updates the example to use `provideMockStore`.
