### PR TITLE
docs(store): fix reducer import in reducer guide

### DIFF
--- a/projects/ngrx.io/content/guide/store/reducers.md
+++ b/projects/ngrx.io/content/guide/store/reducers.md
@@ -109,11 +109,11 @@ The state of your application is defined as one large object. Registering reduce
 <code-example header="app.module.ts">
 import { NgModule } from '@angular/core';
 import { StoreModule } from '@ngrx/store';
-import * as fromScoreboard from './reducers/scoreboard.reducer';
+import { scoreboardReducer } from './reducers/scoreboard.reducer';
 
 @NgModule({
   imports: [
-    StoreModule.forRoot({ game: fromScoreboard.reducer })
+    StoreModule.forRoot({ game: scoreboardReducer })
   ],
 })
 export class AppModule {}

--- a/projects/ngrx.io/content/guide/store/reducers.md
+++ b/projects/ngrx.io/content/guide/store/reducers.md
@@ -155,7 +155,7 @@ export const scoreboardFeatureKey = 'game';
 <code-example header="scoreboard.module.ts">
 import { NgModule } from '@angular/core';
 import { StoreModule } from '@ngrx/store';
-import * as fromScoreboard from './reducers/scoreboard.reducer';
+import { scoreboardReducer } from './reducers/scoreboard.reducer';
   
 @NgModule({
   imports: [

--- a/projects/ngrx.io/content/guide/store/reducers.md
+++ b/projects/ngrx.io/content/guide/store/reducers.md
@@ -156,10 +156,10 @@ export const scoreboardFeatureKey = 'game';
 import { NgModule } from '@angular/core';
 import { StoreModule } from '@ngrx/store';
 import * as fromScoreboard from './reducers/scoreboard.reducer';
-
+  
 @NgModule({
   imports: [
-    StoreModule.forFeature(fromScoreboard.scoreboardFeatureKey, fromScoreboard.reducer)
+    StoreModule.forFeature(fromScoreboard.scoreboardFeatureKey, fromScoreboard.scoreboardReducer)
   ],
 })
 export class ScoreboardModule {}

--- a/projects/ngrx.io/content/guide/store/reducers.md
+++ b/projects/ngrx.io/content/guide/store/reducers.md
@@ -155,11 +155,11 @@ export const scoreboardFeatureKey = 'game';
 <code-example header="scoreboard.module.ts">
 import { NgModule } from '@angular/core';
 import { StoreModule } from '@ngrx/store';
-import { scoreboardReducer } from './reducers/scoreboard.reducer';
+import { scoreboardFeatureKey, scoreboardReducer } from './reducers/scoreboard.reducer';
   
 @NgModule({
   imports: [
-    StoreModule.forFeature(fromScoreboard.scoreboardFeatureKey, fromScoreboard.scoreboardReducer)
+    StoreModule.forFeature(scoreboardFeatureKey, scoreboardReducer)
   ],
 })
 export class ScoreboardModule {}


### PR DESCRIPTION
The name of the reducer exported from the scorebord.reducer.ts is scoreboardReducer.
In the app.module.ts, we should import the reducer with the same name.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
