### PR TITLE
feat(store): opt-in strict projectors

### DIFF
--- a/modules/router-store/spec/types/selectors.spec.ts
+++ b/modules/router-store/spec/types/selectors.spec.ts
@@ -37,10 +37,7 @@ describe('router selectors', () => {
         selectCurrentRoute,
         route => route
       );
-    `).toInfer(
-      'selector',
-      'MemoizedSelector<State, any, DefaultProjectorFn<any>>'
-    );
+    `).toInfer('selector', 'MemoizedSelector<State, any, (s1: any) => any>');
   });
 
   it('selectQueryParams should return Params', () => {
@@ -51,7 +48,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, Params, DefaultProjectorFn<Params>>'
+      'MemoizedSelector<State, Params, (s1: Params) => Params>'
     );
   });
 
@@ -64,7 +61,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, string, DefaultProjectorFn<string>>'
+      'MemoizedSelector<State, string, (s1: string) => string>'
     );
   });
 
@@ -76,7 +73,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, Params, DefaultProjectorFn<Params>>'
+      'MemoizedSelector<State, Params, (s1: Params) => Params>'
     );
   });
 
@@ -89,7 +86,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, string, DefaultProjectorFn<string>>'
+      'MemoizedSelector<State, string, (s1: string) => string>'
     );
   });
 
@@ -99,10 +96,7 @@ describe('router selectors', () => {
         selectRouteData,
         data => data
       );
-    `).toInfer(
-      'selector',
-      'MemoizedSelector<State, Data, DefaultProjectorFn<Data>>'
-    );
+    `).toInfer('selector', 'MemoizedSelector<State, Data, (s1: Data) => Data>');
   });
 
   it('selectUrl should return string', () => {
@@ -113,7 +107,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, string, DefaultProjectorFn<string>>'
+      'MemoizedSelector<State, string, (s1: string) => string>'
     );
   });
 });

--- a/modules/store/spec/types/selector.spec.ts
+++ b/modules/store/spec/types/selector.spec.ts
@@ -1,0 +1,51 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('createSelector()', () => {
+  const expectSnippet = expecter(
+    (code) => `
+      import {createSelector} from '@ngrx/store';
+      import { MemoizedSelector, DefaultProjectorFn } from '@ngrx/store';
+
+      ${code}
+    `,
+    compilerOptions()
+  );
+
+  describe('projector', () => {
+    it('should require parameters when strictness enabled', () => {
+      expectSnippet(`
+        const selectTest = createSelector(
+            () => 'one',
+            () => 2,
+            (one, two) => 3
+        );
+        selectTest.projector<'strict'>();
+      `).toFail(/Expected 2 arguments, but got 0./);
+    });
+    it('should not require parameters when strictness not enabled', () => {
+      expectSnippet(`
+        const selectTest = createSelector(
+            () => 'one',
+            () => 2,
+            (one, two) => 3
+        );
+        selectTest.projector();
+      `).toSucceed();
+    });
+    it('should succeed for existing explicitly typed selectors', () => {
+      expectSnippet(`
+        const selectTest: MemoizedSelector<
+          unknown,
+          number,
+          DefaultProjectorFn<number>
+        > = createSelector(
+          () => 'one',
+          () => 2,
+          (one, two) => 3
+        );
+        selectTest.projector();
+      `).toSucceed();
+    });
+  });
+});

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -17,13 +17,25 @@ export type ComparatorFn = (a: any, b: any) => boolean;
 
 export type DefaultProjectorFn<T> = (...args: any[]) => T;
 
+type AllowStrictProjector<ProjectorFn> = ProjectorFn extends (
+  ...args: infer ProjectorArgs
+) => infer ProjectorResult
+  ? <StrictnessConfig extends 'strict' | 'default' = 'default'>(
+      ...args: StrictnessConfig extends 'strict'
+        ? ProjectorArgs extends unknown[]
+          ? ProjectorArgs
+          : any[]
+        : any[]
+    ) => ProjectorResult
+  : ProjectorFn;
+
 export interface MemoizedSelector<
   State,
   Result,
   ProjectorFn = DefaultProjectorFn<Result>
 > extends Selector<State, Result> {
   release(): void;
-  projector: ProjectorFn;
+  projector: AllowStrictProjector<ProjectorFn>;
   setResult: (result?: Result) => void;
   clearResult: () => void;
 }
