### PR TITLE
fix(store): rename template literal to string literal for createActionGroup

### DIFF
--- a/modules/store/spec/types/action_group_creator.spec.ts
+++ b/modules/store/spec/types/action_group_creator.spec.ts
@@ -60,13 +60,13 @@ describe('createActionGroup', () => {
     });
 
     describe('source', () => {
-      it('should fail when source is not a template literal type', () => {
+      it('should fail when source is not a string literal type', () => {
         expectSnippet(`
           const booksApiActions = createActionGroup({
             source: 'Books API' as string,
             events: {},
           });
-        `).toFail(/source must be a template literal type/);
+        `).toFail(/source must be a string literal type/);
       });
     });
 
@@ -116,7 +116,7 @@ describe('createActionGroup', () => {
         );
       });
 
-      it('should fail when event name is not a template literal type', () => {
+      it('should fail when event name is not a string literal type', () => {
         expectSnippet(`
           const booksApiActions = createActionGroup({
             source: 'Books API',
@@ -124,7 +124,7 @@ describe('createActionGroup', () => {
               ['Load Books Success' as string]: emptyProps()
             },
           });
-        `).toFail(/event name must be a template literal type/);
+        `).toFail(/event name must be a string literal type/);
       });
 
       describe('forbidden characters', () => {

--- a/modules/store/src/action_group_creator_models.ts
+++ b/modules/store/src/action_group_creator_models.ts
@@ -70,10 +70,10 @@ type EmptyStringCheck<
   ? `${Name} cannot be an empty string or contain only spaces`
   : unknown;
 
-type TemplateLiteralCheck<
+type StringLiteralCheck<
   Str extends string,
   Name extends string
-> = string extends Str ? `${Name} must be a template literal type` : unknown;
+> = string extends Str ? `${Name} must be a string literal type` : unknown;
 
 type UniqueEventNameCheck<
   EventNames extends string,
@@ -120,11 +120,11 @@ export interface ActionGroupConfig<
   Source extends string,
   Events extends Record<string, ActionCreatorProps<unknown> | Creator>
 > {
-  source: Source & TemplateLiteralCheck<Source, 'source'>;
+  source: Source & StringLiteralCheck<Source, 'source'>;
   events: {
     [EventName in keyof Events]: Events[EventName] &
       EmptyStringCheck<EventName & string, 'event name'> &
-      TemplateLiteralCheck<EventName & string, 'event name'> &
+      StringLiteralCheck<EventName & string, 'event name'> &
       ForbiddenCharactersCheck<EventName & string, 'event name'> &
       UniqueEventNameCheck<keyof Events & string, EventName & string> &
       NotAllowedEventPropsCheck<Events[EventName]>;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Template literals are subsets of string literal types. The `createActionGroup` function requires to use string literals for source/event names, but the error message is 'source/event name must be a **template** literal type'.

## What is the new behavior?

Displaying correct error message when the type of source/event name is not a string literal.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
