### PR TITLE
docs: Slightly altering the debounced selector and effects example

### DIFF
--- a/projects/ngrx.io/content/guide/component-store/read.md
+++ b/projects/ngrx.io/content/guide/component-store/read.md
@@ -82,7 +82,7 @@ Adding the debounce to a selector is done by passing `{debounce: true}` as the l
 export class MoviesStore extends ComponentStore&lt;MoviesState&gt; {
   
   constructor() {
-    super({movies: Movie[], moviesPerPage: 10, currentPageIndex: 0});
+    super({movies: [], moviesPerPage: 10, currentPageIndex: 0});
  
     // 👇 effect is triggered whenever debounced data is changed
     this.fetchMovies(this.fetchMoviesData$);
@@ -122,6 +122,7 @@ export class MoviesStore extends ComponentStore&lt;MoviesState&gt; {
       );
     },
   );
+};
 </code-example>
 
 

--- a/projects/ngrx.io/content/guide/component-store/read.md
+++ b/projects/ngrx.io/content/guide/component-store/read.md
@@ -111,14 +111,17 @@ export class MoviesStore extends ComponentStore&lt;MoviesState&gt; {
     {debounce: true}, // 👈 setting this selector to debounce
   );
   
-  private readonly fetchMovies = this.effect((moviePageData$: Observable<{moviesPerPage: number, currentPageIndex: number}>) => {
-    return moviePageData$.pipe(
-      concatMap(({moviesPerPage, currentPageIndex}) =>
-        this.movieService.loadMovies(moviesPerPage, currentPageIndex),
-      ).pipe(tap(results => this.updateMovieResults(results))),
-    );
-  });
-}
+  private readonly fetchMovies = this.effect(
+    (moviePageData$: Observable<{ moviesPerPage: number; currentPageIndex: number }>) => {
+      return moviePageData$.pipe(
+        concatMap(({ moviesPerPage, currentPageIndex }) => {
+          return this.movieService
+            .loadMovies(moviesPerPage, currentPageIndex)
+            .pipe(tap((results) => this.updateMovieResults(results)));
+        }),
+      );
+    },
+  );
 </code-example>
 
 

--- a/projects/ngrx.io/content/guide/component-store/read.md
+++ b/projects/ngrx.io/content/guide/component-store/read.md
@@ -83,14 +83,9 @@ export class MoviesStore extends ComponentStore&lt;MoviesState&gt; {
   
   constructor() {
     super({movies: Movie[], moviesPerPage: 10, currentPageIndex: 0});
-
-    this.effect((moviePageData$: Observable<{moviesPerPage: number, currentPageIndex: number}>) => {
-      return moviePageData$.pipe(
-        concatMap(({moviesPerPage, currentPageIndex}) =>
-          this.movieService.loadMovies(moviesPerPage, currentPageIndex),
-        ).pipe(tap(results => this.updateMovieResults(results))),
-      );
-    })(this.fetchMoviesData$); // 👈 effect is triggered whenever debounced data is changed
+ 
+    // 👇 effect is triggered whenever debounced data is changed
+    this.fetchMovies(this.fetchMoviesData$);
   }
 
   // Updates how many movies per page should be displayed
@@ -115,6 +110,14 @@ export class MoviesStore extends ComponentStore&lt;MoviesState&gt; {
     (moviesPerPage, currentPageIndex) => ({moviesPerPage, currentPageIndex}),
     {debounce: true}, // 👈 setting this selector to debounce
   );
+  
+  private readonly fetchMovies = this.effect((moviePageData$: Observable<{moviesPerPage: number, currentPageIndex: number}>) => {
+    return moviePageData$.pipe(
+      concatMap(({moviesPerPage, currentPageIndex}) =>
+        this.movieService.loadMovies(moviesPerPage, currentPageIndex),
+      ).pipe(tap(results => this.updateMovieResults(results))),
+    );
+  });
 }
 </code-example>
 

--- a/projects/ngrx.io/content/guide/component-store/read.md
+++ b/projects/ngrx.io/content/guide/component-store/read.md
@@ -112,9 +112,9 @@ export class MoviesStore extends ComponentStore&lt;MoviesState&gt; {
   );
   
   private readonly fetchMovies = this.effect(
-    (moviePageData$: Observable<{ moviesPerPage: number; currentPageIndex: number }>) => {
+    (moviePageData$: Observable<{moviesPerPage: number; currentPageIndex: number}>) => {
       return moviePageData$.pipe(
-        concatMap(({ moviesPerPage, currentPageIndex }) => {
+        concatMap(({moviesPerPage, currentPageIndex}) => {
           return this.movieService
             .loadMovies(moviesPerPage, currentPageIndex)
             .pipe(tap((results) => this.updateMovieResults(results)));
@@ -122,7 +122,7 @@ export class MoviesStore extends ComponentStore&lt;MoviesState&gt; {
       );
     },
   );
-};
+}
 </code-example>
 
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The previous documentation example uses the `this.effect` API in a way that is inconsistent with the rest of the docs (actually not even sure if it is valid syntax).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
The revised example in the docs now uses code patterns consistent with the `effects` doc section

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```