### PR TITLE
refactor(effects): use ObservableNotification instead of Notification, to support RxJS 8

### DIFF
--- a/modules/effects/src/effect_notification.ts
+++ b/modules/effects/src/effect_notification.ts
@@ -1,13 +1,14 @@
 import { ErrorHandler } from '@angular/core';
 import { Action } from '@ngrx/store';
-import { Notification, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
+import { ObservableNotification } from './utils';
 
 export interface EffectNotification {
   effect: Observable<any> | (() => Observable<any>);
   propertyName: PropertyKey;
   sourceName: string;
   sourceInstance: any;
-  notification: Notification<Action | null | undefined>;
+  notification: ObservableNotification<Action | null | undefined>;
 }
 
 export function reportInvalidActions(

--- a/modules/effects/src/effect_sources.ts
+++ b/modules/effects/src/effect_sources.ts
@@ -1,6 +1,6 @@
 import { ErrorHandler, Inject, Injectable } from '@angular/core';
 import { Action } from '@ngrx/store';
-import { Notification, Observable, Subject, merge } from 'rxjs';
+import { Observable, Subject, merge } from 'rxjs';
 import {
   dematerialize,
   exhaustMap,
@@ -27,7 +27,7 @@ import {
   isOnInitEffects,
 } from './lifecycle_hooks';
 import { EFFECTS_ERROR_HANDLER } from './tokens';
-import { getSourceForInstance } from './utils';
+import { getSourceForInstance, ObservableNotification } from './utils';
 
 @Injectable()
 export class EffectSources extends Subject<any> {
@@ -65,12 +65,8 @@ export class EffectSources extends Subject<any> {
             return output.notification;
           }),
           filter(
-            (
-              notification
-            ): notification is Notification<Action> & {
-              kind: 'N';
-              value: Action;
-            } => notification.kind === 'N' && notification.value != null
+            (notification): notification is ObservableNotification<Action> =>
+              notification.kind === 'N' && notification.value != null
           ),
           dematerialize()
         );

--- a/modules/effects/src/utils.ts
+++ b/modules/effects/src/utils.ts
@@ -1,3 +1,22 @@
 export function getSourceForInstance<T>(instance: T): T {
   return Object.getPrototypeOf(instance);
 }
+
+export interface NextNotification<T> {
+  kind: 'N';
+  value: T;
+}
+
+export interface ErrorNotification {
+  kind: 'E';
+  error: any;
+}
+
+export interface CompleteNotification {
+  kind: 'C';
+}
+
+export type ObservableNotification<T> =
+  | NextNotification<T>
+  | ErrorNotification
+  | CompleteNotification;

--- a/modules/effects/src/utils.ts
+++ b/modules/effects/src/utils.ts
@@ -2,6 +2,8 @@ export function getSourceForInstance<T>(instance: T): T {
   return Object.getPrototypeOf(instance);
 }
 
+// TODO: replace with RxJS interfaces when possible
+// needs dependency on RxJS >=7
 export interface NextNotification<T> {
   kind: 'N';
   value: T;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

when using RxJS 8 and importing from "@ngrx/effects":
` Error: export 'Notification' (imported as 'Notification') was not found in 'rxjs' `

## What is the new behavior?

Working code

## Closes

https://github.com/ngrx/platform/discussions/3365

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
