### PR TITLE
refactor: replace deprecated substr usages

### DIFF
--- a/modules/component-store/schematics-core/utility/project.ts
+++ b/modules/component-store/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/component-store/schematics-core/utility/project.ts
+++ b/modules/component-store/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/component-store/schematics-core/utility/strings.ts
+++ b/modules/component-store/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/modules/component/schematics-core/utility/project.ts
+++ b/modules/component/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/component/schematics-core/utility/project.ts
+++ b/modules/component/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/component/schematics-core/utility/strings.ts
+++ b/modules/component/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/modules/data/schematics-core/utility/project.ts
+++ b/modules/data/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/data/schematics-core/utility/project.ts
+++ b/modules/data/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/data/schematics-core/utility/strings.ts
+++ b/modules/data/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/modules/data/src/selectors/entity-selectors$.ts
+++ b/modules/data/src/selectors/entity-selectors$.ts
@@ -115,7 +115,7 @@ export class EntitySelectors$Factory {
       if (name.startsWith('select')) {
         // strip 'select' prefix from the selector fn name and append `$`
         // Ex: 'selectEntities' => 'entities$'
-        const name$ = name[6].toLowerCase() + name.substr(7) + '$';
+        const name$ = name[6].toLowerCase() + name.substring(7) + '$';
         selectors$[name$] = this.store.select((<any>selectors)[name]);
       }
     });

