### PR TITLE
docs: fix error with serving files with ambiguous casing

### DIFF
--- a/projects/ngrx.io/tools/transforms/angular-api-package/index.js
+++ b/projects/ngrx.io/tools/transforms/angular-api-package/index.js
@@ -175,7 +175,7 @@ module.exports = new Package('angular-api', [basePackage, typeScriptPackage])
 
   .config(function(convertToJsonProcessor, postProcessHtml, API_DOC_TYPES_TO_RENDER, API_DOC_TYPES, autoLinkCode) {
     convertToJsonProcessor.docTypes = convertToJsonProcessor.docTypes.concat(API_DOC_TYPES_TO_RENDER);
-    postProcessHtml.docTypes = convertToJsonProcessor.docTypes.concat(API_DOC_TYPES_TO_RENDER);
+    postProcessHtml.docTypes = postProcessHtml.docTypes.concat(API_DOC_TYPES_TO_RENDER);
     autoLinkCode.docTypes = API_DOC_TYPES;
     autoLinkCode.codeElements = ['code', 'code-example', 'code-pane'];
   });

--- a/projects/ngrx.io/tools/transforms/angular-base-package/index.js
+++ b/projects/ngrx.io/tools/transforms/angular-base-package/index.js
@@ -31,6 +31,7 @@ module.exports = new Package('angular-base', [
   .processor(require('./processors/copyContentAssets'))
   .processor(require('./processors/renderLinkInfo'))
   .processor(require('./processors/checkContentRules'))
+  .processor(require('./processors/disambiguateDocPaths'))
 
   // overrides base packageInfo and returns the one for the 'angular/angular' repo.
   .factory('packageInfo', function() { return require(path.resolve(PROJECT_ROOT, 'package.json')); })
@@ -58,7 +59,7 @@ module.exports = new Package('angular-base', [
     collectExamples.exampleFolders = [];
 
     generateKeywordsProcessor.ignoreWordsFile = path.resolve(__dirname, 'ignore.words');
-    generateKeywordsProcessor.docTypesToIgnore = ['example-region'];
+    generateKeywordsProcessor.docTypesToIgnore = ['example-region', 'disambiguator'];
     generateKeywordsProcessor.propertiesToIgnore = ['renderedContent'];
   })
 
@@ -140,5 +141,5 @@ module.exports = new Package('angular-base', [
   })
 
   .config(function(convertToJsonProcessor) {
-    convertToJsonProcessor.docTypes = [];
+    convertToJsonProcessor.docTypes = ['disambiguator'];
   });

--- a/projects/ngrx.io/tools/transforms/angular-base-package/processors/disambiguateDocPaths.js
+++ b/projects/ngrx.io/tools/transforms/angular-base-package/processors/disambiguateDocPaths.js
@@ -1,0 +1,68 @@
+/**
+ * @dgProcessor disambiguateDocPathsProcessor
+ * @description
+ *
+ * Ensures that docs that have the same path, other than case changes,
+ * are disambiguated.
+ *
+ * For example in Angular there is the `ROUTES` const and a `Routes` type.
+ * In a case-sensitive file-system these would both be stored at the paths
+ *
+ * ```
+ * aio/src/generated/router/Routes.json
+ * aio/src/generated/router/ROUTES.json
+ * ```
+ *
+ * but in a case-insensitive file-system these two paths point to the same file!
+ */
+module.exports = function disambiguateDocPathsProcessor(log) {
+  return {
+    $runAfter: ['paths-computed'],
+    $runBefore: ['rendering-docs'],
+    $process(docs) {
+      // Collect all the ambiguous docs, whose outputPath is are only different by casing.
+      const ambiguousDocMap = new Map();
+      for (const doc of docs) {
+        if (!doc.outputPath) {
+          continue;
+        }
+        const outputPath = doc.outputPath.toLowerCase();
+        if (!ambiguousDocMap.has(outputPath)) {
+          ambiguousDocMap.set(outputPath, []);
+        }
+        const ambiguousDocs = ambiguousDocMap.get(outputPath);
+        ambiguousDocs.push(doc);
+      }
+
+      // Create a disambiguator doc for each set of such ambiguous docs,
+      // and update the ambiguous docs to have unique `path` and `outputPath` properties.
+      for (const [outputPath, ambiguousDocs] of ambiguousDocMap) {
+        if (ambiguousDocs.length === 1) {
+          continue;
+        }
+
+        log.debug('Docs with ambiguous outputPath:' + ambiguousDocs.map((d, i) => `\n - ${d.id}: "${d.outputPath}" replaced with "${convertPath(d.outputPath, i)}".`));
+
+        const doc = ambiguousDocs[0];
+        const path = doc.path;
+        const id = `${doc.id.toLowerCase()}-disambiguator`;
+        const title = `${doc.id.toLowerCase()} (disambiguation)`;
+        const aliases = [id];
+        docs.push({ docType: 'disambiguator', id, title, aliases, path, outputPath, docs: ambiguousDocs });
+
+        // Update the paths
+        let count = 0;
+        for (const doc of ambiguousDocs) {
+          doc.path = convertPath(doc.path, count);
+          doc.outputPath = convertPath(doc.outputPath, count);
+          count += 1;
+        }
+      }
+    }
+  };
+};
+
+function convertPath(path, count) {
+  // Add the counter before any extension
+  return path.replace(/(\.[^.]*)?$/, `-${count}$1`);
+}

--- a/projects/ngrx.io/tools/transforms/templates/disambiguator.template.html
+++ b/projects/ngrx.io/tools/transforms/templates/disambiguator.template.html
@@ -1,0 +1,15 @@
+{% marked %}
+# {$ doc.title $}
+{% endmarked %}
+
+{% block content %}
+<div class="content">
+  There are multiple pages that match this path:
+  <ul>
+    {% for ambiguousDoc in doc.docs %}<li>
+      <a href="{$ ambiguousDoc.path $}">{$ ambiguousDoc.id $}</a>
+      {$ ambiguousDoc.shortDescription | marked $}
+    </li>{% endfor %}
+  </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Serving the docs fails due to files with same name but different casing. Manually cherry-picked changes from https://github.com/angular/angular/pull/41788

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
