### PR TITLE
test(entity): fix expected ids order

### DIFF
--- a/modules/entity/spec/sorted_state_adapter.spec.ts
+++ b/modules/entity/spec/sorted_state_adapter.spec.ts
@@ -316,7 +316,7 @@ describe('Sorted State Adapter', () => {
     );
 
     expect(withUpdates).toEqual({
-      ids: [AClockworkOrange.id, TheGreatGatsby.id],
+      ids: [TheGreatGatsby.id, AClockworkOrange.id],
       entities: {
         [TheGreatGatsby.id]: {
           ...TheGreatGatsby,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Test
```

## What is the current behavior?

The test *Sorted State Adapter -> should let you update many entities by id in the state* fails because the order of the expected IDs is wrong.

Closes #

## What is the new behavior?
The test *Sorted State Adapter -> should let you update many entities by id in the state* succeeds because the order of the expected IDs matches the order of the expected entities.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Why was this broken test not detected? When did it break?