--- a/modules/data/src/utils/default-pluralizer.ts
+++ b/modules/data/src/utils/default-pluralizer.ts
@@ -46,7 +46,7 @@ export class DefaultPluralizer {
       return name + 's';
       // consonant + y
     } else if (name.endsWith('y')) {
-      return name.substr(0, name.length - 1) + 'ies';
+      return name.substring(0, name.length - 1) + 'ies';
       // endings typically pluralized with 'es'
     } else if (/[s|ss|sh|ch|x|z]$/.test(name)) {
       return name + 'es';

--- a/modules/effects/schematics-core/utility/project.ts
+++ b/modules/effects/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/effects/schematics-core/utility/project.ts
+++ b/modules/effects/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/effects/schematics-core/utility/strings.ts
+++ b/modules/effects/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/modules/entity/schematics-core/utility/project.ts
+++ b/modules/entity/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/entity/schematics-core/utility/project.ts
+++ b/modules/entity/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/entity/schematics-core/utility/strings.ts
+++ b/modules/entity/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/modules/eslint-plugin/scripts/generate-docs.ts
+++ b/modules/eslint-plugin/scripts/generate-docs.ts
@@ -10,7 +10,9 @@ const RULES_PATH = './projects/ngrx.io/content/guide/eslint-plugin/rules';
 for (const [ruleName, { meta }] of Object.entries(rules)) {
   const docPath = path.join(RULES_PATH, `${ruleName}.md`);
   const doc = readFileSync(docPath, 'utf-8');
-  const docContent = doc.substr(doc.indexOf(PLACEHOLDER) + PLACEHOLDER.length);
+  const docContent = doc.substring(
+    doc.indexOf(PLACEHOLDER) + PLACEHOLDER.length
+  );
   const newDoc = format(
     `# ${ruleName}
 

--- a/modules/router-store/schematics-core/utility/project.ts
+++ b/modules/router-store/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/router-store/schematics-core/utility/project.ts
+++ b/modules/router-store/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/router-store/schematics-core/utility/strings.ts
+++ b/modules/router-store/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/modules/schematics-core/utility/project.ts
+++ b/modules/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/schematics-core/utility/project.ts
+++ b/modules/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/schematics-core/utility/strings.ts
+++ b/modules/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/modules/schematics/schematics-core/utility/project.ts
+++ b/modules/schematics/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/schematics/schematics-core/utility/project.ts
+++ b/modules/schematics/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/schematics/schematics-core/utility/strings.ts
+++ b/modules/schematics/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/modules/store-devtools/schematics-core/utility/project.ts
+++ b/modules/store-devtools/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/store-devtools/schematics-core/utility/project.ts
+++ b/modules/store-devtools/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/store-devtools/schematics-core/utility/strings.ts
+++ b/modules/store-devtools/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/modules/store/schematics-core/utility/project.ts
+++ b/modules/store/schematics-core/utility/project.ts
@@ -30,7 +30,7 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substring(-1) === '/') {
+  if (project.root.slice(-1) === '/') {
     project.root = project.root.substring(0, project.root.length - 1);
   }
 

--- a/modules/store/schematics-core/utility/project.ts
+++ b/modules/store/schematics-core/utility/project.ts
@@ -30,8 +30,8 @@ export function getProjectPath(
 ) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.substring(-1) === '/') {
+    project.root = project.root.substring(0, project.root.length - 1);
   }
 
   if (options.path === undefined) {

--- a/modules/store/schematics-core/utility/strings.ts
+++ b/modules/store/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.substring(1);
 }
 
 /**

--- a/projects/example-app/src/app/shared/pipes/ellipsis.pipe.spec.ts
+++ b/projects/example-app/src/app/shared/pipes/ellipsis.pipe.spec.ts
@@ -44,10 +44,12 @@ describe('Pipe: Ellipsis', () => {
   });
 
   it('should return up to 250 characters followed by an ellipsis', () => {
-    expect(pipe.transform(longStr)).toEqual(`${longStr.substr(0, 250)}...`);
+    expect(pipe.transform(longStr)).toEqual(`${longStr.substring(0, 250)}...`);
   });
 
   it('should return only 20 characters followed by an ellipsis', () => {
-    expect(pipe.transform(longStr, 20)).toEqual(`${longStr.substr(0, 20)}...`);
+    expect(pipe.transform(longStr, 20)).toEqual(
+      `${longStr.substring(0, 20)}...`
+    );
   });
 });

--- a/projects/ngrx.io/src/app/custom-elements/code/code.component.ts
+++ b/projects/ngrx.io/src/app/custom-elements/code/code.component.ts
@@ -222,7 +222,7 @@ function leftAlign(text: string): string {
     });
 
     return lines
-        .map(line => line.substr(indent))
+        .map(line => line.substring(indent))
         .join('\n')
         .trim();
 }

--- a/projects/ngrx.io/src/app/custom-elements/code/pretty-printer.service.ts
+++ b/projects/ngrx.io/src/app/custom-elements/code/pretty-printer.service.ts
@@ -56,7 +56,7 @@ export class PrettyPrinter {
                 try {
                     return ppo(code, language, linenums);
                 } catch (err) {
-                    const msg = `Could not format code that begins '${code.substr(0, 50)}...'.`;
+                    const msg = `Could not format code that begins '${code.substring(0, 50)}...'.`;
                     console.error(msg, err);
                     throw new Error(msg);
                 }

--- a/projects/ngrx.io/src/app/shared/location.service.ts
+++ b/projects/ngrx.io/src/app/shared/location.service.ts
@@ -71,7 +71,7 @@ export class LocationService {
         const q = path.indexOf('?');
         if (q > -1) {
             try {
-                const params = path.substr(q + 1).split('&');
+                const params = path.substring(q + 1).split('&');
                 params.forEach(p => {
                     const pair = p.split('=');
                     if (pair[0]) {

--- a/projects/ngrx.io/src/index.html
+++ b/projects/ngrx.io/src/index.html
@@ -77,7 +77,7 @@
           col = col || '?';
           stack = url + ':' + line + ':' + col;
         }
-        return (msg + '\n' + stack).substr(0, 150);
+        return (msg + '\n' + stack).substring(0, 150);
       }
     };
   </script>

--- a/projects/ngrx.io/tools/example-zipper/exampleZipper.js
+++ b/projects/ngrx.io/tools/example-zipper/exampleZipper.js
@@ -144,7 +144,7 @@ class ExampleZipper {
 
     let gpaths = json.files.map((fileName) => {
       fileName = fileName.trim();
-      if (fileName.substring(0, 1) === '!') {
+      if (fileName[0] === '!') {
         return '!' + path.join(exampleDirName, fileName.substring(1));
       } else {
         return path.join(exampleDirName, fileName);

--- a/projects/ngrx.io/tools/example-zipper/exampleZipper.js
+++ b/projects/ngrx.io/tools/example-zipper/exampleZipper.js
@@ -126,13 +126,13 @@ class ExampleZipper {
               return file;
             }
 
-            return '!' + basePath + file.substr(1);
+            return '!' + basePath + file.substring(1);
           }
 
           return basePath + file;
         });
 
-        if (json.files[0].substr(0, 1) === '!') {
+        if (json.files[0].substring(0, 1) === '!') {
           json.files = defaultIncludes.concat(json.files);
         }
       }
@@ -144,8 +144,8 @@ class ExampleZipper {
 
     let gpaths = json.files.map((fileName) => {
       fileName = fileName.trim();
-      if (fileName.substr(0, 1) === '!') {
-        return '!' + path.join(exampleDirName, fileName.substr(1));
+      if (fileName.substring(0, 1) === '!') {
+        return '!' + path.join(exampleDirName, fileName.substring(1));
       } else {
         return path.join(exampleDirName, fileName);
       }
@@ -160,7 +160,7 @@ class ExampleZipper {
       let relativePath = path.relative(exampleDirName, fileName);
       relativePath = this._renameFile(relativePath, exampleType);
       let content = fs.readFileSync(fileName, 'utf8');
-      let extn = path.extname(fileName).substr(1);
+      let extn = path.extname(fileName).substring(1);
       // if we don't need to clean up the file then we can do the following.
       // zip.append(fs.createReadStream(fileName), { name: relativePath });
       let output = regionExtractor()(content, extn).contents;

--- a/projects/ngrx.io/tools/examples/shared/boilerplate/systemjs/src/systemjs-angular-loader.js
+++ b/projects/ngrx.io/tools/examples/shared/boilerplate/systemjs/src/systemjs-angular-loader.js
@@ -26,7 +26,7 @@ module.exports.translate = function(load){
       var resolvedUrl = url;
 
       if (url.startsWith('.')) {
-        resolvedUrl = basePath + url.substr(1);
+        resolvedUrl = basePath + url.substring(1);
       }
 
       return 'templateUrl: "' + resolvedUrl + '"';
@@ -36,7 +36,7 @@ module.exports.translate = function(load){
 
       while ((match = stringRegex.exec(relativeUrls)) !== null) {
         if (match[2].startsWith('.')) {
-          urls.push('"' + basePath + match[2].substr(1) + '"');
+          urls.push('"' + basePath + match[2].substring(1) + '"');
         } else {
           urls.push('"' + match[2] + '"');
         }

--- a/projects/ngrx.io/tools/examples/shared/protractor.config.js
+++ b/projects/ngrx.io/tools/examples/shared/protractor.config.js
@@ -139,10 +139,10 @@ function Reporter(options) {
           spec.failedExpectations.forEach(function (fe) {
             results.push(pad + 'message: ' + fe.message);
           });
-          pad=pad.substr(2);
+          pad=pad.substring(2);
         }
       });
-      pad = pad.substr(2);
+      pad = pad.substring(2);
       results.push('');
     });
     results.push('');
@@ -154,7 +154,7 @@ function Reporter(options) {
   function log(str, indent) {
     _pad = _pad || '';
     if (indent == -1) {
-      _pad = _pad.substr(2);
+      _pad = _pad.substring(2);
     }
     console.log(_pad + str);
     if (indent == 1) {

--- a/projects/ngrx.io/tools/stackblitz-builder/builder.js
+++ b/projects/ngrx.io/tools/stackblitz-builder/builder.js
@@ -170,7 +170,7 @@ class StackblitzBuilder {
       const extn = path.extname(fileName);
       if (extn == '.png') {
         content = this._encodeBase64(fileName);
-        fileName = fileName.substr(0, fileName.length - 4) + '.base64.png';
+        fileName = fileName.substring(0, fileName.length - 4) + '.base64.png';
       } else {
         content = fs.readFileSync(fileName, 'utf-8');
       }
@@ -203,7 +203,7 @@ class StackblitzBuilder {
         }
       }
 
-      content = regionExtractor()(content, extn.substr(1)).contents;
+      content = regionExtractor()(content, extn.substring(1)).contents;
 
       postData[`project[files][${relativeFileName}]`] = content;
     });
@@ -275,7 +275,7 @@ class StackblitzBuilder {
     ];
     if (config.files) {
       if (config.files.length > 0) {
-        if (config.files[0].substr(0, 1) == '!') {
+        if (config.files[0].substring(0, 1) == '!') {
           config.files = defaultIncludes.concat(config.files);
         }
       }
@@ -288,7 +288,7 @@ class StackblitzBuilder {
     const gpaths = config.files.map(function (fileName) {
       fileName = fileName.trim();
       if (fileName[0] === '!') {
-        return '!' + path.join(config.basePath, fileName.substr(1));
+        return '!' + path.join(config.basePath, fileName.substring(1));
       } else {
         includeSpec = includeSpec || /\.spec\.(ts|js)$/.test(fileName);
         return path.join(config.basePath, fileName);

--- a/projects/ngrx.io/tools/transforms/angular-api-package/processors/splitDescription.js
+++ b/projects/ngrx.io/tools/transforms/angular-api-package/processors/splitDescription.js
@@ -17,8 +17,8 @@ module.exports = function splitDescription() {
             doc.shortDescription = description;
             doc.description = '';
           } else {
-            doc.shortDescription = description.substr(0, endOfParagraph).trim();
-            doc.description = description.substr(endOfParagraph).trim();
+            doc.shortDescription = description.substring(0, endOfParagraph).trim();
+            doc.description = description.substring(endOfParagraph).trim();
           }
         }
       });

--- a/projects/ngrx.io/tools/transforms/examples-package/processors/collect-examples.js
+++ b/projects/ngrx.io/tools/transforms/examples-package/processors/collect-examples.js
@@ -36,7 +36,7 @@ module.exports = function collectExamples(exampleMap, regionParser, log, createD
             exampleFolders.some((folder) => {
               if (doc.fileInfo.relativePath.indexOf(folder) === 0) {
                 const relativePath =
-                    doc.fileInfo.relativePath.substr(folder.length).replace(/^\//, '');
+                    doc.fileInfo.relativePath.substring(folder.length).replace(/^\//, '');
                 exampleMap[folder][relativePath] = doc;
 
                 // We treat files that end in `.annotated` specially
@@ -45,7 +45,7 @@ module.exports = function collectExamples(exampleMap, regionParser, log, createD
                 // of the original but contains inline doc region comments
                 let fileType = doc.fileInfo.extension;
                 if (fileType === 'annotated') {
-                  fileType = extname(doc.fileInfo.baseName).substr(1) + '.' + fileType;
+                  fileType = extname(doc.fileInfo.baseName).substring(1) + '.' + fileType;
                 }
 
                 const parsedRegions = regionParser(doc.content, fileType);

--- a/projects/ngrx.io/tools/transforms/examples-package/processors/collect-examples.spec.js
+++ b/projects/ngrx.io/tools/transforms/examples-package/processors/collect-examples.spec.js
@@ -205,7 +205,7 @@ describe('collectExampleRegions processor', () => {
 
 function createDoc(content, relativePath, docType) {
   return {
-    fileInfo: {relativePath: relativePath, extension: path.extname(relativePath).substr(1)},
+    fileInfo: {relativePath: relativePath, extension: path.extname(relativePath).substring(1)},
     content: content,
     docType: docType || 'example-file',
     startingLine: 1

--- a/projects/ngrx.io/tools/transforms/examples-package/services/parseArgString.js
+++ b/projects/ngrx.io/tools/transforms/examples-package/services/parseArgString.js
@@ -37,14 +37,14 @@ module.exports = function parseArgString() {
           args[key] = arg;
           key = null;
         } else {
-          if (arg.substr(arg.length - 1) === '=') {
-            key = arg.substr(0, arg.length - 1);
+          if (arg.substring(arg.length - 1) === '=') {
+            key = arg.substring(0, arg.length - 1);
             // remove leading '-' (or '--') if it exists.
-            if (key.substr(0, 1) == '-') {
-              key = key.substr(1);
+            if (key.substring(0, 1) == '-') {
+              key = key.substring(1);
             }
-            if (key.substr(0, 1) == '-') {
-              key = key.substr(1);
+            if (key.substring(0, 1) == '-') {
+              key = key.substring(1);
             }
           } else {
             unnammedArgs.push(arg);

--- a/projects/ngrx.io/tools/transforms/examples-package/services/region-parser.js
+++ b/projects/ngrx.io/tools/transforms/examples-package/services/region-parser.js
@@ -129,7 +129,7 @@ function leftAlign(lines) {
       indent = Math.min(lineIndent, indent);
     }
   });
-  return lines.map(line => line.substr(indent));
+  return lines.map(line => line.substring(indent));
 }
 
 function RegionParserError(message, index) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3402

## What is the new behavior?

 `substring`  was used instead of `substr`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
