### PR TITLE
fix(data): set loaded to true on queryManySuccess

### DIFF
--- a/modules/data/spec/reducers/entity-collection-reducer.spec.ts
+++ b/modules/data/spec/reducers/entity-collection-reducer.spec.ts
@@ -356,7 +356,7 @@ describe('EntityCollectionReducer', () => {
       const collection = state['Hero'];
 
       expect(collection.ids).toEqual([3]);
-      expect(collection.loaded).toBe(false);
+      expect(collection.loaded).toBe(true);
       expect(collection.loading).toBe(false);
     });
 

--- a/modules/data/src/reducers/entity-collection-reducer-methods.ts
+++ b/modules/data/src/reducers/entity-collection-reducer-methods.ts
@@ -290,6 +290,7 @@ export class EntityCollectionReducerMethods<T> {
         collection,
         mergeStrategy
       ),
+      loaded: true,
       loading: false,
     };
   }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `getWithQuery` method has not set the loaded property to true as opposed to the getAll method. 

Closes #3165 

## What is the new behavior?
Now they both `getWithQuery` and `getAll` methods are consistent and do set `loaded` property to _true_ on dispatching their success actions respectively.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```
Now `getWithQuery` method really does "load data collection". So far it has been necessary to call `setLoaded(true)` if a developer has wanted to fetch the list using `getWithQuery`. 

