### PR TITLE
docs: fix heritage links

### DIFF
--- a/projects/ngrx.io/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/projects/ngrx.io/tools/transforms/templates/api/lib/memberHelpers.html
@@ -3,10 +3,10 @@
 
 {%- macro renderHeritage(exportDoc) -%}
   {%- if exportDoc.extendsClauses.length %} extends {% for clause in exportDoc.extendsClauses -%}
-  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text $}</a>{% if not loop.last %}, {% endif -%}
+  {% if clause.doc.path %}<a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% else %}{$ clause.text | escape $}{% endif %}{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
   {%- if exportDoc.implementsClauses.length %} implements {% for clause in exportDoc.implementsClauses -%}
-  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text $}</a>{% if not loop.last %}, {% endif -%}
+  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
 {%- endmacro -%}
 


### PR DESCRIPTION
Hi everyone,

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

I managed to find the similar issue that both Angular and RxJS documentation apps had. Basically, the docs app does not render what [EntityCollectionServiceBase](https://ngrx.io/api/data/EntityCollectionServiceBase) implements. While the docs app says this:

`class EntityCollectionServiceBase<...> implements EntityCollectionService`,

[it actually implements this](https://github.com/ngrx/platform/blob/d3aa7d0bde6c0e4de4b3e91a99fa6708b8c341bb/modules/data/src/entity-services/entity-collection-service-base.ts#L31):

`class EntityCollectionServiceBase<...> implements EntityCollectionService<T>`.

Basically, the docs do not render generic type `<T>`. Here's how this looks like in the DOM:

![image](https://user-images.githubusercontent.com/28087049/145577132-9411a6de-db14-4c1c-be1a-eda95e184799.png)

## What is the new behavior?
This PR fixes the docs rendering for similar cases. This is how this looks like with this fix:

![image](https://user-images.githubusercontent.com/28087049/145577278-d965cf65-2a65-493b-aa25-c3af2358e88a.png)

p.s. I added what Angular docs already have: the check if `clause.doc.path` exists. If it exists, make sure to add `<a>` tag, if it doesn't, just render `clause.text`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
For more info, please check these related issues/PRs:
Related angular/angular#43956
Related ReactiveX/rxjs#6655
Related ReactiveX/rxjs#6427