### PR TITLE
fix(schematics): Use prefix option in feature schematic

### DIFF
--- a/modules/schematics/schematics-core/index.ts
+++ b/modules/schematics/schematics-core/index.ts
@@ -60,6 +60,7 @@ export {
   addReducerImportToNgModule,
   addReducerToActionReducerMap,
   omit,
+  getPrefix,
 } from './utility/ngrx-utils';
 
 export { getProjectPath, getProject, isLib } from './utility/project';

--- a/modules/schematics/schematics-core/utility/ngrx-utils.ts
+++ b/modules/schematics/schematics-core/utility/ngrx-utils.ts
@@ -268,3 +268,9 @@ export function omit<T extends { [key: string]: any }>(
     .filter((key) => key !== keyToRemove)
     .reduce((result, key) => Object.assign(result, { [key]: object[key] }), {});
 }
+
+export function getPrefix(options: any) {
+  return options.creators
+    ? stringUtils.camelize(options.prefix || 'load')
+    : stringUtils.capitalize(options.prefix || 'load');
+}

--- a/modules/schematics/src/action/index.ts
+++ b/modules/schematics/src/action/index.ts
@@ -13,16 +13,18 @@ import {
   SchematicContext,
 } from '@angular-devkit/schematics';
 import { Schema as ActionOptions } from './schema';
