### PR TITLE
bug(store) add explicit overloads for createSelector

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -122,11 +122,81 @@ export function defaultMemoize(
   return { memoized, reset, setResult, clearResult };
 }
 
+export function createSelector<State, S1, Result>(
+  s1: Selector<State, S1>,
+  projector: (s1: S1) => Result
+): MemoizedSelector<State, Result>;
+export function createSelector<State, S1, S2, Result>(
+  s1: Selector<State, S1>,
+  s2: Selector<State, S2>,
+  projector: (s1: S1, s2: S2) => Result
+): MemoizedSelector<State, Result>;
+export function createSelector<State, S1, S2, S3, Result>(
+  s1: Selector<State, S1>,
+  s2: Selector<State, S2>,
+  s3: Selector<State, S3>,
+  projector: (s1: S1, s2: S2, s3: S3) => Result
+): MemoizedSelector<State, Result>;
+export function createSelector<State, S1, S2, S3, S4, Result>(
+  s1: Selector<State, S1>,
+  s2: Selector<State, S2>,
+  s3: Selector<State, S3>,
+  s4: Selector<State, S4>,
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4) => Result
+): MemoizedSelector<State, Result>;
+export function createSelector<State, S1, S2, S3, S4, S5, Result>(
+  s1: Selector<State, S1>,
+  s2: Selector<State, S2>,
+  s3: Selector<State, S3>,
+  s4: Selector<State, S4>,
+  s5: Selector<State, S5>,
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
+): MemoizedSelector<State, Result>;
+export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
+  s1: Selector<State, S1>,
+  s2: Selector<State, S2>,
+  s3: Selector<State, S3>,
+  s4: Selector<State, S4>,
+  s5: Selector<State, S5>,
+  s6: Selector<State, S6>,
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
+): MemoizedSelector<State, Result>;
+export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
+  s1: Selector<State, S1>,
+  s2: Selector<State, S2>,
+  s3: Selector<State, S3>,
+  s4: Selector<State, S4>,
+  s5: Selector<State, S5>,
+  s6: Selector<State, S6>,
+  s7: Selector<State, S7>,
+  projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
+): MemoizedSelector<State, Result>;
+export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
+  s1: Selector<State, S1>,
+  s2: Selector<State, S2>,
+  s3: Selector<State, S3>,
+  s4: Selector<State, S4>,
+  s5: Selector<State, S5>,
+  s6: Selector<State, S6>,
+  s7: Selector<State, S7>,
+  s8: Selector<State, S8>,
+  projector: (
+    s1: S1,
+    s2: S2,
+    s3: S3,
+    s4: S4,
+    s5: S5,
+    s6: S6,
+    s7: S7,
+    s8: S8
+  ) => Result
+): MemoizedSelector<State, Result>;
+
 export function createSelector<State, Slices extends unknown[], Result>(
-  ...args: [...Selector<State, unknown>[], unknown] &
+  ...args: [...slices: Selector<State, unknown>[], projector: unknown] &
     [
-      ...{ [i in keyof Slices]: Selector<State, Slices[i]> },
-      (...s: Slices) => Result
+      ...slices: { [i in keyof Slices]: Selector<State, Slices[i]> },
+      projector: (...s: Slices) => Result
     ]
 ): MemoizedSelector<State, Result>;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3268

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I only added explicit overloads for `createSelector` with variadic "slice" arguments, because only that signature failed due to the problems identified in #3268. The signature that uses an array for the "slices" [does not fail](https://www.typescriptlang.org/play?jsx=0#code/C4TwDgpgBAyhA2EDGwD2AnAPAFQDRQDUA+KAXigAoBnYAQ2AgC4psBKMkggbgFgAoUJCgBZCAFtUASwBeEACZxEKDDnzEysBMjRY8hIrz785yeLXTQAZgFcAdikmpbUJBfoRF2lTDoN8MeEkkCCooCAAPBls5ULsAa1tUAHdbAG0AXXwAJRDreGAiCn4oKCotZXQqZk8KzB93fHjElKIMqAAyYpKoVIA6foBvHskoSWc4iBBUS1hA4Kp06vKdOt8IfzmQ1Ml0kgBfTK6wdFQAKy90Zgp+3qrZoJD2UhIcqjzgflZmUQkZeRqVvU-FBXu8DPx+EgnDRSmtmANLJJKsAoMwAOQ0dxovYaIaI5HozEMNFQPaGSHQlEAcwgwAAIvRaBocIU5Mw2OyOFA5IYobYYRZgNZ0LYgdByBQniQiRByXw+TCykodBpXBB3ACMBRUoLhaK1pkoDT6YzWHKFSj8TRCWsSeQlRdqGtWL0rcBDEA).