### PR TITLE
fix(store): remove store config from forFeature signature with slice

### DIFF
--- a/modules/store/spec/modules.spec.ts
+++ b/modules/store/spec/modules.spec.ts
@@ -26,10 +26,10 @@ describe(`Store Modules`, () => {
   );
 
   // Trigger here is basically an action type used to trigger state update
-  const createDummyReducer = <T>(def: T, trigger: string): ActionReducer<T> => (
-    s = def,
-    { type, payload }: any
-  ) => (type === trigger ? payload : s);
+  const createDummyReducer =
+    <T>(def: T, trigger: string): ActionReducer<T> =>
+    (s = def, { type, payload }: any) =>
+      type === trigger ? payload : s;
   const rootFruitReducer = createDummyReducer('apple', 'fruit');
   const featureAReducer = createDummyReducer(5, 'a');
   const featureBListReducer = createDummyReducer([1, 2, 3], 'bList');
@@ -104,7 +104,7 @@ describe(`Store Modules`, () => {
       });
     });
 
-    it(`should should use config.reducerFactory`, (done) => {
+    it(`should use config.reducerFactory`, (done) => {
       store.dispatch({ type: 'fruit', payload: 'banana' });
       store.dispatch({ type: 'a', payload: 42 });
 
@@ -241,11 +241,12 @@ describe(`Store Modules`, () => {
       store = TestBed.inject(Store);
     });
 
-    it('should set up a feature state', () => {
+    it('should set up a feature state', (done) => {
       store.pipe(take(1)).subscribe((state: State) => {
         expect(state).toEqual({
           a: 5,
         } as State);
+        done();
       });
     });
   });

--- a/modules/store/spec/types/store_module.spec.ts
+++ b/modules/store/spec/types/store_module.spec.ts
@@ -4,7 +4,7 @@ import { compilerOptions } from './utils';
 describe('StoreModule', () => {
   const expectSnippet = expecter(
     (code) => `
-      import {StoreModule,ActionReducerMap,Action} from '@ngrx/store';
+      import { StoreModule, ActionReducerMap, Action, createReducer } from '@ngrx/store';
 
       interface State {
         featureA: object;
@@ -68,6 +68,15 @@ describe('StoreModule', () => {
       `).toFail(
         /Type '{ notExisting: number; }' is not assignable to type 'InitialState<State>/
       );
+    });
+
+    it('throws when store config is passed along with slice object', () => {
+      expectSnippet(`
+        StoreModule.forFeature(
+          { name: 'feature', reducer: createReducer(0) },
+          { initialState: 100, metaReducers: [metaReducer] }
+        );
+      `).toFail(/No overload matches this call/);
     });
   });
 });

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -202,18 +202,15 @@ export class StoreModule {
     config?: StoreConfig<T, V> | InjectionToken<StoreConfig<T, V>>
   ): ModuleWithProviders<StoreFeatureModule>;
   static forFeature<T, V extends Action = Action>(
-    slice: FeatureSlice<T, V>,
-    config?: StoreConfig<T, V> | InjectionToken<StoreConfig<T, V>>
+    slice: FeatureSlice<T, V>
   ): ModuleWithProviders<StoreFeatureModule>;
   static forFeature(
     featureNameOrSlice: string | FeatureSlice<any, any>,
-    reducersOrConfig?:
+    reducers?:
       | ActionReducerMap<any, any>
       | InjectionToken<ActionReducerMap<any, any>>
       | ActionReducer<any, any>
-      | InjectionToken<ActionReducer<any, any>>
-      | StoreConfig<any, any>
-      | InjectionToken<StoreConfig<any, any>>,
+      | InjectionToken<ActionReducer<any, any>>,
     config: StoreConfig<any, any> | InjectionToken<StoreConfig<any, any>> = {}
   ): ModuleWithProviders<StoreFeatureModule> {
     return {
@@ -257,15 +254,13 @@ export class StoreModule {
           useValue:
             featureNameOrSlice instanceof Object
               ? featureNameOrSlice.reducer
-              : reducersOrConfig,
+              : reducers,
         },
         {
           provide: _FEATURE_REDUCERS_TOKEN,
           multi: true,
           useExisting:
-            reducersOrConfig instanceof InjectionToken
-              ? reducersOrConfig
-              : _FEATURE_REDUCERS,
+            reducers instanceof InjectionToken ? reducers : _FEATURE_REDUCERS,
         },
         {
           provide: FEATURE_REDUCERS,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `StoreModule.forFeature` signature with `FeatureSlice` has `StoreConfig` as the second input argument, but the configuration isn't registered if passed.

Closes #3216

## What is the new behavior?

The `StoreModule.forFeature` signature with `FeatureSlice` no longer has `StoreConfig` as the second input argument.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No

BREAKING CHANGES:

The `StoreConfig` argument is removed from the `StoreModule.forFeature` signature with `FeatureSlice`.

BEFORE:

The `StoreModule.forFeature` signature with `FeatureSlice` has `StoreConfig` as the second input argument, but the configuration isn't registered if passed.

AFTER:

The `StoreModule.forFeature` signature with `FeatureSlice` no longer has `StoreConfig` as the second input argument.
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->