### PR TITLE
docs(store): include version in command for v12 update

### DIFF
--- a/projects/ngrx.io/content/guide/migration/v12.md
+++ b/projects/ngrx.io/content/guide/migration/v12.md
@@ -7,7 +7,7 @@ NgRx supports using the Angular CLI `ng update` command to update your dependenc
 To update your packages to the latest released version, run the command below.
 
 ```sh
-ng update @ngrx/store
+ng update @ngrx/store@12
 ```
 
 ## Dependencies


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Documentation for migrating to v12 does not include version number in command used to update the framework.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?
Version number is added to command used to migrate the framework to v12 in order to avoid confusion to the reader. Without this, the update version will be the latest version. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
