### PR TITLE
feat(component-store): accept error type in `tapResponse`

### DIFF
--- a/modules/component-store/src/tap-response.ts
+++ b/modules/component-store/src/tap-response.ts
@@ -17,14 +17,14 @@ import { catchError, tap } from 'rxjs/operators';
  *          (alert) => this.alertsService.dismissAlert(alert).pipe(
  *              tapResponse(
  *                 (dismissedAlert) => this.alertDismissed(dismissedAlert),
- *                 (error) => this.logError(error),
+ *                 (error: { message: string }) => this.logError(error.message),
  *              ))));
  *   });
  * ```
  */
 export function tapResponse<T>(
   nextFn: (next: T) => void,
-  errorFn: (error: unknown) => void,
+  errorFn: <E = unknown>(error: E) => void,
   completeFn?: () => void
 ): (source: Observable<T>) => Observable<T> {
   return (source) =>

--- a/projects/ngrx.io/content/guide/component-store/effect.md
+++ b/projects/ngrx.io/content/guide/component-store/effect.md
@@ -85,7 +85,7 @@ An easy way to handle the response in ComponentStore effects in a safe way, with
         //👇 Act on the result within inner pipe.
         tapResponse(
           (movie) => this.addMovie(movie),
-          (error: HttpErrorResponse) => this.logError(e),
+          (error: HttpErrorResponse) => this.logError(error),
         ),
       )),
     );

--- a/projects/ngrx.io/content/guide/component-store/effect.md
+++ b/projects/ngrx.io/content/guide/component-store/effect.md
@@ -85,7 +85,7 @@ An easy way to handle the response in ComponentStore effects in a safe way, with
         //👇 Act on the result within inner pipe.
         tapResponse(
           (movie) => this.addMovie(movie),
-          (error) => this.logError(e),
+          (error: HttpErrorResponse) => this.logError(e),
         ),
       )),
     );


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The input argument of `tapResponse` error callback cannot be typed directly.

Closes #3051

## What is the new behavior?

The input argument of `tapResponse` error callback can be typed directly:

```ts
tapResponse(
  () => {},
  (error: { message: string }) => console.error(error.message),
),
```

If not passed, the type of error will be `unknown`, just like the current `tapResponse` implementation.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
