### PR TITLE
docs(store): make docs compliant with ngrx lint (#3325)

### DIFF
--- a/projects/ngrx.io/content/examples/store/src/app/counter.selector.ts
+++ b/projects/ngrx.io/content/examples/store/src/app/counter.selector.ts
@@ -1,0 +1,3 @@
+import { createFeatureSelector } from '@ngrx/store';
+
+export const selectCount = createFeatureSelector<number>('count');

--- a/projects/ngrx.io/content/examples/store/src/app/my-counter/my-counter.component.ts
+++ b/projects/ngrx.io/content/examples/store/src/app/my-counter/my-counter.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { increment, decrement, reset } from '../counter.actions';
+import { selectCount } from '../counter.selector';
 
 @Component({
   selector: 'app-my-counter',
@@ -10,8 +11,8 @@ import { increment, decrement, reset } from '../counter.actions';
 export class MyCounterComponent {
   count$: Observable<number>;
 
-  constructor(private store: Store<{ count: number }>) {
-    this.count$ = store.select('count');
+  constructor(private store: Store) {
+    this.count$ = store.select(selectCount);
   }
 
   increment() {

--- a/projects/ngrx.io/content/guide/store/index.md
+++ b/projects/ngrx.io/content/guide/store/index.md
@@ -57,7 +57,12 @@ The following tutorial shows you how to manage the state of a counter, and how t
 <code-example header="src/app/app.module.ts (StoreModule)" path="store/src/app/app.module.1.ts">
 </code-example>
 
-6.  Create a new file called `my-counter.component.ts` in a folder named `my-counter` within the `app` folder that will define a new component called `MyCounterComponent`. This component will render buttons that allow the user to change the count state. Also, create the `my-counter.component.html` file within this same folder.
+6. Create a new file named `counter.selector.ts` within the `app` folder to define a selector function to obatain the `count` from the state.
+
+<code-example header="src/app/counter.selector.ts" path="store/src/app/counter.selector.ts">
+</code-example>
+
+7.  Create a new file called `my-counter.component.ts` in a folder named `my-counter` within the `app` folder that will define a new component called `MyCounterComponent`. This component will render buttons that allow the user to change the count state. Also, create the `my-counter.component.html` file within this same folder.
 
 <code-example header="src/app/my-counter/my-counter.component.ts" >
 import { Component } from '@angular/core';
@@ -99,7 +104,7 @@ export class MyCounterComponent {
 </code-example>
 
 
-7.  Add the new component to your AppModule's declarations and declare it in the template:
+8.  Add the new component to your AppModule's declarations and declare it in the template:
 
 <code-example header="src/app/app.component.html" path="store/src/app/app.component.html" region="counter">
 </code-example>
@@ -107,7 +112,7 @@ export class MyCounterComponent {
 <code-example header="src/app/app.module.ts" path="store/src/app/app.module.ts">
 </code-example>
 
-8.  Inject the store into `MyCounterComponent` and connect the `count$` stream to the store's `count` state. Implement the `increment`, `decrement`, and `reset` methods by dispatching actions to the store.
+9.  Inject the store into `MyCounterComponent` and use the `selectCount` selector to connect the `count$` stream to the store's `count` state. Implement the `increment`, `decrement`, and `reset` methods by dispatching actions to the store.
 
 <code-example header="src/app/my-counter/my-counter.component.ts" path="store/src/app/my-counter/my-counter.component.ts">
 </code-example>
@@ -118,6 +123,7 @@ Let's cover what you did:
 
 - Defined actions to express events.
 - Defined a reducer function to manage the state of the counter.
+- Defined a selector function to obtain the state of the counter.
 - Registered the global state container that is available throughout your application.
 - Injected the `Store` service to dispatch actions and select the current state of the counter.
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Code examples in the [Getting started](https://ngrx.io/guide/store) cause lint errors with ngrx eslint-plugin-ngrx recommended configuration. (It's worth noting that `yarn add @ngrx/store` enables the recommended configuration in the ESLint configuration file by default.)

These lines of code from the guide:

```ts
  // src/app/my-counter/my-counter.component.ts

  constructor(private store: Store<{ count: number }>) {
    this.count$ = store.select('count');
  }
```
surface the errors: 
- `Store` should not be typed, use `Store` (without generic) instead. [ngrx/no-typed-global-store](https://github.com/timdeschryver/eslint-plugin-ngrx/blob/main/docs/rules/no-typed-global-store.md)
- Using `string` or `props drilling` is forbidden. Use a selector instead. [ngrx/prefer-selector-in-select](https://github.com/timdeschryver/eslint-plugin-ngrx/tree/main/docs/rules/prefer-selector-in-select.md)

Closes #3325

## What is the new behavior?
With these changes, the relevant code doesn't trigger ngrx lint errors.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
