### PR TITLE
feat(store) add overload for projector to inform about incorrect usage

### DIFF
--- a/modules/router-store/spec/types/selectors.spec.ts
+++ b/modules/router-store/spec/types/selectors.spec.ts
@@ -105,15 +105,25 @@ describe('router selectors', () => {
     );
   });
 
-  it('selectUrl should return string', () => {
+  it('selectUrl with strict option should return strict selector with [string] slices and string projection', () => {
     expectSnippet(`
       export const selector = createSelector(
         selectUrl,
-        url => url
+        url => url,
+        { strict: true }
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, string, DefaultProjectorFn<string>>'
+      'StrictMemoizedSelector<[url: string], string, State>'
     );
+  });
+
+  it('selectUrl with strict generic params should return strict selector with [string] slices and string projection', () => {
+    expectSnippet(`
+      export const selector = createSelector<[string], string>(
+        selectUrl,
+        url => url
+      );
+    `).toInfer('selector', 'StrictMemoizedSelector<[url: string], string>');
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Starts process on #3097 

## What is the new behavior?

A message on an overload for `projector` when it is used incorrectly:

<img width="854" alt="Screen Shot 2021-11-11 at 15 00 12" src="https://user-images.githubusercontent.com/25187726/141361253-ffc2db94-04bb-4819-b683-1001922bbb84.png">


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information