### PR TITLE
docs(store): clarify necessity of exported reducer function

### DIFF
--- a/projects/ngrx.io/content/guide/store/reducers.md
+++ b/projects/ngrx.io/content/guide/store/reducers.md
@@ -84,7 +84,7 @@ export function reducer(state: State | undefined, action: Action) {
 
 <div class="alert is-important">
 
-**Note:** The exported `reducer` function is necessary as [function calls are not supported](https://angular.io/guide/aot-compiler#function-calls-are-not-supported) the View Engine AOT compiler. It is no longer required if you use the default Ivy AOT compiler (or JIT).
+**Note:** The exported `reducer` function is no longer required if you use the default Ivy AOT compiler (or JIT). It is only necessary with the View Engine AOT compiler as [function calls are not supported](https://angular.io/guide/aot-compiler#function-calls-are-not-supported) there.
 
 </div>
 


### PR DESCRIPTION
Rephrase the explanation of the whether the exported reducer function is necessary, in light of the fact that the Ivy compiler is now enabled by default. Most new users will not require the separate exported reducer function, so it makes sense to lead with that.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

