### PR TITLE
refactor(store): use Record as Store generic

### DIFF
--- a/modules/store/spec/types/feature_creator.spec.ts
+++ b/modules/store/spec/types/feature_creator.spec.ts
@@ -244,7 +244,7 @@ describe('createFeature()', () => {
       `).toSucceed();
     });
 
-    it('should allow use with untyped store.select', () => {
+    it('should not allow use with untyped store.select', () => {
       expectSnippet(`
         const { selectCounterState, selectCount } = createFeature<{ counter: { count: number } }>({
           name: 'counter',
@@ -254,7 +254,9 @@ describe('createFeature()', () => {
         let store!: Store;
         const counterState$ = store.select(selectCounterState);
         const count$ = store.select(selectCount);
-      `).toFail(/No overload matches this call/);
+      `).toFail(
+        /Type 'Record<string, unknown>' is not assignable to type '{ counter: { count: number; }; }/
+      );
     });
 
     it('should allow use with typed store.select', () => {

--- a/modules/store/spec/types/feature_creator.spec.ts
+++ b/modules/store/spec/types/feature_creator.spec.ts
@@ -254,9 +254,7 @@ describe('createFeature()', () => {
         let store!: Store;
         const counterState$ = store.select(selectCounterState);
         const count$ = store.select(selectCount);
-      `).toFail(
-        /Type 'object' is not assignable to type '{ counter: { count: number; }; }'/
-      );
+      `).toFail(/No overload matches this call/);
     });
 
     it('should allow use with typed store.select', () => {

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -10,7 +10,7 @@ import { ReducerManager } from './reducer_manager';
 import { StateObservable } from './state';
 
 @Injectable()
-export class Store<T = object>
+export class Store<T = Record<string, unknown>>
   extends Observable<T>
   implements Observer<Action>
 {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This change should help for cases as https://github.com/ngrx/platform/issues/2780#issuecomment-931443027.
This change doesn't fix the cases where `createFeatureSelector` is used with 2 generics.
To resolve those cases, we could assert the generic `T` as `any`, or remove the `<State, FeatureState>` overload from `createFeatureSelector` in the next version.

```ts
export const selectBooksState = createFeatureSelector<State, BooksState>(
  booksFeatureKey
);
```