### PR TITLE
docs(router-store): place `serializer` setting documentation correctly

### DIFF
--- a/modules/router-store/src/router_store_module.ts
+++ b/modules/router-store/src/router_store_module.ts
@@ -61,6 +61,11 @@ export interface StoreRouterConfig<
   T extends BaseRouterStoreState = SerializedRouterStateSnapshot
 > {
   stateKey?: StateKeyOrSelector<T>;
+  /**
+   * Decides which router serializer should be used, if there is none provided, and the metadata on the dispatched @ngrx/router-store action payload.
+   * Set to `Full` to use the `DefaultRouterStateSerializer` and to set the angular router events as payload.
+   * Set to `Minimal` to use the `MinimalRouterStateSerializer` and to set a minimal router event with the navigation id and url as payload.
+   */
   serializer?: new (...args: any[]) => RouterStateSerializer;
   /**
    * By default, ROUTER_NAVIGATION is dispatched before guards and resolvers run.
@@ -70,11 +75,6 @@ export interface StoreRouterConfig<
    * set this property to NavigationActionTiming.PostActivation.
    */
   navigationActionTiming?: NavigationActionTiming;
-  /**
-   * Decides which router serializer should be used, if there is none provided, and the metadata on the dispatched @ngrx/router-store action payload.
-   * Set to `Full` to use the `DefaultRouterStateSerializer` and to set the angular router events as payload.
-   * Set to `Minimal` to use the `MinimalRouterStateSerializer` and to set a minimal router event with the navigation id and url as payload.
-   */
   routerState?: RouterState;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The inline documentation for `StoreRouterConfig#serializer` is placed at `StoreRouterConfig#routerState`.

Closes #

## What is the new behavior?
The inline documentation for `StoreRouterConfig#serializer` is placed correctly.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
