### PR TITLE
feat(store): provide better TS errors for action creator props

### DIFF
--- a/modules/store/spec/types/action_creator.spec.ts
+++ b/modules/store/spec/types/action_creator.spec.ts
@@ -58,6 +58,54 @@ describe('createAction()', () => {
         /Type 'ActionCreatorProps<\{\}>' is not assignable to type '"action creator props cannot be an empty object"'/
       );
     });
+
+    it('should not allow strings', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<string>());
+      `).toFail(
+        /Type 'string' is not assignable to type '"action creator props cannot be a primitive value"'/
+      );
+    });
+
+    it('should not allow numbers', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<number>());
+      `).toFail(
+        /Type 'number' is not assignable to type '"action creator props cannot be a primitive value"'/
+      );
+    });
+
+    it('should not allow bigints', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<bigint>());
+      `).toFail(
+        /Type 'bigint' is not assignable to type '"action creator props cannot be a primitive value"'/
+      );
+    });
+
+    it('should not allow booleans', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<boolean>());
+      `).toFail(
+        /Type 'boolean' is not assignable to type '"action creator props cannot be a primitive value"'/
+      );
+    });
+
+    it('should not allow null', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<null>());
+      `).toFail(
+        /Type 'null' is not assignable to type '"action creator props cannot be a primitive value"'/
+      );
+    });
+
+    it('should not allow undefined', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<undefined>());
+      `).toFail(
+        /Type 'undefined' is not assignable to type '"action creator props cannot be a primitive value"'/
+      );
+    });
   });
 
   describe('with function', () => {
@@ -103,6 +151,54 @@ describe('createAction()', () => {
         const foo = createAction('FOO', () => [ ]);
       `).toFail(
         /Type 'any\[\]' is not assignable to type '"action creator props cannot be an array"'/
+      );
+    });
+
+    it('should not allow strings', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', () => '');
+      `).toFail(
+        /Type 'string' is not assignable to type '"action creator cannot return a primitive value"'/
+      );
+    });
+
+    it('should not allow numbers', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', () => 0);
+      `).toFail(
+        /Type 'number' is not assignable to type '"action creator cannot return a primitive value"'/
+      );
+    });
+
+    it('should not allow bigints', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', () => 0n);
+      `).toFail(
+        /Type 'bigint' is not assignable to type '"action creator cannot return a primitive value"'/
+      );
+    });
+
+    it('should not allow booleans', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', () => false);
+      `).toFail(
+        /Type 'boolean' is not assignable to type '"action creator cannot return a primitive value"'/
+      );
+    });
+
+    it('should not allow null', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', () => null);
+      `).toFail(
+        /Type 'null' is not assignable to type '"action creator cannot return a primitive value"'/
+      );
+    });
+
+    it('should not allow undefined', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', () => undefined);
+      `).toFail(
+        /Type 'undefined' is not assignable to type '"action creator cannot return a primitive value"'/
       );
     });
   });

--- a/modules/store/spec/types/action_creator.spec.ts
+++ b/modules/store/spec/types/action_creator.spec.ts
@@ -39,7 +39,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<{ type: number }>());
       `).toFail(
-        / Type 'ActionCreatorProps<\{ type: number; \}>' is not assignable to type '"type property is not allowed in action creators"'/
+        / Type 'ActionCreatorProps<\{ type: number; \}>' is not assignable to type '"action creator props cannot have a property named `type`"'/
       );
     });
 
@@ -47,7 +47,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<[]>());
       `).toFail(
-        /Type 'ActionCreatorProps<\[\]>' is not assignable to type '"arrays are not allowed in action creators"'/
+        /Type 'ActionCreatorProps<\[\]>' is not assignable to type '"action creator props cannot be an array"'/
       );
     });
 
@@ -55,7 +55,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<{}>());
       `).toFail(
-        /Type 'ActionCreatorProps<\{\}>' is not assignable to type '"empty objects are not allowed in action creators"'/
+        /Type 'ActionCreatorProps<\{\}>' is not assignable to type '"action creator props cannot be an empty object"'/
       );
     });
   });