@@ -125,25 +137,25 @@ export function defaultMemoize(
 export function createSelector<State, S1, Result>(
   s1: Selector<State, S1>,
   projector: (s1: S1) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (s1: S1) => Result>;
 export function createSelector<State, S1, S2, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
   projector: (s1: S1, s2: S2) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (s1: S1, s2: S2) => Result>;
 export function createSelector<State, S1, S2, S3, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
   s3: Selector<State, S3>,
   projector: (s1: S1, s2: S2, s3: S3) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (s1: S1, s2: S2, s3: S3) => Result>;
 export function createSelector<State, S1, S2, S3, S4, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
   s3: Selector<State, S3>,
   s4: Selector<State, S4>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (s1: S1, s2: S2, s3: S3, s4: S4) => Result>;
 export function createSelector<State, S1, S2, S3, S4, S5, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -151,7 +163,11 @@ export function createSelector<State, S1, S2, S3, S4, S5, Result>(
   s4: Selector<State, S4>,
   s5: Selector<State, S5>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<
+  State,
+  Result,
+  (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
+>;
 export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -160,7 +176,11 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
   s5: Selector<State, S5>,
   s6: Selector<State, S6>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<
+  State,
+  Result,
+  (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
+>;
 export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -170,7 +190,11 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
   s6: Selector<State, S6>,
   s7: Selector<State, S7>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<
+  State,
+  Result,
+  (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
+>;
 export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -190,7 +214,11 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
     s7: S7,
     s8: S8
   ) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<
+  State,
+  Result,
+  (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7, s8: S8) => Result
+>;
 
 export function createSelector<State, Slices extends unknown[], Result>(
   ...args: [...slices: Selector<State, unknown>[], projector: unknown] &
@@ -198,7 +226,7 @@ export function createSelector<State, Slices extends unknown[], Result>(
       ...slices: { [i in keyof Slices]: Selector<State, Slices[i]> },
       projector: (...s: Slices) => Result
     ]
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (...s: Slices) => Result>;
 
 /**
  * @deprecated Selectors with props are deprecated, for more info see {@link https://github.com/ngrx/platform/issues/2980 Github Issue}
@@ -346,7 +374,7 @@ export function createSelector<State, Slices extends unknown[], Result>(
   selectors: Selector<State, unknown>[] &
     [...{ [i in keyof Slices]: Selector<State, Slices[i]> }],
   projector: (...s: Slices) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (...s: Slices) => Result>;
 
 /**
  * @deprecated Selectors with props are deprecated, for more info see {@link https://github.com/ngrx/platform/issues/2980 Github Issue}

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -17,15 +17,22 @@ export type ComparatorFn = (a: any, b: any) => boolean;
 
 export type DefaultProjectorFn<T> = (...args: any[]) => T;
 
-type AllowStrictProjector<ProjectorFn> = ProjectorFn extends (
+type ProjectorStrictnessConfig = 'strict' | 'default';
+
+type OptionallyStrictProjectorArgs<
+  StrictnessConfig extends ProjectorStrictnessConfig,
+  ProjectorArgs
+> = StrictnessConfig extends 'strict'
+  ? ProjectorArgs extends unknown[]
+    ? ProjectorArgs
+    : any[]
+  : any[];
+
+type OptionallyStrictProjectorFn<ProjectorFn> = ProjectorFn extends (
   ...args: infer ProjectorArgs
 ) => infer ProjectorResult
-  ? <StrictnessConfig extends 'strict' | 'default' = 'default'>(
-      ...args: StrictnessConfig extends 'strict'
-        ? ProjectorArgs extends unknown[]
-          ? ProjectorArgs
-          : any[]
-        : any[]
+  ? <StrictnessConfig extends ProjectorStrictnessConfig = 'default'>(
+      ...args: OptionallyStrictProjectorArgs<StrictnessConfig, ProjectorArgs>
     ) => ProjectorResult
   : ProjectorFn;
 
@@ -35,7 +42,7 @@ export interface MemoizedSelector<
   ProjectorFn = DefaultProjectorFn<Result>
 > extends Selector<State, Result> {
   release(): void;
-  projector: AllowStrictProjector<ProjectorFn>;
+  projector: OptionallyStrictProjectorFn<ProjectorFn>;
   setResult: (result?: Result) => void;
   clearResult: () => void;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Starts dealing with #3097.

Adds an optional generic parameter to `projector` that enables strictness.

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This approach allows tests to use strict projectors without affecting production code or existing tests:

<img width="785" alt="Screen Shot 2022-03-26 at 18 53 52" src="https://user-images.githubusercontent.com/25187726/160259614-85dbda9c-b520-4c32-847f-51e344290b3f.png">
