### PR TITLE
docs: remove links from heritage docs

### DIFF
--- a/projects/ngrx.io/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/projects/ngrx.io/tools/transforms/templates/api/lib/memberHelpers.html
@@ -3,10 +3,10 @@
 
 {%- macro renderHeritage(exportDoc) -%}
   {%- if exportDoc.extendsClauses.length %} extends {% for clause in exportDoc.extendsClauses -%}
-  {% if clause.doc.path %}<a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% else %}{$ clause.text | escape $}{% endif %}{% if not loop.last %}, {% endif -%}
+  {$ clause.text | escape $}{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
   {%- if exportDoc.implementsClauses.length %} implements {% for clause in exportDoc.implementsClauses -%}
-  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% if not loop.last %}, {% endif -%}
+  {$ clause.text | escape $}{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
 {%- endmacro -%}
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Current docs generation scripts include additional `<a>` tags that prevent proper work of the [`autoLinkCode`](https://github.com/ngrx/platform/blob/1d3e33735f/projects/ngrx.io/tools/transforms/angular-base-package/post-processors/auto-link-code.js) processor from adding proper `<a>` tags. In [the example](https://ngrx.io/api/store/ActionsSubject) from the image above you can see that some `<a>` tags are missing `href` attribute value:

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/28087049/157391235-ecbafaba-60ec-4056-906f-287930ffed1b.png">

This will be fixed with this PR.

## What is the new behavior?

Please pardon me for not properly explaining the new behavior, this is the third similar PR. I linked below related PRs, please read the description in them - they are all the same and behave the same in all three projects.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
Related angular/angular#45287
Related ReactiveX/rxjs#6864