@@ -88,7 +88,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', (type: string) => ({type}));
       `).toFail(
-        /Type '\{ type: string; \}' is not assignable to type '"type property is not allowed in action creators"'/
+        /Type '\{ type: string; \}' is not assignable to type '"action creator props cannot have a property named `type`"'/
       );
     });
 
@@ -102,7 +102,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', () => [ ]);
       `).toFail(
-        /Type 'any\[\]' is not assignable to type '"arrays are not allowed in action creators"'/
+        /Type 'any\[\]' is not assignable to type '"action creator props cannot be an array"'/
       );
     });
   });

--- a/modules/store/spec/types/action_creator.spec.ts
+++ b/modules/store/spec/types/action_creator.spec.ts
@@ -39,7 +39,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<{ type: number }>());
       `).toFail(
-        / Type 'ActionCreatorProps<\{ type: number; \}>' is not assignable to type '"action creator props cannot have a property named `type`"'/
+        /Type '{ type: number; }' does not satisfy the constraint '"action creator props cannot have a property named `type`"'/
       );
     });
 
@@ -47,7 +47,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<[]>());
       `).toFail(
-        /Type 'ActionCreatorProps<\[\]>' is not assignable to type '"action creator props cannot be an array"'/
+        /Type '\[]' does not satisfy the constraint '"action creator props cannot be an array"'/
       );
     });
 
@@ -55,7 +55,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<{}>());
       `).toFail(
-        /Type 'ActionCreatorProps<\{\}>' is not assignable to type '"action creator props cannot be an empty object"'/
+        /Type '{}' does not satisfy the constraint '"action creator props cannot be an empty object"'/
       );
     });
 
@@ -63,7 +63,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<string>());
       `).toFail(
-        /Type 'string' is not assignable to type '"action creator props cannot be a primitive value"'/
+        /Type 'string' does not satisfy the constraint '"action creator props cannot be a primitive value"'/
       );
     });
 
@@ -71,7 +71,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<number>());
       `).toFail(
-        /Type 'number' is not assignable to type '"action creator props cannot be a primitive value"'/
+        /Type 'number' does not satisfy the constraint '"action creator props cannot be a primitive value"'/
       );
     });
 
@@ -79,7 +79,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<bigint>());
       `).toFail(
-        /Type 'bigint' is not assignable to type '"action creator props cannot be a primitive value"'/
+        /Type 'bigint' does not satisfy the constraint '"action creator props cannot be a primitive value"'/
       );
     });
 
@@ -87,7 +87,15 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<boolean>());
       `).toFail(
-        /Type 'boolean' is not assignable to type '"action creator props cannot be a primitive value"'/
+        /Type 'boolean' does not satisfy the constraint '"action creator props cannot be a primitive value"'/
+      );
+    });
+
+    it('should not allow symbols', () => {
+      expectSnippet(`
+        const foo = createAction('FOO', props<symbol>());
+      `).toFail(
+        /Type 'symbol' does not satisfy the constraint '"action creator props cannot be a primitive value"'/
       );
     });
 
@@ -95,7 +103,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<null>());
       `).toFail(
-        /Type 'null' is not assignable to type '"action creator props cannot be a primitive value"'/
+        /Type 'ActionCreatorProps<null>' is not assignable to type '"action creator cannot return an array"'/
       );
     });
 
@@ -103,7 +111,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', props<undefined>());
       `).toFail(
-        /Type 'undefined' is not assignable to type '"action creator props cannot be a primitive value"'/
+        /Type 'ActionCreatorProps<undefined>' is not assignable to type '"action creator cannot return an array"'/
       );
     });
   });
@@ -136,7 +144,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', (type: string) => ({type}));
       `).toFail(
-        /Type '\{ type: string; \}' is not assignable to type '"action creator props cannot have a property named `type`"'/
+        /Type '\{ type: string; \}' is not assignable to type '"action creator cannot return an object with a property named `type`"'/
       );
     });
 
