### PR TITLE
refactor(store): export TypedAction

### DIFF
--- a/modules/store/src/index.ts
+++ b/modules/store/src/index.ts
@@ -13,6 +13,7 @@ export {
   SelectorWithProps,
   RuntimeChecks,
   FunctionWithParametersType,
+  TypedAction
 } from './models';
 export { createAction, props, union } from './action_creator';
 export { Store, select } from './store';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

This is a suggestion to export `TypedAction` for public usage.

We are using some of the models from `ngrx/store`, namely  `Action, ActionCreator, ActionCreatorProps, createAction, Creator, NotAllowedCheck, props `and `TypedAction` to create our own utils for building actions and reducers.

TypedAction is the only model that is currently imported from an internal folder (`@ngrx/store/src/models`)

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

That it is not exported

## What is the new behavior?

That the `TypedAction`-model is included in the public API

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information