### PR TITLE
feat(component): add suspense template input to LetDirective

### DIFF
--- a/modules/component/.eslintrc.json
+++ b/modules/component/.eslintrc.json
@@ -13,7 +13,8 @@
       },
       "rules": {
         "@angular-eslint/directive-selector": "off",
-        "@angular-eslint/component-selector": "off"
+        "@angular-eslint/component-selector": "off",
+        "@angular-eslint/no-input-rename": "off"
       },
       "plugins": ["@typescript-eslint"]
     },

--- a/modules/component/spec/fixtures/fixtures.ts
+++ b/modules/component/spec/fixtures/fixtures.ts
@@ -1,5 +1,4 @@
-import createSpy = jasmine.createSpy;
-import { ChangeDetectorRef, NgZone } from '@angular/core';
+import { NgZone } from '@angular/core';
 import { MockNoopNgZone } from './mock-noop-ng-zone';
 
 /**
@@ -17,27 +16,13 @@ export const manualInstanceNoopNgZone = new NoopNgZone({
 });
 
 export class MockChangeDetectorRef {
-  markForCheck = createSpy('markForCheck');
-  detectChanges = createSpy('detectChanges');
-  checkNoChanges = createSpy('checkNoChanges');
-  detach = createSpy('detach');
-  reattach = createSpy('reattach');
+  markForCheck = jest.fn();
+  detectChanges = jest.fn();
+  checkNoChanges = jest.fn();
+  detach = jest.fn();
+  reattach = jest.fn();
 }
 
-export const mockPromise = {
-  then: () => {},
-};
-
-export function getMockOptimizedStrategyConfig() {
-  return {
-    component: {},
-    cdRef: (new MockChangeDetectorRef() as any) as ChangeDetectorRef,
-  };
-}
-
-export function getMockNoopStrategyConfig() {
-  return {
-    component: {},
-    cdRef: (new MockChangeDetectorRef() as any) as ChangeDetectorRef,
-  };
+export class MockErrorHandler {
+  handleError = jest.fn();
 }

--- a/projects/ngrx.io/content/guide/component/let.md
+++ b/projects/ngrx.io/content/guide/component/let.md
@@ -49,7 +49,7 @@ and safe to work with streams in the template:
 </ng-container>
 ```
 
-### Tracking Different Observable Events
+## Tracking Different Observable Events
 
 In addition to that it provides us information from the whole observable context.
 We can track next, error, and complete events:
@@ -64,7 +64,7 @@ We can track next, error, and complete events:
 </ng-container>
 ```
 
-### Using Suspense Template
+## Using Suspense Template
 
 There is an option to pass the suspense template that will be displayed
 when an observable is in a suspense state:
@@ -81,18 +81,19 @@ when an observable is in a suspense state:
 
 <div class="alert is-helpful">
 
-Observable is in a suspense state until it emits the first event (next, error, or complete).
+An observable is in a suspense state until it emits the first event (next, error, or complete).
 
 </div>
 
-In case the new observable is passed to the `*ngrxLet` directive in runtime,
+In case a new observable is passed to the `*ngrxLet` directive at runtime,
 the suspense template will be displayed again until the new observable emits the first event.
 
 ## Included Features
 
-- Binding is always present.
-- It takes away the multiple usages of the `async` or `ngrxPush` pipe.
-- Unified/structured way of handling `null` and `undefined`.
+- Binding is present even for falsy values.
+  (See ["Comparison with `*ngIf` and `async`"](#comparison-with-ngif-and-async) section)
+- Takes away the multiple usages of the `async` or `ngrxPush` pipe.
+- Provides a unified/structured way of handling `null` and `undefined`.
 - Triggers the change detection differently if `zone.js` is present or not
   using the `ChangeDetectorRef.markForCheck` or `ChangeDetectorRef.detectChanges`.
 - Distinct the same values in a row using the `distinctUntilChanged` operator.

--- a/projects/ngrx.io/content/guide/component/let.md
+++ b/projects/ngrx.io/content/guide/component/let.md
@@ -79,6 +79,15 @@ when an observable is in a suspense state:
 </ng-template>
 ```
 
+<div class="alert is-helpful">
+
+Observable is in a suspense state until it emits the first event (next, error, or complete).
+
+</div>
+
+In case the new observable is passed to the `*ngrxLet` directive in runtime,
+the suspense template will be displayed again until the new observable emits the first event.
+
 ## Included Features
 
 - Binding is always present.

--- a/projects/ngrx.io/content/guide/component/let.md
+++ b/projects/ngrx.io/content/guide/component/let.md
@@ -1,82 +1,89 @@
 # ngrxLet Structural Directive
 
-The `*ngrxLet` directive serves a convenient way of binding observables to a view context (a dom element scope).
-It also helps with several internal processing under the hood.
-
-Same as [PushPipe](guide/component/push), it also respects ViewEngine as well as Ivy's new rendering API.
+The `*ngrxLet` directive serves a convenient way of binding observables to a view context
+(DOM element's scope). It also helps with several internal processing under the hood.
 
 ## Usage
 
-The `*ngrxLet` directive is provided through the `ReactiveComponentModule`. To use it, add the `ReactiveComponentModule` to the `imports` of your NgModule.
+The `*ngrxLet` directive is provided through the `ReactiveComponentModule`.
+To use it, add the `ReactiveComponentModule` to the `imports` of your NgModule:
 
-```typescript
+```ts
 import { NgModule } from '@angular/core';
 import { ReactiveComponentModule } from '@ngrx/component';
 
 @NgModule({
   imports: [
     // other imports
-    ReactiveComponentModule
-  ]
+    ReactiveComponentModule,
+  ],
 })
 export class MyFeatureModule {}
 ```
 
-## Comparison with Async Pipe
+## Comparison with `*ngIf` and `async`
 
-The current way of binding an observable to the view looks like that:
+The current way of binding an observable to the view looks like this:
 
 ```html
-<ng-container *ngIf="observableNumber$ | async as n">
-  <app-number [number]="n">
-  </app-number>
-  <app-number-special [number]="n">
-  </app-number-special>
+<ng-container *ngIf="number$ | async as n">
+  <app-number [number]="n"></app-number>
+  
+  <app-number-special [number]="n"></app-number-special>
 </ng-container>
  ```
 
-The problem is `*ngIf` is also interfering with rendering and in case of a falsy value the component would be hidden.
+The problem is that `*ngIf` is interfering with rendering.
+In case of `0` (falsy value), the component would be hidden.
 
-The `*ngrxLet` directive takes over several things while making it more convenient and safe to work with streams in the template.
+The `*ngrxLet` directive takes over several things and makes it more convenient
+and safe to work with streams in the template:
 
 ```html
-<ng-container *ngrxLet="observableNumber$ as n">
-  <app-number [number]="n">
-  </app-number>
+<ng-container *ngrxLet="number$ as n">
+  <app-number [number]="n"></app-number>
 </ng-container>
 
-<ng-container *ngrxLet="observableNumber$; let n">
-  <app-number [number]="n">
-  </app-number>
+<ng-container *ngrxLet="number$; let n">
+  <app-number [number]="n"></app-number>
 </ng-container>
 ```
 
-In addition to that it provides us information from the whole observable context.
-We can track the observable notifications:
+### Tracking Different Observable Events
 
-- next value
-- error value
-- completion state
+In addition to that it provides us information from the whole observable context.
+We can track next, error, and complete events:
 
 ```html
-<ng-container *ngrxLet="observableNumber$; let n; let e = $error, let c = $complete">
-  <app-number [number]="n"  *ngIf="!e && !c">
+<ng-container *ngrxLet="number$ as n; let e = $error; let c = $complete">
+  <app-number [number]="n" *ngIf="!e && !c">
   </app-number>
-  <ng-container *ngIf="e">
-  There is an error: {{e}}
-  </ng-container>
-  <ng-container *ngIf="c">
-  Observable completed: {{c}}
-  </ng-container>
+
+  <p *ngIf="e">There is an error.</p>
+  <p *ngIf="c">Observable is completed.</p>
 </ng-container>
+```
+
+### Using Suspense Template
+
+There is an option to pass the suspense template that will be displayed
+when an observable is in a suspense state:
+
+```html
+<ng-container *ngrxLet="number$ as n; suspenseTpl: loading">
+  <app-number [number]="n"></app-number>
+</ng-container>
+
+<ng-template #loading>
+  <p>Loading...</p>
+</ng-template>
 ```
 
 ## Included Features
 
-- Binding is always present. (`*ngIf="truthy$"`)
-- Takes away the multiple usages of the `async` or `ngrxPush` pipe
-- Provides a unified/structured way of handling `null` and `undefined`
-- Triggers change-detection differently if `zone.js` is present or not (`ChangeDetectorRef.detectChanges` or `ChangeDetectorRef.markForCheck`)
-- Triggers change-detection differently if ViewEngine or Ivy is present (`ChangeDetectorRef.detectChanges` or `ɵdetectChanges`)
-- Distinct same values in a row (distinctUntilChanged operator),
-                                                                 
+- Binding is always present.
+- It takes away the multiple usages of the `async` or `ngrxPush` pipe.
+- Unified/structured way of handling `null` and `undefined`.
+- Triggers the change detection differently if `zone.js` is present or not
+  using the `ChangeDetectorRef.markForCheck` or `ChangeDetectorRef.detectChanges`.
+- Distinct the same values in a row using the `distinctUntilChanged` operator.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3340

## What is the new behavior?

Added ability to pass the suspense template to `LetDirective`:

```html
<p *ngrxLet="obs$ as o; suspenseTpl: loading">
  {{ o }}
</p>
<ng-template #loading>Loading...</ng-template>
```

A suspense template will be displayed when passed observable is in a suspense state. If the suspense template is not passed, the behavior will remain the same:

- The main template will be rendered only when the first observable emits next/error/complete event.
- If a new observable is passed, the main template will be displayed in a suspense state as well, but the value will be `undefined`. However, there is new view context property `$suspense` that can be used in this case:

```ts
@Component({
  template: `
    <button (click)="onSwitch()">Switch Observable</button>
    <ng-container *ngrxLet="obs$ as o; $suspense as s">
      <p *ngIf="!s">{{ o }}</p>
      <p *ngIf="s">Loading...</p>
    </ng-container>
  `,
})
export class DemoComponent {
  obs$ = of(true);

  onSwitch(): void {
    this.obs$ = of(false).pipe(delay(1000));
  }
}
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