@@ -150,55 +158,7 @@ describe('createAction()', () => {
       expectSnippet(`
         const foo = createAction('FOO', () => [ ]);
       `).toFail(
-        /Type 'any\[\]' is not assignable to type '"action creator props cannot be an array"'/
-      );
-    });
-
-    it('should not allow strings', () => {
-      expectSnippet(`
-        const foo = createAction('FOO', () => '');
-      `).toFail(
-        /Type 'string' is not assignable to type '"action creator cannot return a primitive value"'/
-      );
-    });
-
-    it('should not allow numbers', () => {
-      expectSnippet(`
-        const foo = createAction('FOO', () => 0);
-      `).toFail(
-        /Type 'number' is not assignable to type '"action creator cannot return a primitive value"'/
-      );
-    });
-
-    it('should not allow bigints', () => {
-      expectSnippet(`
-        const foo = createAction('FOO', () => 0n);
-      `).toFail(
-        /Type 'bigint' is not assignable to type '"action creator cannot return a primitive value"'/
-      );
-    });
-
-    it('should not allow booleans', () => {
-      expectSnippet(`
-        const foo = createAction('FOO', () => false);
-      `).toFail(
-        /Type 'boolean' is not assignable to type '"action creator cannot return a primitive value"'/
-      );
-    });
-
-    it('should not allow null', () => {
-      expectSnippet(`
-        const foo = createAction('FOO', () => null);
-      `).toFail(
-        /Type 'null' is not assignable to type '"action creator cannot return a primitive value"'/
-      );
-    });
-
-    it('should not allow undefined', () => {
-      expectSnippet(`
-        const foo = createAction('FOO', () => undefined);
-      `).toFail(
-        /Type 'undefined' is not assignable to type '"action creator cannot return a primitive value"'/
+        /Type 'any\[\]' is not assignable to type '"action creator cannot return an array"'/
       );
     });
   });

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -124,7 +124,14 @@ export function createAction<T extends string, C extends Creator>(
   }
 }
 
