### PR TITLE
docs: turn on rendering parameter types

### DIFF
--- a/projects/ngrx.io/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/projects/ngrx.io/tools/transforms/templates/api/lib/memberHelpers.html
@@ -54,7 +54,7 @@
 </div>{% endif %}
 
 <h4 class="no-anchor">Parameters</h4>
-{$ params.renderParameters(overload.parameterDocs, cssClass + '-parameters', cssClass + '-parameter') $}
+{$ params.renderParameters(overload.parameterDocs, cssClass + '-parameters', cssClass + '-parameter', true) $}
 
 {% if overload.type or overload.returns.type %}
 <h4 class="no-anchor">Returns</h4>

--- a/projects/ngrx.io/tools/transforms/templates/api/lib/paramList.html
+++ b/projects/ngrx.io/tools/transforms/templates/api/lib/paramList.html
@@ -17,12 +17,15 @@
   <tbody>
   {% for parameter in parameters %}
     <tr class="{$ parameterClass $}">
-      <td class="param-name"><a id="{$ parameter.anchor $}"></a>{$ parameter.name $}</td>
-      {% if showType %}<td class="param-type"><code>{$ parameter.type $}</code></td>{% endif %}
+      <td class="param-name">
+        <a id="{$ parameter.anchor or parameter.name $}"></a>
+        <code>{$ parameter.name $}</code>
+      </td>
+      {% if showType %}<td class="param-type"><code>{$ parameter.type | escape $}</code></td>{% endif %}
       <td class="param-description">
       {% marked %}
       {% if (parameter.shortDescription | trim) or (parameter.description | trim) %}{$ parameter.shortDescription + '\n\n' + parameter.description $}
-      {% elseif not showType and parameter.type %}<p>Type: <code>{$ parameter.type $}</code>.</p>
+      {% elseif not showType and parameter.type %}<p>Type: <code>{$ parameter.type | escape $}</code>.</p>
       {% endif %}
 
       {% if parameter.isOptional or parameter.defaultValue !== undefined %}Optional. Default is `{$ parameter.defaultValue === undefined and 'undefined' or parameter.defaultValue $}`.{% endif %}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
This PR includes rendering parameters in the function documents. It also fixes an issue related to anchor tag ID. Let me [show an example](https://ngrx.io/api/effects/act):

![image](https://user-images.githubusercontent.com/28087049/158017515-ab8b67df-6703-4c93-88d2-8f8f18b3cb89.png)

## What is the new behavior?

This PR fixes this so that parameters of the function from the image are properly rendered:

![image](https://user-images.githubusercontent.com/28087049/158017539-eb1b85fb-b283-4988-a470-9a0c40a7b420.png)

This PR also fixes an issue with `a` tag having an empty ID. Having proper id will make it possible to write docs in such way so that it produces a link that leads to the parameter name on a page. This is how you could write such a documentation:

```
/**
 * Please check {@link act#configOrProject} for more info. 
 */
```

This didn't work previously as fragment `#configOrProject` didn't exist.

For more info, please check [this PR](https://github.com/ReactiveX/rxjs/pull/6761) and [this comment](https://github.com/ReactiveX/rxjs/pull/6756#discussion_r783055893).

Another issue that this PR fixes is [described here](https://github.com/ReactiveX/rxjs/pull/6863).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
Related ReactiveX/rxjs#6761
Related ReactiveX/rxjs#6863