### PR TITLE
StoreDevtoolsConfig: Remove links to NFSW website

### DIFF
--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -13,7 +13,10 @@ export type SerializationOptions = {
 export type Predicate = (state: any, action: Action) => boolean;
 
 /**
- * @see http://extension.remotedev.io/docs/API/Arguments.html#features
+ * Chrome extension documentation
+ * @see https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#features
+ * Firefox extension documentation
+ * @see https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#features
  */
 export interface DevToolsFeatureOptions {
   /**
@@ -59,7 +62,10 @@ export interface DevToolsFeatureOptions {
 }
 
 /**
- * @see http://extension.remotedev.io/docs/API/Arguments.html
+ * Chrome extension documentation
+ * @see https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md
+ * Firefox extension documentation
+ * @see https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md
  */
 export class StoreDevtoolsConfig {
   /**


### PR DESCRIPTION
The JsDoc comments of the StoreDevtoolsConfig class and DevToolsFeatureOptions interface lead to a site that is now NSFW.
This commit replaces the single link by two links: one for the Firefox extension documentation, and one for the Chrome extension documentation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

JsDoc leads to a porn site (remotedev.extensions.io)

Closes #3143 

## What is the new behavior?
The link now leads to real docs

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] Hell No, it's just a damn link!
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