-export function props<P extends object>(): ActionCreatorProps<P> {
+export function props<
+  P extends R extends any
+    ? P extends object
+      ? NotAllowedCheck<P>
+      : unknown
+    : unknown,
+  R = any
+>(): ActionCreatorProps<P> {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/naming-convention
   return { _as: 'props', _p: undefined! };
 }

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -5,6 +5,7 @@ import {
   FunctionWithParametersType,
   NotAllowedCheck,
   ActionCreatorProps,
+  NotAllowedInPropsCheck,
 } from './models';
 import { REGISTERED_ACTION_TYPES } from './globals';
 
@@ -125,12 +126,8 @@ export function createAction<T extends string, C extends Creator>(
 }
 
 export function props<
-  P extends R extends any
-    ? P extends object
-      ? NotAllowedCheck<P>
-      : unknown
-    : unknown,
-  R = any
+  P extends SafeProps,
+  SafeProps = NotAllowedInPropsCheck<P>
 >(): ActionCreatorProps<P> {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/naming-convention
   return { _as: 'props', _p: undefined! };

--- a/modules/store/src/feature_creator_models.ts
+++ b/modules/store/src/feature_creator_models.ts
@@ -1,4 +1,5 @@
 import { MemoizedSelector } from './selector';
+import { Primitive } from './models';
 
 // Generating documentation for `createFeature` function is solved by moving types that use
 // template literal types (`FeatureSelector` and `NestedSelectors`) from `feature_creator.ts`.
@@ -28,5 +29,3 @@ export type NestedSelectors<
         FeatureState[K]
       >;
     };
-
-type Primitive = string | number | bigint | boolean | null | undefined;

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -67,10 +67,6 @@ export const emptyObjectsAreNotAllowedMsg =
   'action creator cannot return an empty object';
 type EmptyObjectsAreNotAllowed = typeof emptyObjectsAreNotAllowedMsg;
 
-export const primitivesAreNotAllowedMsg =
-  'action creator cannot return a primitive value';
-type PrimitivesAreNotAllowed = typeof primitivesAreNotAllowedMsg;
-
 export const arraysAreNotAllowedInProps =
   'action creator props cannot be an array';
 type ArraysAreNotAllowedInProps = typeof arraysAreNotAllowedInProps;

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -95,8 +95,6 @@ export type Creator<
   R extends object = object
 > = FunctionWithParametersType<P, R>;
 
-type Primitive = string | number | bigint | boolean | symbol | null | undefined;
-
 export type NotAllowedCheck<T extends object> = T extends any[]
   ? ArraysAreNotAllowed
   : T extends { type: any }
@@ -113,9 +111,7 @@ export type NotAllowedInPropsCheck<T> = T extends object
     : keyof T extends never
     ? EmptyObjectsAreNotAllowedInProps
     : unknown
-  : T extends Primitive
-  ? PrimitivesAreNotAllowedInProps
-  : never;
+  : PrimitivesAreNotAllowedInProps;
 
 /**
  * See `Creator`.

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -99,19 +99,15 @@ export type Creator<
   R extends object = object
 > = FunctionWithParametersType<P, R>;
 
-type Primitive = string | number | bigint | boolean | null | undefined;
+type Primitive = string | number | bigint | boolean | symbol | null | undefined;
 
-export type NotAllowedCheck<T> = T extends object
-  ? T extends any[]
-    ? ArraysAreNotAllowed
-    : T extends { type: any }
-    ? TypePropertyIsNotAllowed
-    : keyof T extends never
-    ? EmptyObjectsAreNotAllowed
-    : unknown
-  : T extends Primitive
-  ? PrimitivesAreNotAllowed
-  : never;
+export type NotAllowedCheck<T extends object> = T extends any[]
+  ? ArraysAreNotAllowed
+  : T extends { type: any }
+  ? TypePropertyIsNotAllowed
+  : keyof T extends never
+  ? EmptyObjectsAreNotAllowed
+  : unknown;
 
 export type NotAllowedInPropsCheck<T> = T extends object
   ? T extends any[]

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -126,10 +126,6 @@ export type NotAllowedInPropsCheck<T> = T extends object
   ? PrimitivesAreNotAllowedInProps
   : never;
 
-type Huh = NotAllowedInPropsCheck<unknown>;
-
-props<unknown>();
-
 /**
  * See `Creator`.
  */

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -56,16 +56,36 @@ export type SelectorWithProps<State, Props, Result> = (
   props: Props
 ) => Result;
 
-export const arraysAreNotAllowedMsg = 'action creator props cannot be an array';
+export const arraysAreNotAllowedMsg = 'action creator cannot return an array';
 type ArraysAreNotAllowed = typeof arraysAreNotAllowedMsg;
 
 export const typePropertyIsNotAllowedMsg =
-  'action creator props cannot have a property named `type`';
+  'action creator cannot return an object with a property named `type`';
 type TypePropertyIsNotAllowed = typeof typePropertyIsNotAllowedMsg;
 
 export const emptyObjectsAreNotAllowedMsg =
-  'action creator props cannot be an empty object';
+  'action creator cannot return an empty object';
 type EmptyObjectsAreNotAllowed = typeof emptyObjectsAreNotAllowedMsg;
+
+export const primitivesAreNotAllowedMsg =
+  'action creator cannot return a primitive value';
+type PrimitivesAreNotAllowed = typeof primitivesAreNotAllowedMsg;
+
+export const arraysAreNotAllowedInProps =
+  'action creator props cannot be an array';
+type ArraysAreNotAllowedInProps = typeof arraysAreNotAllowedInProps;
+
+export const typePropertyIsNotAllowedInProps =
+  'action creator props cannot have a property named `type`';
+type TypePropertyIsNotAllowedInProps = typeof typePropertyIsNotAllowedInProps;
+
+export const emptyObjectsAreNotAllowedInProps =
+  'action creator props cannot be an empty object';
+type EmptyObjectsAreNotAllowedInProps = typeof emptyObjectsAreNotAllowedInProps;
+
+export const primitivesAreNotAllowedInProps =
+  'action creator props cannot be a primitive value';
+type PrimitivesAreNotAllowedInProps = typeof primitivesAreNotAllowedInProps;
 
 export type FunctionIsNotAllowed<
   T,
@@ -79,13 +99,31 @@ export type Creator<
   R extends object = object
 > = FunctionWithParametersType<P, R>;
 
-export type NotAllowedCheck<T extends object> = T extends any[]
-  ? ArraysAreNotAllowed
-  : T extends { type: any }
-  ? TypePropertyIsNotAllowed
-  : keyof T extends never
-  ? EmptyObjectsAreNotAllowed
-  : unknown;
+type Primitive = string | number | bigint | boolean | null | undefined;
+
+export type NotAllowedCheck<T> = T extends object
+  ? T extends any[]
+    ? ArraysAreNotAllowed
+    : T extends { type: any }
+    ? TypePropertyIsNotAllowed
+    : keyof T extends never
+    ? EmptyObjectsAreNotAllowed
+    : unknown
+  : T extends Primitive
+  ? PrimitivesAreNotAllowed
+  : never;
+
+export type NotAllowedInPropsCheck<T> = T extends object
+  ? T extends any[]
+    ? ArraysAreNotAllowedInProps
+    : T extends { type: any }
+    ? TypePropertyIsNotAllowedInProps
+    : keyof T extends never
+    ? EmptyObjectsAreNotAllowedInProps
+    : unknown
+  : T extends Primitive
+  ? PrimitivesAreNotAllowedInProps
+  : never;
 
 /**
  * See `Creator`.

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -1,5 +1,3 @@
-import { props } from './action_creator';
-
 export interface Action {
   type: string;
 }

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -56,16 +56,15 @@ export type SelectorWithProps<State, Props, Result> = (
   props: Props
 ) => Result;
 
-export const arraysAreNotAllowedMsg =
-  'arrays are not allowed in action creators';
+export const arraysAreNotAllowedMsg = 'action creator props cannot be an array';
 type ArraysAreNotAllowed = typeof arraysAreNotAllowedMsg;
 
 export const typePropertyIsNotAllowedMsg =
-  'type property is not allowed in action creators';
+  'action creator props cannot have a property named `type`';
 type TypePropertyIsNotAllowed = typeof typePropertyIsNotAllowedMsg;
 
 export const emptyObjectsAreNotAllowedMsg =
-  'empty objects are not allowed in action creators';
+  'action creator props cannot be an empty object';
 type EmptyObjectsAreNotAllowed = typeof emptyObjectsAreNotAllowedMsg;
 
 export type FunctionIsNotAllowed<

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -1,3 +1,5 @@
+import { props } from './action_creator';
+
 export interface Action {
   type: string;
 }
@@ -95,6 +97,15 @@ export type Creator<
   R extends object = object
 > = FunctionWithParametersType<P, R>;
 
+export type Primitive =
+  | string
+  | number
+  | bigint
+  | boolean
+  | symbol
+  | null
+  | undefined;
+
 export type NotAllowedCheck<T extends object> = T extends any[]
   ? ArraysAreNotAllowed
   : T extends { type: any }
@@ -111,7 +122,13 @@ export type NotAllowedInPropsCheck<T> = T extends object
     : keyof T extends never
     ? EmptyObjectsAreNotAllowedInProps
     : unknown
-  : PrimitivesAreNotAllowedInProps;
+  : T extends Primitive
+  ? PrimitivesAreNotAllowedInProps
+  : never;
+
+type Huh = NotAllowedInPropsCheck<unknown>;
+
+props<unknown>();
 
 /**
  * See `Creator`.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2892

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes - usage of `props` outside of an action creator now breaks for invalid types
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Thanks to the advice from [Nadia Chibrikova on StackOverflow](https://stackoverflow.com/a/68080083/11087018), `props` can have its generic argument asserted to pass `NotAllowedCheck`:

<img width="939" alt="Screen Shot 2021-06-30 at 21 43 28" src="https://user-images.githubusercontent.com/25187726/124052373-48186680-d9ec-11eb-95b6-3714aeceb9b4.png">

This provides a more precise error than the current one which is hidden within TS outputting multiple errors for a mismatch for each overload of `createAction`:

<img width="984" alt="Screen Shot 2021-06-30 at 21 44 48" src="https://user-images.githubusercontent.com/25187726/124052444-6b431600-d9ec-11eb-82d9-f33d26d65145.png">

Additionally, I've updated the error messages to be hopefully more explicit about what is wrong.

UPDATE: With a suggestive playground link, I took @markostanimirovic's subtle suggestion to explicitly restrict primitive types.

I've also separated the error messages to be more contextually meaningful when using `props` vs when providing a creator function to `createAction`.