### PR TITLE
refactor: replace mapTo deprecations

### DIFF
--- a/modules/effects/spec/effect_sources.spec.ts
+++ b/modules/effects/spec/effect_sources.spec.ts
@@ -10,7 +10,7 @@ import {
   timer,
   Subject,
 } from 'rxjs';
-import { map, mapTo } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 
 import {
   Effect,
@@ -423,14 +423,14 @@ describe('EffectSources', () => {
         effectOne = createEffect(() => {
           return this.actions$.pipe(
             ofType('Action 1'),
-            mapTo({ type: 'Action 1 Response' })
+            map(() => ({ type: 'Action 1 Response' }))
           );
         });
 
         effectTwo = createEffect(() => {
           return this.actions$.pipe(
             ofType('Action 2'),
-            mapTo({ type: 'Action 2 Response' })
+            map(() => ({ type: 'Action 2 Response' }))
           );
         });
 

--- a/modules/effects/spec/integration.spec.ts
+++ b/modules/effects/spec/integration.spec.ts
@@ -13,9 +13,8 @@ import {
   USER_PROVIDED_EFFECTS,
 } from '..';
 import { ofType, createEffect, OnRunEffects, EffectNotification } from '../src';
-import { mapTo, exhaustMap, tap } from 'rxjs/operators';
+import { map, exhaustMap, tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { FeatureModule } from 'modules/store/spec/ngc/main';
 
 describe('NgRx Effects Integration spec', () => {
   it('throws if forRoot() with Effects is used more than once', (done: any) => {
@@ -316,14 +315,14 @@ describe('NgRx Effects Integration spec', () => {
     response = createEffect(() => {
       return this.actions$.pipe(
         ofType('[EffectWithOnInitAndResponse]: INIT'),
-        mapTo({ type: '[EffectWithOnInitAndResponse]: INIT Response' })
+        map(() => ({ type: '[EffectWithOnInitAndResponse]: INIT Response' }))
       );
     });
 
     noop = createEffect(() => {
       return this.actions$.pipe(
         ofType('noop'),
-        mapTo({ type: 'noop response' })
+        map(() => ({ type: 'noop response' }))
       );
     });
 

--- a/modules/router-store/spec/integration.spec.ts
+++ b/modules/router-store/spec/integration.spec.ts
@@ -9,7 +9,7 @@ import {
   ActivatedRouteSnapshot,
 } from '@angular/router';
 import { Store, ScannedActionsSubject } from '@ngrx/store';
-import { filter, first, mapTo, take } from 'rxjs/operators';
+import { filter, first, map, take } from 'rxjs/operators';
 
 import {
   NavigationActionTiming,
@@ -748,7 +748,10 @@ describe('integration spec', () => {
       reducers: { routerReducer },
       canActivate: () => {
         store.dispatch({ type: 'USER_EVENT' });
-        return store.pipe(take(1), mapTo(true));
+        return store.pipe(
+          take(1),
+          map(() => true)
+        );
       },
     });
 

--- a/projects/example-app/src/app/core/effects/user.effects.ts
+++ b/projects/example-app/src/app/core/effects/user.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { fromEvent, merge, timer } from 'rxjs';
-import { map, switchMapTo } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 
 import { createEffect } from '@ngrx/effects';
 import { UserActions } from '@example-app/core/actions';
@@ -14,7 +14,8 @@ export class UserEffects {
 
   idle$ = createEffect(() =>
     merge(this.clicks$, this.keys$, this.mouse$).pipe(
-      switchMapTo(timer(5 * 60 * 1000)), // 5 minute inactivity timeout
+      // 5 minute inactivity timeout
+      switchMap(() => timer(5 * 60 * 1000)),
       map(() => UserActions.idleTimeout())
     )
   );


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

`mapTo` variations are deprecated, this PR replaces them with the `map` equivalents.
 
