### PR TITLE
refactor(component-store): add docs and warning for hooks without provideComponentStore

### DIFF
--- a/modules/component-store/spec/component-store.spec.ts
+++ b/modules/component-store/spec/component-store.spec.ts
@@ -1579,11 +1579,21 @@ describe('Component Store', () => {
       expect(extraStore).toBeDefined();
     });
 
+    it('should not log a warning when a ComponentStore with hooks is provided using provideComponentStore()', fakeAsync(() => {
+      jest.spyOn(console, 'warn');
+
+      const state = setup();
+
+      const store = state.injector.get(LifecycleStore);
+
+      tick(0);
+      expect(store.ngrxOnStoreInit).toBeDefined();
+      expect(store['ɵhasProvider']).toBeTruthy();
+      expect(console.warn).not.toHaveBeenCalled();
+    }));
+
     it('should log a warning when a hook is implemented without using provideComponentStore()', fakeAsync(() => {
-      const consoleOrig = console;
-      (global.console as any) = {
-        warn: jest.fn(),
-      };
+      jest.spyOn(console, 'warn');
 
       const state = setup({
         providers: [NonProviderStore],
@@ -1595,8 +1605,6 @@ describe('Component Store', () => {
       expect(store.ngrxOnStoreInit).toBeDefined();
       expect(store['ɵhasProvider']).toBeFalsy();
       expect(console.warn).toHaveBeenCalled();
-
-      console = consoleOrig;
     }));
   });
 });

--- a/modules/component-store/spec/component-store.spec.ts
+++ b/modules/component-store/spec/component-store.spec.ts
@@ -36,6 +36,7 @@ import {
   Injector,
   Provider,
 } from '@angular/core';
+import { fakeAsync, tick } from '@angular/core/testing';
 
 describe('Component Store', () => {
   describe('initialization', () => {
@@ -1502,6 +1503,11 @@ describe('Component Store', () => {
       }
     }
 
+    @Injectable()
+    class NonProviderStore extends ComponentStore<{}> implements OnStoreInit {
+      ngrxOnStoreInit() {}
+    }
+
     function setup({
       initialState,
       providers = [],
@@ -1572,5 +1578,25 @@ describe('Component Store', () => {
       expect(lifecycleStore).toBeDefined();
       expect(extraStore).toBeDefined();
     });
+
+    it('should log a warning when a hook is implemented without using provideComponentStore()', fakeAsync(() => {
+      const consoleOrig = console;
+      (global.console as any) = {
+        warn: jest.fn(),
+      };
+
+      const state = setup({
+        providers: [NonProviderStore],
+      });
+
+      const store = state.injector.get(NonProviderStore);
+
+      tick(0);
+      expect(store.ngrxOnStoreInit).toBeDefined();
+      expect(store['ɵhasProvider']).toBeFalsy();
+      expect(console.warn).toHaveBeenCalled();
+
+      console = consoleOrig;
+    }));
   });
 });

--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -326,10 +326,18 @@ export class ComponentStore<T extends object> implements OnDestroy {
         (isOnStoreInitDefined(this) || isOnStateInitDefined(this)) &&
         !this.ɵhasProvider
       ) {
+        const warnings = [
+          isOnStoreInitDefined(this) ? 'OnStoreInit' : '',
+          isOnStateInitDefined(this) ? 'OnStateInit' : '',
+        ].filter((defined) => defined);
+
         console.warn(
-          `@ngrx/component-store: The ${this.constructor.name} has one or more ` +
-            'lifecycle hooks implemented without being provided using the ' +
-            `provideComponentStore(${this.constructor.name}) function. `
+          `@ngrx/component-store: ${
+            this.constructor.name
+          } has the ${warnings.join(' and ')} ` +
+            'lifecycle hook(s) implemented without being provided using the ' +
+            `provideComponentStore(${this.constructor.name}) function. ` +
+            `To resolve this, provide the component store via provideComponentStore(${this.constructor.name})`
         );
       }
     });

