### PR TITLE
docs: update JSDocs to show up in the online documentation

### DIFF
--- a/modules/effects/src/act.ts
+++ b/modules/effects/src/act.ts
@@ -44,11 +44,6 @@ export interface ActConfig<
   unsubscribe?: (count: number, input: Input) => UnsubscribeAction;
 }
 
-/**
- * Wraps project fn with error handling making it safe to use in Effects.
- * Takes either config with named properties that represent different possible
- * callbacks or project/error callbacks that are required.
- */
 export function act<
   Input,
   OutputAction extends Action,
@@ -76,6 +71,11 @@ export function act<
 ) => Observable<
   OutputAction | ErrorAction | CompleteAction | UnsubscribeAction
 >;
+/**
+ * Wraps project fn with error handling making it safe to use in Effects.
+ * Takes either a config with named properties that represent different possible
+ * callbacks or project/error callbacks that are required.
+ */
 export function act<
   Input,
   OutputAction extends Action,

--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -32,28 +32,7 @@ type ActionExtractor<
   AC extends ActionCreator<string, Creator>,
   E
 > = T extends string ? E : ReturnType<Extract<T, AC>>;
-/**
- * 'ofType' filters an Observable of Actions into an observable of the actions
- * whose type strings are passed to it.
- *
- * For example, if `actions` has type `Actions<AdditionAction|SubstractionAction>`, and
- * the type of the `Addition` action is `add`, then
- * `actions.pipe(ofType('add'))` returns an `Observable<AdditionAction>`.
- *
- * Properly typing this function is hard and requires some advanced TS tricks
- * below.
- *
- * Type narrowing automatically works, as long as your `actions` object
- * starts with a `Actions<SomeUnionOfActions>` instead of generic `Actions`.
- *
- * For backwards compatibility, when one passes a single type argument
- * `ofType<T>('something')` the result is an `Observable<T>`. Note, that `T`
- * completely overrides any possible inference from 'something'.
- *
- * Unfortunately, for unknown 'actions: Actions' these types will produce
- * 'Observable<never>'. In such cases one has to manually set the generic type
- * like `actions.ofType<AdditionAction>('add')`.
- */
+
 export function ofType<
   AC extends ActionCreator<string, Creator>[],
   U extends Action = Action,
@@ -116,6 +95,28 @@ export function ofType<
 export function ofType<V extends Action>(
   ...allowedTypes: Array<string | ActionCreator<string, Creator>>
 ): OperatorFunction<Action, V>;
