### PR TITLE
fix: set correct dist paths for testing packages

### DIFF
--- a/modules/effects/testing/package.json
+++ b/modules/effects/testing/package.json
@@ -1,12 +1,3 @@
 {
-  "name": "@ngrx/effects/testing",
-  "ngPackage": {},
-  "typings": "./testing.d.ts",
-  "main": "../bundles/core-testing.umd.js",
-  "module": "../fesm5/testing.js",
-  "es2015": "../fesm2015/testing.js",
-  "esm5": "../esm5/testing/testing.js",
-  "esm2015": "../esm2015/testing/testing.js",
-  "fesm5": "../fesm5/testing.js",
-  "fesm2015": "../fesm2015/testing.js"
+  "ngPackage": {}
 }

--- a/modules/store/testing/package.json
+++ b/modules/store/testing/package.json
@@ -1,12 +1,3 @@
 {
-  "name": "@ngrx/store/testing",
-  "ngPackage": {},
-  "typings": "./testing.d.ts",
-  "main": "../bundles/core-testing.umd.js",
-  "module": "../fesm5/testing.js",
-  "es2015": "../fesm2015/testing.js",
-  "esm5": "../esm5/testing/testing.js",
-  "esm2015": "../esm2015/testing/testing.js",
-  "fesm5": "../fesm5/testing.js",
-  "fesm2015": "../fesm2015/testing.js"
+  "ngPackage": {}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3248 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This PR changes the package.json from the testing (store and effects) packages.
Instead of setting the paths manually, the ng-packagr can do it for us - [docs](https://github.com/ng-packagr/ng-packagr/blob/master/docs/secondary-entrypoints.md#example-folder-layout-for-secondary-entry-points)

After this change the output files look like this:

Store:

Before:

```json
{
  "name": "@ngrx/store/testing",
  "typings": "ngrx-store-testing.d.ts",
  "main": "../bundles/core-testing.umd.js",
  "module": "../fesm2015/ngrx-store-testing.mjs",
  "es2015": "../fesm2015/testing.js",
  "esm5": "../esm5/testing/testing.js",
  "esm2015": "../esm2015/testing/testing.js",
  "fesm5": "../fesm5/testing.js",
  "fesm2015": "../fesm2015/ngrx-store-testing.mjs",
  "es2020": "../fesm2020/ngrx-store-testing.mjs",
  "esm2020": "../esm2020/testing/ngrx-store-testing.mjs",
  "fesm2020": "../fesm2020/ngrx-store-testing.mjs",
  "sideEffects": false
}
```

After:

```json
{
  "module": "../fesm2015/ngrx-store-testing.mjs",
  "es2020": "../fesm2020/ngrx-store-testing.mjs",
  "esm2020": "../esm2020/testing/ngrx-store-testing.mjs",
  "fesm2020": "../fesm2020/ngrx-store-testing.mjs",
  "fesm2015": "../fesm2015/ngrx-store-testing.mjs",
  "typings": "ngrx-store-testing.d.ts",
  "sideEffects": false,
  "name": "@ngrx/store/testing"
}
```

Effects:

Before:

```json
{
  "name": "@ngrx/effects/testing",
  "typings": "ngrx-effects-testing.d.ts",
  "main": "../bundles/core-testing.umd.js",
  "module": "../fesm2015/ngrx-effects-testing.mjs",
  "es2015": "../fesm2015/testing.js",
  "esm5": "../esm5/testing/testing.js",
  "esm2015": "../esm2015/testing/testing.js",
  "fesm5": "../fesm5/testing.js",
  "fesm2015": "../fesm2015/ngrx-effects-testing.mjs",
  "es2020": "../fesm2020/ngrx-effects-testing.mjs",
  "esm2020": "../esm2020/testing/ngrx-effects-testing.mjs",
  "fesm2020": "../fesm2020/ngrx-effects-testing.mjs",
  "sideEffects": false
}
```

After:

```json
{
  "module": "../fesm2015/ngrx-effects-testing.mjs",
  "es2020": "../fesm2020/ngrx-effects-testing.mjs",
  "esm2020": "../esm2020/testing/ngrx-effects-testing.mjs",
  "fesm2020": "../fesm2020/ngrx-effects-testing.mjs",
  "fesm2015": "../fesm2015/ngrx-effects-testing.mjs",
  "typings": "ngrx-effects-testing.d.ts",
  "sideEffects": false,
  "name": "@ngrx/effects/testing"
}
```