-import { getProjectPath, stringUtils, parseName } from '../../schematics-core';
-import { capitalize, camelize } from '../../schematics-core/utility/strings';
+import {
+  getProjectPath,
+  stringUtils,
+  parseName,
+  getPrefix,
+} from '../../schematics-core';
 
 export default function (options: ActionOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
     options.path = getProjectPath(host, options);
 
-    options.prefix = options.creators
-      ? camelize(options.prefix || 'load')
-      : capitalize(options.prefix || 'load');
+    options.prefix = getPrefix(options);
 
     const parsedPath = parseName(options.path, options.name);
     options.name = parsedPath.name;

--- a/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
+++ b/modules/schematics/src/effect/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, <%= effectMethod %><% if (feature) { %>, ofType<% } %> } from '@ngrx/effects';
 <% if (feature && api) { %>import { catchError, map, concatMap } from 'rxjs/operators';
 import { Observable, EMPTY, of } from 'rxjs';
-<% if (!creators) {%>import { Load<%= classify(name) %>sFailure, Load<%= classify(name) %>sSuccess, <%= classify(name) %>ActionTypes, <%= classify(name) %>Actions } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
+<% if (!creators) {%>import { <%= prefix %><%= classify(name) %>sFailure, <%= prefix %><%= classify(name) %>sSuccess, <%= classify(name) %>ActionTypes, <%= classify(name) %>Actions } from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
 <% if (creators) {%>import * as <%= classify(name) %>Actions from '<%= featurePath(group, flat, "actions", dasherize(name)) %><%= dasherize(name) %>.actions';<% } %>
 <% } %>
 <% if (feature && !api) { %>import { concatMap } from 'rxjs/operators';
@@ -15,34 +15,34 @@ import { Observable, EMPTY } from 'rxjs';
 export class <%= classify(name) %>Effects {
 <% if (feature && api && !creators) { %>
   <%= effectStart %>
-    ofType(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s),
+    ofType(<%= classify(name) %>ActionTypes.<%= prefix %><%= classify(name) %>s),
     concatMap(() =>
       /** An EMPTY observable only emits completion. Replace with your own observable API request */
       EMPTY.pipe(
-        map(data => new Load<%= classify(name) %>sSuccess({ data })),
-        catchError(error => of(new Load<%= classify(name) %>sFailure({ error }))))
+        map(data => new <%= prefix %><%= classify(name) %>sSuccess({ data })),
+        catchError(error => of(new <%= prefix %><%= classify(name) %>sFailure({ error }))))
     )
   <%= effectEnd %>
 <% } else if (feature && api && creators) { %>
   <%= effectStart %>
-      ofType(<%= classify(name) %>Actions.load<%= classify(name) %>s),
+      ofType(<%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>s),
       concatMap(() =>
         /** An EMPTY observable only emits completion. Replace with your own observable API request */
         EMPTY.pipe(
-          map(data => <%= classify(name) %>Actions.load<%= classify(name) %>sSuccess({ data })),
-          catchError(error => of(<%= classify(name) %>Actions.load<%= classify(name) %>sFailure({ error }))))
+          map(data => <%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>sSuccess({ data })),
+          catchError(error => of(<%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>sFailure({ error }))))
       )
   <%= effectEnd %>
 <% } %>
 <% if (feature && !api && !creators) { %>
   <%= effectStart %>
-    ofType(<%= classify(name) %>ActionTypes.Load<%= classify(name) %>s),
+    ofType(<%= classify(name) %>ActionTypes.<%= prefix %><%= classify(name) %>s),
     /** An EMPTY observable only emits completion. Replace with your own observable API request */
     concatMap(() => EMPTY as Observable<{ type: string }>)
   <%= effectEnd %>
 <% } else if (feature && !api && creators) { %>
   <%= effectStart %>
-      ofType(<%= classify(name) %>Actions.load<%= classify(name) %>s),
+      ofType(<%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>s),
       /** An EMPTY observable only emits completion. Replace with your own observable API request */
       concatMap(() => EMPTY as Observable<{ type: string }>)
   <%= effectEnd %>

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -27,6 +27,7 @@ describe('Effect Schematic', () => {
     root: false,
     group: false,
     creators: false,
+    prefix: 'load',
   };
 
   const projectPath = getTestProjectPath();
@@ -462,5 +463,36 @@ describe('Effect Schematic', () => {
     );
 
     expect(content).toMatch(/effects = TestBed\.inject\(FooEffects\);/);
+  });
+
+  it('should add prefix to the effect', async () => {
+    const options = {
+      ...defaultOptions,
+      prefix: 'custom',
+      feature: true,
+      api: true,
+    };
+
+    const tree = await schematicRunner
+      .runSchematicAsync('effect', options, appTree)
+      .toPromise();
+    const content = tree.readContent(
+      `${projectPath}/src/app/foo/foo.effects.ts`
+    );
+
+    expect(content).toMatch(
+      /import { CustomFoosFailure, CustomFoosSuccess, FooActionTypes, FooActions } from '\.\/foo.actions';/
+    );
+
+    expect(content).toMatch(/customFoos\$ = this\.actions\$.pipe\(/);
+    expect(content).toMatch(/ofType\(FooActionTypes\.CustomFoos\),/);
+
+    expect(content).toMatch(
+      /map\(data => new CustomFoosSuccess\({ data }\)\),/
+    );
+
+    expect(content).toMatch(
+      /catchError\(error => of\(new CustomFoosFailure\({ error }\)\)\)\)/
+    );
   });
 });

--- a/modules/schematics/src/effect/index.spec.ts
+++ b/modules/schematics/src/effect/index.spec.ts
@@ -495,4 +495,35 @@ describe('Effect Schematic', () => {
       /catchError\(error => of\(new CustomFoosFailure\({ error }\)\)\)\)/
     );
   });
+
+  it('should add prefix to the effect using creator function', async () => {
+    const options = {
+      ...defaultOptions,
+      creators: true,
+      api: true,
+      feature: true,
+      prefix: 'custom',
+    };
+
+    const tree = await schematicRunner
+      .runSchematicAsync('effect', options, appTree)
+      .toPromise();
+    const content = tree.readContent(
+      `${projectPath}/src/app/foo/foo.effects.ts`
+    );
+
+    expect(content).toMatch(
+      /customFoos\$ = createEffect\(\(\) => {\s* return this.actions\$.pipe\(/
+    );
+
+    expect(content).toMatch(/ofType\(FooActions.customFoos\),/);
+
+    expect(content).toMatch(
+      /map\(data => FooActions.customFoosSuccess\({ data }\)\),/
+    );
+
+    expect(content).toMatch(
+      /catchError\(error => of\(FooActions.customFoosFailure\({ error }\)\)\)\)/
+    );
+  });
 });