+/**
+ * `ofType` filters an Observable of `Actions` into an Observable of the actions
+ * whose type strings are passed to it.
+ *
+ * For example, if `actions` has type `Actions<AdditionAction|SubstractionAction>`, and
+ * the type of the `Addition` action is `add`, then
+ * `actions.pipe(ofType('add'))` returns an `Observable<AdditionAction>`.
+ *
+ * Properly typing this function is hard and requires some advanced TS tricks
+ * below.
+ *
+ * Type narrowing automatically works, as long as your `actions` object
+ * starts with a `Actions<SomeUnionOfActions>` instead of generic `Actions`.
+ *
+ * For backwards compatibility, when one passes a single type argument
+ * `ofType<T>('something')` the result is an `Observable<T>`. Note, that `T`
+ * completely overrides any possible inference from 'something'.
+ *
+ * Unfortunately, for unknown 'actions: Actions' these types will produce
+ * 'Observable<never>'. In such cases one has to manually set the generic type
+ * like `actions.ofType<AdditionAction>('add')`.
+ */
 export function ofType(
   ...allowedTypes: Array<string | ActionCreator<string, Creator>>
 ): OperatorFunction<Action, Action> {

--- a/modules/effects/src/concat_latest_from.ts
+++ b/modules/effects/src/concat_latest_from.ts
@@ -9,7 +9,7 @@ export function concatLatestFrom<T extends Observable<unknown>, V>(
   observableFactory: (value: V) => T
 ): OperatorFunction<V, [V, ObservedValueOf<T>]>;
 /**
- * 'concatLatestFrom' combines the source value
+ * `concatLatestFrom` combines the source value
  * and the last available value from a lazily evaluated Observable
  * in a new array
  */

--- a/modules/effects/testing/src/testing.ts
+++ b/modules/effects/testing/src/testing.ts
@@ -2,18 +2,15 @@ import { FactoryProvider } from '@angular/core';
 import { Actions } from '@ngrx/effects';
 import { defer, Observable } from 'rxjs';
 
-/**
- * @description
- * Creates mock actions provider.
- *
- * @param source Actions' source
- */
 export function provideMockActions(source: Observable<any>): FactoryProvider;
+export function provideMockActions(
+  factory: () => Observable<any>
+): FactoryProvider;
 /**
  * @description
  * Creates mock actions provider.
  *
- * @param factory Actions' source creation function
+ * @param factoryOrSource Actions' source or source creation function
  *
  * @usageNotes
  *
@@ -60,9 +57,6 @@ export function provideMockActions(source: Observable<any>): FactoryProvider;
  * });
  * ```
  */
-export function provideMockActions(
-  factory: () => Observable<any>
-): FactoryProvider;
 export function provideMockActions(
   factoryOrSource: (() => Observable<any>) | Observable<any>
 ): FactoryProvider {

--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -11,37 +11,102 @@ export type SerializationOptions = {
   refs?: Array<any>;
 };
 export type Predicate = (state: any, action: Action) => boolean;
+
+/**
+ * @see http://extension.remotedev.io/docs/API/Arguments.html#features
+ */
 export interface DevToolsFeatureOptions {
+  /**
+   * Start/pause recording of dispatched actions
+   */
   pause?: boolean;
+  /**
+   * Lock/unlock dispatching actions and side effects
+   */
   lock?: boolean;
+  /**
+   * Persist states on page reloading
+   */
   persist?: boolean;
+  /**
+   * Export history of actions in a file
+   */
   export?: boolean;
+  /**
+   * Import history of actions from a file
+   */
   import?: 'custom' | boolean;
+  /**
+   * Jump back and forth (time travelling)
+   */
   jump?: boolean;
+  /**
+   * Skip (cancel) actions
+   */
   skip?: boolean;
+  /**
+   * Drag and drop actions in the history list
+   */
   reorder?: boolean;
+  /**
+   * Dispatch custom actions or action creators
+   */
   dispatch?: boolean;
+  /**
+   * Generate tests for the selected actions
+   */
   test?: boolean;
 }
 
+/**
+ * @see http://extension.remotedev.io/docs/API/Arguments.html
+ */
 export class StoreDevtoolsConfig {
+  /**
+   * Maximum allowed actions to be stored in the history tree (default: `false`)
+   */
   maxAge: number | false = false;
   monitor?: ActionReducer<any, any>;
+  /**
+   * Function which takes `action` object and id number as arguments, and should return `action` object back.
+   */
   actionSanitizer?: ActionSanitizer;
+  /**
+   * Function which takes `state` object and index as arguments, and should return `state` object back.
+   */
   stateSanitizer?: StateSanitizer;
+  /**
+   * The instance name to be shown on the monitor page (default: `document.title`)
+   */
   name?: string;
   serialize?: boolean | SerializationOptions;
   logOnly?: boolean;
   features?: DevToolsFeatureOptions;
+  /**
+   * Action types to be hidden in the monitors. If `actionsSafelist` specified, `actionsBlocklist` is ignored.
+   */
   actionsBlocklist?: string[];
+  /**
+   * Action types to be shown in the monitors
+   */
   actionsSafelist?: string[];
+  /**
+   * Called for every action before sending, takes state and action object, and returns true in case it allows sending the current data to the monitor.
+   */
   predicate?: Predicate;
+  /**
+   * Auto pauses when the extension’s window is not opened, and so has zero impact on your app when not in use.
+   */
   autoPause?: boolean;
 }
 
 export const STORE_DEVTOOLS_CONFIG = new InjectionToken<StoreDevtoolsConfig>(
   '@ngrx/store-devtools Options'
 );
+
+/**
+ * Used to provide a `StoreDevtoolsConfig` for the store-devtools.
+ */
 export const INITIAL_OPTIONS = new InjectionToken<StoreDevtoolsConfig>(
   '@ngrx/store-devtools Initial Config'
 );
@@ -71,16 +136,16 @@ export function createConfig(
     // Add all features explicitly. This prevent buggy behavior for
     // options like "lock" which might otherwise not show up.
     features: {
-      pause: true, // start/pause recording of dispatched actions
-      lock: true, // lock/unlock dispatching actions and side effects
-      persist: true, // persist states on page reloading
-      export: true, // export history of actions in a file
-      import: 'custom', // import history of actions from a file
-      jump: true, // jump back and forth (time travelling)
-      skip: true, // skip (cancel) actions
-      reorder: true, // drag and drop actions in the history list
-      dispatch: true, // dispatch custom actions or action creators
-      test: true, // generate tests for the selected actions
+      pause: true, // Start/pause recording of dispatched actions
+      lock: true, // Lock/unlock dispatching actions and side effects
+      persist: true, // Persist states on page reloading
+      export: true, // Export history of actions in a file
+      import: 'custom', // Import history of actions from a file
+      jump: true, // Jump back and forth (time travelling)
+      skip: true, // Skip (cancel) actions
+      reorder: true, // Drag and drop actions in the history list
+      dispatch: true, // Dispatch custom actions or action creators
+      test: true, // Generate tests for the selected actions
     },
   };
 

--- a/projects/ngrx.io/src/app/custom-elements/api/api-list.component.ts
+++ b/projects/ngrx.io/src/app/custom-elements/api/api-list.component.ts
@@ -56,6 +56,7 @@ export class ApiListComponent implements OnInit {
 
     statuses: Option[] = [
         { value: 'all', title: 'All' },
+        { value: 'stable', title: 'Stable' },
         { value: 'deprecated', title: 'Deprecated' },
         { value: 'security-risk', title: 'Security Risk' },
     ];


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There are function, classes, that have JSDoc currently in code (for example [act](https://ngrx.io/api/effects/act), [ofType](https://ngrx.io/api/effects/ofType) - misplaced JSDoc, [StoreDevtoolsConfig](https://ngrx.io/api/store-devtools/StoreDevtoolsConfig) - add property JSDoc with link to the original redux devtool website for explanation) but it is currently not visible in the docs.

## What is the new behavior?

All the written is JSDoc are now visible when looking at the online documentation.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Also, the `stable` status toggle is reenabled on the api page, to be able filter out the deprecated, etc functions, classes, etc.