### PR TITLE
fix(store): infer initial store state properly with metareducers

### DIFF
--- a/modules/store/spec/types/store_module.spec.ts
+++ b/modules/store/spec/types/store_module.spec.ts
@@ -1,0 +1,73 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('StoreModule', () => {
+  const expectSnippet = expecter(
+    (code) => `
+      import {StoreModule,ActionReducerMap,Action} from '@ngrx/store';
+
+      interface State {
+        featureA: object;
+        featureB: object;
+      }
+
+      const reducers: ActionReducerMap<State, Action> = {} as ActionReducerMap<
+        State,
+        Action
+      >;
+
+      function metaReducer(reducer) {
+        return (state, action) => {
+          return reducer(state, action);
+        };
+      }
+
+      ${code}
+    `,
+    compilerOptions()
+  );
+
+  describe('StoreModule.forRoot()', () => {
+    it('accepts initialState and metaReducers with matching State', () => {
+      expectSnippet(`
+        StoreModule.forRoot(reducers, {
+          initialState: { featureA: {} },
+          metaReducers: [metaReducer]
+        });
+      `).toSucceed();
+    });
+
+    it("throws when initial state don't with store state", () => {
+      expectSnippet(`
+        StoreModule.forRoot(reducers, {
+          initialState: { notExisting: 3 },
+          metaReducers: [metaReducer]
+        });
+      `).toFail(
+        /Type '{ notExisting: number; }' is not assignable to type 'InitialState<State>/
+      );
+    });
+  });
+
+  describe('StoreModule.forFeature()', () => {
+    it('accepts initialState and metaReducers with matching State', () => {
+      expectSnippet(`
+        StoreModule.forFeature('feature', reducers, {
+          initialState: { featureA: {} },
+          metaReducers: [metaReducer]
+        });
+      `).toSucceed();
+    });
+
+    it("throws when initial state don't with store state", () => {
+      expectSnippet(`
+        StoreModule.forFeature('feature', reducers, {
+          initialState: { notExisting: 3 },
+          metaReducers: [metaReducer]
+        });
+      `).toFail(
+        /Type '{ notExisting: number; }' is not assignable to type 'InitialState<State>/
+      );
+    });
+  });
+});

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -37,7 +37,6 @@ import {
   USER_PROVIDED_META_REDUCERS,
   _RESOLVED_META_REDUCERS,
   _ROOT_STORE_GUARD,
-  ACTIVE_RUNTIME_CHECKS,
   _ACTION_TYPE_UNIQUENESS_CHECK,
 } from './tokens';
 import { ACTIONS_SUBJECT_PROVIDERS, ActionsSubject } from './actions_subject';
@@ -108,7 +107,7 @@ export class StoreFeatureModule implements OnDestroy {
 export interface StoreConfig<T, V extends Action = Action> {
   initialState?: InitialState<T>;
   reducerFactory?: ActionReducerFactory<T, V>;
-  metaReducers?: MetaReducer<T, V>[];
+  metaReducers?: MetaReducer<{ [P in keyof T]: T[P] }, V>[];
 }
 
 export interface RootStoreConfig<T, V extends Action = Action>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3007

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```


This will probably be a breaking change because we're more strict.

```
BREAKING CHANGE:

`initialState` needs to match the interface of the store.
```

## Other information
