### PR TITLE
fix(entity): set correct input argument types for removeMutably methods

### DIFF
--- a/modules/entity/src/unsorted_state_adapter.ts
+++ b/modules/entity/src/unsorted_state_adapter.ts
@@ -85,12 +85,12 @@ export function createUnsortedStateAdapter<T>(selectId: IdSelector<T>): any {
     }
   }
 
-  function removeOneMutably(key: T, state: R): DidMutate;
+  function removeOneMutably(key: string | number, state: R): DidMutate;
   function removeOneMutably(key: any, state: any): DidMutate {
     return removeManyMutably([key], state);
   }
 
-  function removeManyMutably(keys: T[], state: R): DidMutate;
+  function removeManyMutably(keys: string[] | number[], state: R): DidMutate;
   function removeManyMutably(predicate: Predicate<T>, state: R): DidMutate;
   function removeManyMutably(
     keysOrPredicate: any[] | Predicate<T>,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Input argument types for `removeOneMutably` and `removeManyMutably` methods are incorrect.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