--- a/modules/schematics/src/effect/schema.json
+++ b/modules/schematics/src/effect/schema.json
@@ -76,6 +76,12 @@
       "type": "boolean",
       "default": false,
       "description": "Setup root effects module without registering initial effects."
+    },
+    "prefix": {
+      "description": "The prefix of the effect.",
+      "type": "string",
+      "default": "load",
+      "x-prompt": "What should be the prefix of the effect?"
     }
   },
   "required": []

--- a/modules/schematics/src/effect/schema.ts
+++ b/modules/schematics/src/effect/schema.ts
@@ -59,4 +59,9 @@ export interface Schema {
    * Setup root effects module without registering initial effects.
    */
   minimal?: boolean;
+
+  /**
+   * The prefix for the effects.
+   */
+  prefix?: string;
 }

--- a/modules/schematics/src/feature/index.spec.ts
+++ b/modules/schematics/src/feature/index.spec.ts
@@ -271,4 +271,68 @@ describe('Feature Schematic', () => {
       /on\(FooActions.loadFoosFailure, \(state, action\) => state\),/
     );
   });
+
+  it('should have all api effect with prefix if api flag enabled', async () => {
+    const options = {
+      ...defaultOptions,
+      api: true,
+      prefix: 'custom',
+    };
+
+    const tree = await schematicRunner
+      .runSchematicAsync('feature', options, appTree)
+      .toPromise();
+    const fileContent = tree.readContent(
+      `${projectPath}/src/app/foo.effects.ts`
+    );
+
+    expect(fileContent).toMatch(
+      /import { Actions, createEffect, ofType } from '@ngrx\/effects';/
+    );
+    expect(fileContent).toMatch(
+      /import { catchError, map, concatMap } from 'rxjs\/operators';/
+    );
+    expect(fileContent).toMatch(
+      /import { Observable, EMPTY, of } from 'rxjs';/
+    );
+    expect(fileContent).toMatch(
+      /import \* as FooActions from '.\/foo.actions';/
+    );
+
+    expect(fileContent).toMatch(/export class FooEffects/);
+    expect(fileContent).toMatch(/customFoos\$ = createEffect\(\(\) => {/);
+    expect(fileContent).toMatch(/return this.actions\$.pipe\(/);
+    expect(fileContent).toMatch(/ofType\(FooActions.customFoos\),/);
+    expect(fileContent).toMatch(/concatMap\(\(\) =>/);
+    expect(fileContent).toMatch(/EMPTY.pipe\(/);
+    expect(fileContent).toMatch(
+      /map\(data => FooActions.customFoosSuccess\({ data }\)\),/
+    );
+    expect(fileContent).toMatch(
+      /catchError\(error => of\(FooActions.customFoosFailure\({ error }\)\)\)\)/
+    );
+  });
+
+  it('should have all api actions with prefix in reducer if api flag enabled', async () => {
+    const options = {
+      ...defaultOptions,
+      api: true,
+      prefix: 'custom',
+    };
+
+    const tree = await schematicRunner
+      .runSchematicAsync('feature', options, appTree)
+      .toPromise();
+    const fileContent = tree.readContent(
+      `${projectPath}/src/app/foo.reducer.ts`
+    );
+
+    expect(fileContent).toMatch(/on\(FooActions.customFoos, state => state\),/);
+    expect(fileContent).toMatch(
+      /on\(FooActions.customFoosSuccess, \(state, action\) => state\),/
+    );
+    expect(fileContent).toMatch(
+      /on\(FooActions.customFoosFailure, \(state, action\) => state\),/
+    );
+  });
 });

--- a/modules/schematics/src/feature/index.spec.ts
+++ b/modules/schematics/src/feature/index.spec.ts
@@ -286,25 +286,9 @@ describe('Feature Schematic', () => {
       `${projectPath}/src/app/foo.effects.ts`
     );
 
-    expect(fileContent).toMatch(
-      /import { Actions, createEffect, ofType } from '@ngrx\/effects';/
-    );
-    expect(fileContent).toMatch(
-      /import { catchError, map, concatMap } from 'rxjs\/operators';/
-    );
-    expect(fileContent).toMatch(
-      /import { Observable, EMPTY, of } from 'rxjs';/
-    );
-    expect(fileContent).toMatch(
-      /import \* as FooActions from '.\/foo.actions';/
-    );
-
-    expect(fileContent).toMatch(/export class FooEffects/);
     expect(fileContent).toMatch(/customFoos\$ = createEffect\(\(\) => {/);
-    expect(fileContent).toMatch(/return this.actions\$.pipe\(/);
     expect(fileContent).toMatch(/ofType\(FooActions.customFoos\),/);
-    expect(fileContent).toMatch(/concatMap\(\(\) =>/);
-    expect(fileContent).toMatch(/EMPTY.pipe\(/);
+
     expect(fileContent).toMatch(
       /map\(data => FooActions.customFoosSuccess\({ data }\)\),/
     );

--- a/modules/schematics/src/feature/index.ts
+++ b/modules/schematics/src/feature/index.ts
@@ -19,6 +19,7 @@ export default function (options: FeatureOptions): Rule {
         skipTests: options.skipTests,
         api: options.api,
         creators: options.creators,
+        prefix: options.prefix,
       }),
       schematic('reducer', {
         flat: options.flat,
@@ -32,6 +33,7 @@ export default function (options: FeatureOptions): Rule {
         feature: true,
         api: options.api,
         creators: options.creators,
+        prefix: options.prefix,
       }),
       schematic('effect', {
         flat: options.flat,
@@ -44,6 +46,7 @@ export default function (options: FeatureOptions): Rule {
         feature: true,
         api: options.api,
         creators: options.creators,
+        prefix: options.prefix,
       }),
       schematic('selector', {
         flat: options.flat,

--- a/modules/schematics/src/feature/schema.json
+++ b/modules/schematics/src/feature/schema.json
@@ -63,6 +63,12 @@
       "description": "Specifies if the actions, reducers, and effects should be created using creator functions",
       "aliases": ["c"],
       "x-prompt": "Do you want to use the create functions?"
+    },
+    "prefix": {
+      "description": "The prefix of the action, effect and reducer.",
+      "type": "string",
+      "default": "load",
+      "x-prompt": "What should be the prefix of the action, effect and reducer?"
     }
   },
   "required": []

--- a/modules/schematics/src/feature/schema.ts
+++ b/modules/schematics/src/feature/schema.ts
@@ -49,4 +49,6 @@ export interface Schema {
    * Specifies whether to use creator functions for actions, reducers, and effects.
    */
   creators?: boolean;
+
+  prefix?: string;
 }

--- a/modules/schematics/src/reducer/creator-files/__name@dasherize@if-flat__/__name@dasherize__.reducer.ts.template
+++ b/modules/schematics/src/reducer/creator-files/__name@dasherize@if-flat__/__name@dasherize__.reducer.ts.template
@@ -15,18 +15,18 @@ export const initialState: State = {
 export const reducer = createReducer(
   initialState,
 <% if(feature) { %>
-  on(<%= classify(name) %>Actions.load<%= classify(name) %>s, state => state),
-<% if(api) { %>  on(<%= classify(name) %>Actions.load<%= classify(name) %>sSuccess, (state, action) => state),
-  on(<%= classify(name) %>Actions.load<%= classify(name) %>sFailure, (state, action) => state),
+  on(<%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>s, state => state),
+<% if(api) { %>  on(<%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>sSuccess, (state, action) => state),
+  on(<%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>sFailure, (state, action) => state),
 <% } %><% } %>
 );
 <% }else { %>
 const <%= camelize(name) %>Reducer = createReducer(
   initialState,
 <% if(feature) { %>
-  on(<%= classify(name) %>Actions.load<%= classify(name) %>s, state => state),
-<% if(api) { %>  on(<%= classify(name) %>Actions.load<%= classify(name) %>sSuccess, (state, action) => state),
-  on(<%= classify(name) %>Actions.load<%= classify(name) %>sFailure, (state, action) => state),
+  on(<%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>s, state => state),
+<% if(api) { %>  on(<%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>sSuccess, (state, action) => state),
+  on(<%= classify(name) %>Actions.<%= prefix %><%= classify(name) %>sFailure, (state, action) => state),
 <% } %><% } %>
 );
 

--- a/modules/schematics/src/reducer/files/__name@dasherize@if-flat__/__name@dasherize__.reducer.ts.template
+++ b/modules/schematics/src/reducer/files/__name@dasherize@if-flat__/__name@dasherize__.reducer.ts.template
@@ -14,13 +14,13 @@ export const initialState: State = {
 export function reducer(state = initialState, action: <% if(feature) { %><%= classify(name) %>Actions<% } else { %>Action<% } %>): State {
   switch (action.type) {
 <% if(feature) { %>
-    case <%= classify(name) %>ActionTypes.Load<%= classify(name) %>s:
+    case <%= classify(name) %>ActionTypes.<%= prefix %><%= classify(name) %>s:
       return state;
 <% if(api) { %>
-    case <%= classify(name) %>ActionTypes.Load<%= classify(name) %>sSuccess:
+    case <%= classify(name) %>ActionTypes.<%= prefix %><%= classify(name) %>sSuccess:
       return state;
 
-    case <%= classify(name) %>ActionTypes.Load<%= classify(name) %>sFailure:
+    case <%= classify(name) %>ActionTypes.<%= prefix %><%= classify(name) %>sFailure:
       return state;
 <% } %><% } %>
     default:

--- a/modules/schematics/src/reducer/index.spec.ts
+++ b/modules/schematics/src/reducer/index.spec.ts
@@ -339,4 +339,25 @@ describe('Reducer Schematic', () => {
     expect(fileContent).toMatch(/case FooActionTypes\.LoadFoosFailure/);
     expect(fileContent).not.toMatch(/import { Action } from '@ngrx\/store'/);
   });
+
+  it('should create a reducer with prefix in an api feature', async () => {
+    const tree = await schematicRunner
+      .runSchematicAsync(
+        'reducer',
+        { ...defaultOptions, feature: true, api: true, prefix: 'custom' },
+        appTree
+      )
+      .toPromise();
+    const fileContent = tree.readContent(
+      `${projectPath}/src/app/foo.reducer.ts`
+    );
+
+    expect(fileContent).toMatch(/on\(FooActions.customFoos, state => state\)/);
+    expect(fileContent).toMatch(
+      /on\(FooActions.customFoosSuccess, \(state, action\) => state\)/
+    );
+    expect(fileContent).toMatch(
+      /on\(FooActions.customFoosFailure, \(state, action\) => state\)/
+    );
+  });
 });

--- a/modules/schematics/src/reducer/index.ts
+++ b/modules/schematics/src/reducer/index.ts
@@ -23,6 +23,7 @@ import {
   parseName,
   isIvyEnabled,
   getProject,
+  getPrefix,
 } from '../../schematics-core';
 import { Schema as ReducerOptions } from './schema';
 
@@ -30,6 +31,8 @@ export default function (options: ReducerOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
     const projectConfig = getProject(host, options);
     options.path = getProjectPath(host, options);
+
+    options.prefix = getPrefix(options);
 
     if (options.module) {
       options.module = findModuleFromOptions(host, options);

--- a/modules/schematics/src/reducer/schema.json
+++ b/modules/schematics/src/reducer/schema.json
@@ -70,5 +70,11 @@
       "x-prompt": "Do you want to use the create function?"
     }
   },
+  "prefix": {
+    "description": "The prefix of the reducer.",
+    "type": "string",
+    "default": "load",
+    "x-prompt": "What should be the prefix of the reducer?"
+  },
   "required": []
 }

--- a/modules/schematics/src/reducer/schema.ts
+++ b/modules/schematics/src/reducer/schema.ts
@@ -55,4 +55,9 @@ export interface Schema {
    * handling actions and reducers.
    */
   creators?: boolean;
+
+  /**
+   * The prefix for the reducers.
+   */
+  prefix?: string;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3116

## What is the new behavior?

When using the `feature` schematic with `--prefix` option, `effects` and `reducers` will use the supplied prefix. `action` already uses the supplied prefix.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
