### PR TITLE
docs(entity): remove partial update notes for upsert methods

### DIFF
--- a/projects/ngrx.io/content/guide/entity/adapter.md
+++ b/projects/ngrx.io/content/guide/entity/adapter.md
@@ -89,8 +89,8 @@ state if no changes were made.
 - `removeAll`: Clear entity collection.
 - `updateOne`: Update one entity in the collection. Supports partial updates.
 - `updateMany`: Update multiple entities in the collection. Supports partial updates.
-- `upsertOne`: Add or Update one entity in the collection. Supports partial updates.
-- `upsertMany`: Add or Update multiple entities in the collection. Supports partial updates.
+- `upsertOne`: Add or Update one entity in the collection.
+- `upsertMany`: Add or Update multiple entities in the collection.
 - `mapOne`: Update one entity in the collection by defining a map function.
 - `map`: Update multiple entities in the collection by defining a map function, similar to [Array.map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
 
@@ -238,9 +238,7 @@ interface UpdateNum<T> {
 type Update<T> = UpdateStr<T> | UpdateNum<T>;
 ```
 
-Secondly, `upsertOne` and `upsertMany` will perform an insert or update. If a partial entity is provided this will perform an update.
-
-To prevent partial updates either explicitly set all the fields, setting non-used fields with value `undefined`, or use the `setOne`, `setAll` or `setMany` adapter methods. 
+Secondly, `upsertOne` and `upsertMany` will perform an insert or update. These methods do not support partial updates.
 
 ### Entity Selectors
 


### PR DESCRIPTION
Removed mentions of partial updates for upsertOne and upsertMany as they are not longer support them

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

[<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
](https://github.com/ngrx/platform/issues/3282)

Closes #3282

## What is the new behavior?

Correct documentation for upsertOne and upsertMany method. Now documentation explicitly state that upsertOne and upsertMany do not support partial updates.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
