### PR TITLE
docs: fix links missing objects with a dollar sign

### DIFF
--- a/projects/ngrx.io/tools/transforms/angular-base-package/post-processors/auto-link-code.js
+++ b/projects/ngrx.io/tools/transforms/angular-base-package/post-processors/auto-link-code.js
@@ -45,7 +45,7 @@ module.exports = function autoLinkCode(getDocFromAlias) {
                 parent.children.splice(index, 1, createLinkNode(docs[0], node.value));
               } else {
                 // Parse the text for words that we can convert to links
-                const nodes = textContent(node).split(/([A-Za-z0-9_.-]+)/)
+                const nodes = textContent(node).split(/([A-Za-z0-9_.$-]+)/)
                   .filter(word => word.length)
                   .map((word, index, words) => {
                     // remove docs that fail the custom filter tests


### PR DESCRIPTION
Hi everyone,

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, [auto-link-code](https://github.com/ngrx/platform/blob/875adb3a99/projects/ngrx.io/tools/transforms/angular-base-package/post-processors/auto-link-code.js#L23) tool adds links to `<code>` tags automatically by parsing the entire node and doing lookup for existing words (objects/functions/classes). It misses words that contain `$`. Thus, docs pages like [`EntityCollectionServiceBase`](https://ngrx.io/api/data/EntityCollectionServiceBase) page don't show correct links:

<img width="1127" alt="image" src="https://user-images.githubusercontent.com/28087049/148839175-db9efd71-d01f-423a-8492-d6fe04b3628b.png">


## What is the new behavior?

This PR fixes this issue so that `EntityCollectionServiceBase` starts showing [correct links](https://github.com/ngrx/platform/blob/875adb3a99/modules/data/src/entity-services/entity-collection-service-base.ts#L30):

<img width="887" alt="image" src="https://user-images.githubusercontent.com/28087049/148840146-49ba028c-45bd-45be-a56f-ffb16504d137.png">


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
None