### PR TITLE
fix(component-store): accept error type in tapResponse with strict generic checks

### DIFF
--- a/modules/component-store/spec/tap-response.spec.ts
+++ b/modules/component-store/spec/tap-response.spec.ts
@@ -1,0 +1,50 @@
+import { EMPTY, noop, Observable, of, throwError } from 'rxjs';
+import { tapResponse } from '@ngrx/component-store';
+import { concatMap, finalize } from 'rxjs/operators';
+
+describe('tapResponse', () => {
+  it('should invoke next callback on next', () => {
+    const nextCallback = jest.fn<void, [number]>();
+
+    of(1, 2, 3).pipe(tapResponse(nextCallback, noop)).subscribe();
+
+    expect(nextCallback.mock.calls).toEqual([[1], [2], [3]]);
+  });
+
+  it('should invoke error callback on error', () => {
+    const errorCallback = jest.fn<void, [{ message: string }]>();
+    const error = { message: 'error' };
+
+    throwError(error).pipe(tapResponse(noop, errorCallback)).subscribe();
+
+    expect(errorCallback).toHaveBeenCalledWith(error);
+  });
+
+  it('should invoke complete callback on complete', () => {
+    const completeCallback = jest.fn<void, []>();
+
+    EMPTY.pipe(tapResponse(noop, noop, completeCallback)).subscribe();
+
+    expect(completeCallback).toHaveBeenCalledWith();
+  });
+
+  it('should not unsubscribe from outer observable on inner observable error', () => {
+    const innerCompleteCallback = jest.fn<void, []>();
+    const outerCompleteCallback = jest.fn<void, []>();
+
+    new Observable((subscriber) => subscriber.next(1))
+      .pipe(
+        concatMap(() =>
+          throwError('error').pipe(
+            tapResponse(noop, noop),
+            finalize(innerCompleteCallback)
+          )
+        ),
+        finalize(outerCompleteCallback)
+      )
+      .subscribe();
+
+    expect(innerCompleteCallback).toHaveBeenCalled();
+    expect(outerCompleteCallback).not.toHaveBeenCalled();
+  });
+});

--- a/modules/component-store/spec/types/tap-response.types.spec.ts
+++ b/modules/component-store/spec/types/tap-response.types.spec.ts
@@ -1,0 +1,71 @@
+import { Expect, expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('tapResponse types', () => {
+  const snippetFactory = (code: string): string => `
+    import { tapResponse } from '@ngrx/component-store';
+    import { noop, of } from 'rxjs';
+
+    ${code}
+  `;
+
+  function testWith(expectSnippet: (code: string) => Expect): void {
+    it('should infer next type', () => {
+      expectSnippet(`
+        of(1).pipe(
+          tapResponse((next) => {
+            const num = next;
+          }, noop)
+        );
+      `).toInfer('num', 'number');
+    });
+
+    it('should accept error type', () => {
+      expectSnippet(`
+        of(true).pipe(
+          tapResponse(noop, (error: { message: string }) => {
+            const err = error;
+          })
+        );
+      `).toInfer('err', '{ message: string; }');
+    });
+
+    it('should use unknown as default error type', () => {
+      expectSnippet(`
+        of(true).pipe(
+          tapResponse(noop, (error) => {
+            const err = error;
+          })
+        );
+      `).toInfer('err', 'unknown');
+    });
+  }
+
+  describe('strict mode', () => {
+    const expectSnippet = expecter(snippetFactory, {
+      ...compilerOptions(),
+      strict: true,
+    });
+
+    testWith(expectSnippet);
+  });
+
+  describe('non-strict mode', () => {
+    const expectSnippet = expecter(snippetFactory, {
+      ...compilerOptions(),
+      strict: false,
+    });
+
+    testWith(expectSnippet);
+  });
+
+  describe('non-strict mode with strict generic checks', () => {
+    const expectSnippet = expecter(snippetFactory, {
+      ...compilerOptions(),
+      strict: false,
+      noStrictGenericChecks: false,
+    });
+
+    testWith(expectSnippet);
+  });
+});

--- a/modules/component-store/src/tap-response.ts
+++ b/modules/component-store/src/tap-response.ts
@@ -22,9 +22,9 @@ import { catchError, tap } from 'rxjs/operators';
  *   });
  * ```
  */
-export function tapResponse<T>(
+export function tapResponse<T, E = unknown>(
   nextFn: (next: T) => void,
-  errorFn: <E = unknown>(error: E) => void,
+  errorFn: (error: E) => void,
   completeFn?: () => void
 ): (source: Observable<T>) => Observable<T> {
   return (source) =>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`tapResponse` cannot accept error type when `noStrictGenericChecks` is `false`.

This bug is reported [here](https://github.com/ngrx/platform/pull/3056#issuecomment-877183920).

## What is the new behavior?

`tapResponse` accepts error type when `noStrictGenericChecks` is `false`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Added unit and type tests for `tapResponse` operator.
