### PR TITLE
feat(store): make reducers accessible from ReducerManager

### DIFF
--- a/modules/store/spec/reducer_manager.spec.ts
+++ b/modules/store/spec/reducer_manager.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { createReducer, ReducerManager, StoreModule } from '@ngrx/store';
+
+describe(ReducerManager.name, () => {
+  it('should provide reducers being registered in store', () => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          'feature-1': createReducer(0),
+        }),
+      ],
+    });
+
+    const reducerManager = TestBed.inject(ReducerManager);
+
+    expect(Object.keys(reducerManager.currentReducers)).toContain('feature-1');
+  });
+
+  it('should provide reducers being registered at runtime', () => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          'feature-1': createReducer(0),
+        }),
+      ],
+    });
+
+    const reducerManager = TestBed.inject(ReducerManager);
+
+    reducerManager.addReducer('feature-2', createReducer(0));
+
+    expect(Object.keys(reducerManager.currentReducers)).toContain('feature-1');
+    expect(Object.keys(reducerManager.currentReducers)).toContain('feature-2');
+  });
+});

--- a/modules/store/src/reducer_manager.ts
+++ b/modules/store/src/reducer_manager.ts
@@ -25,7 +25,7 @@ export const UPDATE = '@ngrx/store/update-reducers' as const;
 export class ReducerManager
   extends BehaviorSubject<ActionReducer<any, any>>
   implements OnDestroy {
-  get reducerSnapshot(): ActionReducerMap<any, any> {
+  get currentReducers(): ActionReducerMap<any, any> {
     return this.reducers;
   }
 

--- a/modules/store/src/reducer_manager.ts
+++ b/modules/store/src/reducer_manager.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable, OnDestroy, Provider } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-
 import { ActionsSubject } from './actions_subject';
 import {
   Action,
@@ -26,6 +25,10 @@ export const UPDATE = '@ngrx/store/update-reducers' as const;
 export class ReducerManager
   extends BehaviorSubject<ActionReducer<any, any>>
   implements OnDestroy {
+  get reducerSnapshot(): ActionReducerMap<any, any> {
+    return this.reducers;
+  }
+
   constructor(
     private dispatcher: ReducerManagerDispatcher,
     @Inject(INITIAL_STATE) private initialState: any,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `ActionReducerMap` of `ReduceManager` is internal.
It is hard to enhance `ActionReducerMap` dynamically.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3049

## What is the new behavior?

The `ActionReducerMap` of `ReduceManager` can be accessed via getter (READ-ONLY).
This allows to get to know which features are registered in the store, at run-time.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

