### PR TITLE
docs: add styling for deprecated items

### DIFF
--- a/projects/ngrx.io/src/styles/2-modules/_api-list.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_api-list.scss
@@ -279,7 +279,6 @@ p {
 
 .code-anchor {
   cursor: pointer;
-  text-decoration: none;
   font-size: inherit;
 
   &:hover {

--- a/projects/ngrx.io/src/styles/2-modules/_api-pages.scss
+++ b/projects/ngrx.io/src/styles/2-modules/_api-pages.scss
@@ -111,3 +111,7 @@
     color: $purple;
   }
 }
+
+.deprecated-api-item {
+  text-decoration: line-through;
+}

--- a/projects/ngrx.io/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/projects/ngrx.io/tools/transforms/templates/api/lib/memberHelpers.html
@@ -12,15 +12,15 @@
 
 {%- macro renderMembers(doc) -%}
   {%- for member in doc.staticProperties %}{% if not member.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
   {% for member in doc.staticMethods %}{% if not member.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
   {% if doc.constructorDoc and not doc.constructorDoc.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ doc.constructorDoc.anchor | urlencode $}">{$ renderMemberSyntax(doc.constructorDoc, 1) $}</a>{% endif -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ doc.constructorDoc.anchor | urlencode $}">{$ renderMemberSyntax(doc.constructorDoc, 1) $}</a>{% endif -%}
   {% for member in doc.properties %}{% if not member.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
   {% for member in doc.methods %}{% if not member.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
 
   {%- for ancestor in doc.extendsClauses %}{% if ancestor.doc %}
 
@@ -46,7 +46,7 @@
   {$ overload.shortDescription | marked $}
 </div>{% endif %}
 
-<code-example language="ts" hideCopy="true" linenums="false" class="no-box api-heading">{$ renderMemberSyntax(overload) $}</code-example>
+<code-example language="ts" hideCopy="true" linenums="false" class="no-box api-heading{% if overload.deprecated %} deprecated-api-item{% endif %}">{$ renderMemberSyntax(overload) $}</code-example>
 
 {% if overload.deprecated !== undefined %}
 <div class="deprecated">
@@ -186,7 +186,7 @@
       <tr class="{$ propertyClass $}">
         <td>
           <a id="{$ property.anchor $}"></a>
-          <code>{$ renderMemberSyntax(property) $}</code>
+          <code{% if property.deprecated %} class="deprecated-api-item"{% endif %}>{$ renderMemberSyntax(property) $}</code>
         </td>
         <td>
           {%- if (property.isGetAccessor or property.isReadonly) and not property.isSetAccessor %}<span class='read-only-property'>Read-only.</span>{% endif %}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
None.

## What is the new behavior?
This PR adds styling to the deprecated items. Since there are no much deprecated items, here's what it looks like on the only deprecated item that exists in the repository:

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/28087049/157984885-2ae8784e-e77c-4c0e-8092-779cbf54e828.png">

To show other example, I locally faked another deprecation and here's the result:

<img width="323" alt="image" src="https://user-images.githubusercontent.com/28087049/157984992-f66c2f52-b158-4a9c-800d-b70eb8eab64d.png">

I also faked `name?` property 🙂 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
Similar to ReactiveX/rxjs#6379 and ReactiveX/rxjs#6886