### PR TITLE
chore: include version number to ng add command in migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,3 @@
-# V4 Migration guide
+# V13 Migration guide
 
-This document has been moved to https://ngrx.io/guide/migration/v4
+This document has been moved to https://ngrx.io/guide/migration/v13.

--- a/build/update-version-numbers.ts
+++ b/build/update-version-numbers.ts
@@ -37,6 +37,7 @@ function updateVersions(version: string) {
     ['Update ng-add schematic', createUpdateAddSchematicBuilder(version)],
     ['Update docs version picker', createArchivePreviousDocsBuilder(version)],
     ['Create migration docs', createMigrationDocs(version)],
+    ['Update GitHub MIGRATION.MD', createMigrationMD(version)],
   ]);
 
   publishNext({
@@ -177,7 +178,7 @@ NgRx supports using the Angular CLI \`ng update\` command to update your depende
 To update your packages to the latest released version, run the command below.
 
 \`\`\`sh
-ng update @ngrx/store
+ng update @ngrx/store@${newMajor}
 \`\`\`
 
 ## Dependencies
@@ -202,4 +203,19 @@ TK
 function writeAsJson(path: string, json: object) {
   const content = JSON.stringify(json, null, 2);
   writeFileSync(path, `${content}${EOL}`);
+}
+
+/**
+ * Update the migration.MD file that is visible in GitHub
+ */
+function createMigrationMD(version: string) {
+  return async () => {
+    const [newMajor] = version.split('.');
+
+    const migrationPlaceholder = `# V${newMajor} Migration guide
+
+This document has been moved to https://ngrx.io/guide/migration/${newMajor}.
+`;
+    writeFileSync('./MIGRATION.md', migrationPlaceholder);
+  };
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[x] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

In the past there were some issues when people upgraded the NgRx dependencies because they wanted to update to a specific version, and not the the latest version. That's why I'm proposing that we
explicitly set the version number to the `ng upgraded` command in the migration guide. An alternative would be that we update the previous migration guide.


This PR also updates the version number in `MIGRATION.md`, and includes it in the update script.