--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -19,7 +19,6 @@ import {
   distinctUntilChanged,
   shareReplay,
   take,
-  delay,
 } from 'rxjs/operators';
 import { debounceSync } from './debounce-sync';
 import {

--- a/modules/component-store/src/index.ts
+++ b/modules/component-store/src/index.ts
@@ -1,3 +1,7 @@
 export * from './component-store';
 export * from './tap-response';
-export * from './lifecycle_hooks';
+export {
+  provideComponentStore,
+  OnStateInit,
+  OnStoreInit,
+} from './lifecycle_hooks';

--- a/modules/component-store/src/lifecycle_hooks.ts
+++ b/modules/component-store/src/lifecycle_hooks.ts
@@ -26,7 +26,7 @@ export interface OnStateInit {
  * @param cs ComponentStore type
  * @returns boolean
  */
-function isOnStoreInitDefined(cs: unknown): cs is OnStoreInit {
+export function isOnStoreInitDefined(cs: unknown): cs is OnStoreInit {
   return typeof (cs as OnStoreInit).ngrxOnStoreInit === 'function';
 }
 
@@ -37,7 +37,7 @@ function isOnStoreInitDefined(cs: unknown): cs is OnStoreInit {
  * @param cs ComponentStore type
  * @returns boolean
  */
-function isOnStateInitDefined(cs: unknown): cs is OnStateInit {
+export function isOnStateInitDefined(cs: unknown): cs is OnStateInit {
   return typeof (cs as OnStateInit).ngrxOnStateInit === 'function';
 }
 
@@ -98,6 +98,9 @@ export function provideComponentStore<T extends object>(
       provide: componentStoreClass,
       useFactory: () => {
         const componentStore = inject(CS_WITH_HOOKS);
+
+        // Set private property that CS has been provided with lifecycle hooks
+        componentStore['ɵhasProvider'] = true;
 
         if (isOnStoreInitDefined(componentStore)) {
           componentStore.ngrxOnStoreInit();

--- a/projects/ngrx.io/content/guide/component-store/lifecycle.md
+++ b/projects/ngrx.io/content/guide/component-store/lifecycle.md
@@ -1,6 +1,6 @@
 # Lifecycle
 
-NgRx ComponentStore comes with lifecycle hooks for performing tasks after the ComponentStore is initially instantiated, and after the initial state is first set. You can use these lifecycle hooks to set up long-running effects, wire up additional logic, and other tasks outside the constructor of the ComponentStore.
+NgRx ComponentStore comes with lifecycle hooks and observables for performing tasks after the ComponentStore is initially instantiated, after the initial state is first set, and when the ComponentStore is destroyed. You can use these lifecycle hooks to set up long-running effects, wire up additional logic, and other tasks outside the constructor of the ComponentStore.
 
 ## Setup
 
@@ -73,7 +73,7 @@ export class BooksStore extends ComponentStore<BooksState> implements OnStateIni
   }
 
   ngrxOnStateInit() {
-    // called after store has been instantiated
+    // called once after state has been first initialized
   }
 }
 
@@ -98,12 +98,11 @@ export interface BooksState {
 @Injectable()
 export class BooksStore extends ComponentStore<BooksState> implements OnStateInit {
   constructor() {
-    // lazy state initialization
     super();
   }
 
   ngrxOnStateInit() {
-    // called after store state has been initialized
+    // called once after state has been first initialized
   }
 }
 
@@ -121,6 +120,7 @@ export class BooksPageComponent implements OnInit {
   constructor(private booksStore: BooksStore) {}
 
   ngOnInit() {
+    // lazy state initialization
     this.booksStore.setState(initialState);
   }
 }

--- a/projects/ngrx.io/content/guide/component-store/lifecycle.md
+++ b/projects/ngrx.io/content/guide/component-store/lifecycle.md
@@ -4,7 +4,7 @@ NgRx ComponentStore comes with lifecycle hooks and observables for performing ta
 
 ## Setup
 
-Both lifecycle hooks are enabled by providing the ComponentStore through the `provideComponentStore()` function. This function registers the ComponentStore as a provider, and sets up a factory provider to instantiate the ComponentStore instance and run the implemented lifecycle hooks.
+Both lifecycle hooks are enabled by providing the ComponentStore through the `provideComponentStore()` function. This function registers the ComponentStore as a provider, sets up a factory provider to instantiate the ComponentStore instance, and calls the implemented lifecycle hooks.
 
 Currently, Angular provides initializer tokens in a few areas. The `APP_INITIALIZER` and `BOOTSTRAP_INITIALIZER` for application/bootstrap init logic, and the `ENVIRONMENT_INITIALIZER` for environment injector init logic. The `provideComponentStore()` mimics this behavior to run the lifecycle hooks. The function is required because there aren't any provided tokens at the component level injector to allow initialization tasks.
 
@@ -18,6 +18,7 @@ Currently, Angular provides initializer tokens in a few areas. The `APP_INITIALI
 
 The `OnStoreInit` interface is used the implement the `ngrxOnStoreInit` method in the ComponentStore class. This lifecycle method is called immediately after the ComponentStore class is instantiated.
 
+<code-example header="books.store.ts">
 ```ts
 export interface BooksState {
   collection: Book[];
@@ -28,7 +29,7 @@ export const initialState: BooksState = {
 };
 
 @Injectable()
-export class BooksStore extends ComponentStore<BooksState> implements OnStoreInit {
+export class BooksStore extends ComponentStore&lt;BooksState&gt; implements OnStoreInit {
 
   constructor() {
     super(initialState);
@@ -38,7 +39,9 @@ export class BooksStore extends ComponentStore<BooksState> implements OnStoreIni
     // called after store has been instantiated
   }
 }
+</code-example>
 
+<code-example header="books-page.component.ts">
 @Component({
   // ... other metadata
   providers: [
@@ -48,7 +51,7 @@ export class BooksStore extends ComponentStore<BooksState> implements OnStoreIni
 export class BooksPageComponent {
   constructor(private booksStore: BooksStore) {}
 }
-```
+</code-example>
 
 ## OnStateInit
 
@@ -56,7 +59,7 @@ The `OnStateInit` interface is used the implement the `ngrxOnStateInit` method i
 
 ### Eager State Init
 
-```ts
+<code-example header="books.store.ts">
 export interface BooksState {
   collection: Book[];
 }
@@ -66,7 +69,7 @@ export const initialState: BooksState = {
 };
 
 @Injectable()
-export class BooksStore extends ComponentStore<BooksState> implements OnStateInit {
+export class BooksStore extends ComponentStore&lt;BooksState&gt; implements OnStateInit {
   constructor() {
     // eager state initialization
     super(initialState);
@@ -76,7 +79,9 @@ export class BooksStore extends ComponentStore<BooksState> implements OnStateIni
     // called once after state has been first initialized
   }
 }
+</code-example>
 
+<code-example header="books-page.component.ts">
 @Component({
   // ... other metadata
   providers: [
@@ -86,17 +91,17 @@ export class BooksStore extends ComponentStore<BooksState> implements OnStateIni
 export class BooksPageComponent {
   constructor(private booksStore: BooksStore) {}
 }
-```
+</code-example>
 
 ### Lazy State Init
 
-```ts
+<code-example header="books.store.ts">
 export interface BooksState {
   collection: Book[];
 }
 
 @Injectable()
-export class BooksStore extends ComponentStore<BooksState> implements OnStateInit {
+export class BooksStore extends ComponentStore&lt;BooksState&gt; implements OnStateInit {
   constructor() {
     super();
   }
@@ -109,7 +114,9 @@ export class BooksStore extends ComponentStore<BooksState> implements OnStateIni
 export const initialState: BooksState = {
   collection: []
 };
+</code-example>
 
+<code-example header="books-page.component.ts">
 @Component({
   // ... other metadata
   providers: [
@@ -124,7 +131,7 @@ export class BooksPageComponent implements OnInit {
     this.booksStore.setState(initialState);
   }
 }
-```
+</code-example>
 
 ## OnDestroy
 
@@ -132,7 +139,7 @@ ComponentStore also implements the `OnDestroy` interface from `@angulare/core` t
 
 It also exposes a `destroy$` property on the ComponentStore class that can be used instead of manually creating a `Subject` to unsubscribe from any observables created in the component.
 
-```ts
+<code-example header="books-page.component.ts">
 @Component({
   // ... other metadata
   providers: [ComponentStore]
@@ -143,11 +150,11 @@ export class BooksPageComponent implements OnInit {
   ngOnInit() {
     const timer = interval(1000)
       .pipe(takeUntil(this.cs.destroy$))
-      .subscribe(() => {
+      .subscribe(() =&gt; {
         // listen until ComponentStore is destroyed
       });
   }
 }
-```
+</code-example>
 
 The `provideComponentStore()` function is not required to listen to the `destroy$` property on the ComoponentStore.

--- a/projects/ngrx.io/content/guide/component-store/lifecycle.md
+++ b/projects/ngrx.io/content/guide/component-store/lifecycle.md
@@ -1,0 +1,153 @@
+# Lifecycle
+
+NgRx ComponentStore comes with lifecycle hooks for performing tasks after the ComponentStore is initially instantiated, and after the initial state is first set. You can use these lifecycle hooks to set up long-running effects, wire up additional logic, and other tasks outside the constructor of the ComponentStore.
+
+## Setup
+
+Both lifecycle hooks are enabled by providing the ComponentStore through the `provideComponentStore()` function. This function registers the ComponentStore as a provider, and sets up a factory provider to instantiate the ComponentStore instance and run the implemented lifecycle hooks.
+
+Currently, Angular provides initializer tokens in a few areas. The `APP_INITIALIZER` and `BOOTSTRAP_INITIALIZER` for application/bootstrap init logic, and the `ENVIRONMENT_INITIALIZER` for environment injector init logic. The `provideComponentStore()` mimics this behavior to run the lifecycle hooks. The function is required because there aren't any provided tokens at the component level injector to allow initialization tasks.
+
+<div class="alert is-important">
+
+**Note:** If you implement the lifecycle hooks in the ComponentStore, and register it with `providers` without using `provideComponentStore()`, in development mode, a warning is logged to the browser console.
+
+</div>
+
+## OnStoreInit
+
+The `OnStoreInit` interface is used the implement the `ngrxOnStoreInit` method in the ComponentStore class. This lifecycle method is called immediately after the ComponentStore class is instantiated.
+
+```ts
+export interface BooksState {
+  collection: Book[];
+}
+
+export const initialState: BooksState = {
+  collection: []
+};
+
+@Injectable()
+export class BooksStore extends ComponentStore<BooksState> implements OnStoreInit {
+
+  constructor() {
+    super(initialState);
+  }
+
+  ngrxOnStoreInit() {
+    // called after store has been instantiated
+  }
+}
+
+@Component({
+  // ... other metadata
+  providers: [
+    provideComponentStore(BooksStore)
+  ]
+})
+export class BooksPageComponent {
+  constructor(private booksStore: BooksStore) {}
+}
+```
+
+## OnStateInit
+
+The `OnStateInit` interface is used the implement the `ngrxOnStateInit` method in the ComponentStore class. This lifecycle method is called **only once** after the ComponentStore state is initially set. ComponentStore supports eager and lazy initialization of state, and the lifecycle hook is called appropriately in either scenario.
+
+### Eager State Init
+
+```ts
+export interface BooksState {
+  collection: Book[];
+}
+
+export const initialState: BooksState = {
+  collection: []
+};
+
+@Injectable()
+export class BooksStore extends ComponentStore<BooksState> implements OnStateInit {
+  constructor() {
+    // eager state initialization
+    super(initialState);
+  }
+
+  ngrxOnStateInit() {
+    // called after store has been instantiated
+  }
+}
+
+@Component({
+  // ... other metadata
+  providers: [
+    provideComponentStore(BooksStore)
+  ]
+})
+export class BooksPageComponent {
+  constructor(private booksStore: BooksStore) {}
+}
+```
+
+### Lazy State Init
+
+```ts
+export interface BooksState {
+  collection: Book[];
+}
+
+@Injectable()
+export class BooksStore extends ComponentStore<BooksState> implements OnStateInit {
+  constructor() {
+    // lazy state initialization
+    super();
+  }
+
+  ngrxOnStateInit() {
+    // called after store state has been initialized
+  }
+}
+
+export const initialState: BooksState = {
+  collection: []
+};
+
+@Component({
+  // ... other metadata
+  providers: [
+    provideComponentStore(BooksStore)
+  ]
+})
+export class BooksPageComponent implements OnInit {
+  constructor(private booksStore: BooksStore) {}
+
+  ngOnInit() {
+    this.booksStore.setState(initialState);
+  }
+}
+```
+
+## OnDestroy
+
+ComponentStore also implements the `OnDestroy` interface from `@angulare/core` to complete any internally created observables.
+
+It also exposes a `destroy$` property on the ComponentStore class that can be used instead of manually creating a `Subject` to unsubscribe from any observables created in the component.
+
+```ts
+@Component({
+  // ... other metadata
+  providers: [ComponentStore]
+})
+export class BooksPageComponent implements OnInit {
+  constructor(private cs: ComponentStore) {}
+
+  ngOnInit() {
+    const timer = interval(1000)
+      .pipe(takeUntil(this.cs.destroy$))
+      .subscribe(() => {
+        // listen until ComponentStore is destroyed
+      });
+  }
+}
+```
+
+The `provideComponentStore()` function is not required to listen to the `destroy$` property on the ComoponentStore.

--- a/projects/ngrx.io/content/guide/component-store/lifecycle.md
+++ b/projects/ngrx.io/content/guide/component-store/lifecycle.md
@@ -19,7 +19,6 @@ Currently, Angular provides initializer tokens in a few areas. The `APP_INITIALI
 The `OnStoreInit` interface is used the implement the `ngrxOnStoreInit` method in the ComponentStore class. This lifecycle method is called immediately after the ComponentStore class is instantiated.
 
 <code-example header="books.store.ts">
-```ts
 export interface BooksState {
   collection: Book[];
 }

--- a/projects/ngrx.io/content/navigation.json
+++ b/projects/ngrx.io/content/navigation.json
@@ -258,6 +258,10 @@
               ]
             },
             {
+              "title": "Lifecycle",
+              "url": "guide/component-store/lifecycle"
+            },
+            {
               "title": "ComponentStore vs Store",
               "url": "guide/component-store/comparison"
             },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Adds a check and warning if lifecycle hooks are defined on the ComponentStore and its not provided using the `provideComponentStore()` function.

Adds documentation for lifecycle hooks and explanation for `provideComponentStore()` function.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
