### PR TITLE
docs: prioritize ng add in installation guides

### DIFF
--- a/projects/ngrx.io/content/guide/component-store/install.md
+++ b/projects/ngrx.io/content/guide/component-store/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-## Installing with `ng add` (recommended)
+## Installing with `ng add`
 
 You can install the ComponentStore to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
 

--- a/projects/ngrx.io/content/guide/component-store/install.md
+++ b/projects/ngrx.io/content/guide/component-store/install.md
@@ -1,5 +1,19 @@
 # Installation
 
+## Installing with `ng add` (recommended)
+
+You can install the ComponentStore to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+
+```sh
+ng add @ngrx/component-store@latest
+```
+
+This command will automate the following steps:
+
+1. Update `package.json` > `dependencies` with `@ngrx/component-store`.
+2. Run the package manager to install the added dependency. 
+
+
 ## Installing with `npm`
 
 For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
@@ -15,16 +29,3 @@ For more information on using `yarn` check out the docs <a href="https://yarnpkg
 ```sh
 yarn add @ngrx/component-store
 ```
-
-## Installing with `ng add`
-
-If your project is using the Angular CLI 6+ then you can install the ComponentStore to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
-
-```sh
-ng add @ngrx/component-store@latest
-```
-
-This command will automate the following steps:
-
-1. Update `package.json` > `dependencies` with `@ngrx/component-store`.
-2. Run the package manager to install the added dependency. 

--- a/projects/ngrx.io/content/guide/component/install.md
+++ b/projects/ngrx.io/content/guide/component/install.md
@@ -1,5 +1,18 @@
 # Installation
 
+## Installing with `ng add`
+
+You can install the Component package to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+
+```sh
+ng add @ngrx/component@latest
+```
+
+This command will automate the following steps:
+
+1. Update `package.json` > `dependencies` with `@ngrx/component`.
+2. Run the package manager to install the added dependency. 
+
 ## Installing with `npm`
 
 For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
@@ -15,16 +28,3 @@ For more information on using `yarn` check out the docs <a href="https://yarnpkg
 ```sh
 yarn add @ngrx/component
 ```
-
-## Installing with `ng add`
-
-If your project is using the Angular CLI 6+ then you can install the Component package to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
-
-```sh
-ng add @ngrx/component@latest
-```
-
-This command will automate the following steps:
-
-1. Update `package.json` > `dependencies` with `@ngrx/component`.
-2. Run the package manager to install the added dependency. 

--- a/projects/ngrx.io/content/guide/data/install.md
+++ b/projects/ngrx.io/content/guide/data/install.md
@@ -1,24 +1,8 @@
 # Installation
 
-## Installing with `npm`
-
-For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
-
-```sh
-npm install @ngrx/data --save
-```
-
-## Installing with `yarn`
-
-For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
-
-```sh
-yarn add @ngrx/data
-```
-
 ## Installing with `ng add`
 
-If your project is using the Angular CLI 6+ then you can install the Data package to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+You can install the Data package to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
 
 ```sh
 ng add @ngrx/data@latest
@@ -42,3 +26,19 @@ With the `migrateNgRxData` flag the following will also take place:
 
 1. Remove `ngrx-data` from `package.json` > `dependencies`.
 2. Rename `ngrx-data` types to the matching `@ngrx/data` types.
+
+## Installing with `npm`
+
+For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
+
+```sh
+npm install @ngrx/data --save
+```
+
+## Installing with `yarn`
+
+For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
+
+```sh
+yarn add @ngrx/data
+```

--- a/projects/ngrx.io/content/guide/data/install.md
+++ b/projects/ngrx.io/content/guide/data/install.md
@@ -10,11 +10,13 @@ ng add @ngrx/data@latest
 
 ### Optional `ng add` flags
 
-* project - name of the project defined in your `angular.json` to help locating the module to add the `EntityDataModule` to.
-* module - name of file containing the module that you wish to add the import for the `EntityDataModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`.
-* effects - if `false` it will use the `EntityDataModuleWithoutEffects` module instead of the default `EntityDataModule`.
-* migrateNgRxData - if `true` it will replace the `ngrx-data` module with the `@ngrx/data` module.
-* entityConfig - if `false` it will not create and declare the `entity-metadata` file.
+| flag | description | value type | default value |
+| --- | --- | --- | ---
+| `--project` | Name of the project defined in your `angular.json` to help locating the module to add the `EntityDataModule` to. | `string` |
+| `--module` | Name of file containing the module that you wish to add the import for the `EntityDataModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`. | `string` | `app`
+| `--effects` | If `false` it will use the `EntityDataModuleWithoutEffects` module instead of the default `EntityDataModule`. | `boolean` | `true`
+| `--migrateNgRxData` | If `true` it will replace the `ngrx-data` module with the `@ngrx/data` module. | `boolean` | `false`
+| `--entityConfig` | If `false` it will not create and declare the `entity-metadata` file. | `boolean` | `true`
 
 This command will automate the following steps:
 

--- a/projects/ngrx.io/content/guide/effects/install.md
+++ b/projects/ngrx.io/content/guide/effects/install.md
@@ -1,24 +1,8 @@
 # Installation
 
-## Installing with `npm`
-
-For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
-
-```sh
-npm install @ngrx/effects --save
-```
-
-## Installing with `yarn`
-
-For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
-
-```sh
-yarn add @ngrx/effects
-```
-
 ## Installing with `ng add`
 
-If your project is using the Angular CLI 6+ then you can install the Effects to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+You can install the Effects to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
 
 ```sh
 ng add @ngrx/effects@latest
@@ -39,3 +23,19 @@ This command will automate the following steps:
 1. Update `package.json` > `dependencies` with `@ngrx/effects`.
 2. Run `npm install` to install those dependencies. 
 3. Update your `src/app/app.module.ts` > `imports` array with `EffectsModule.forRoot([AppEffects])`. If you provided flags then the command will attempt to locate and update module found by the flags.
+
+## Installing with `npm`
+
+For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
+
+```sh
+npm install @ngrx/effects --save
+```
+
+## Installing with `yarn`
+
+For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
+
+```sh
+yarn add @ngrx/effects
+```

--- a/projects/ngrx.io/content/guide/effects/install.md
+++ b/projects/ngrx.io/content/guide/effects/install.md
@@ -10,13 +10,15 @@ ng add @ngrx/effects@latest
 
 ### Optional `ng add` flags
 
-* path - path to the module that you wish to add the import for the `EffectsModule` to.
-* flat - Indicate if a directory is to be created to hold your effects file
-* skipTests - When true, does not create test files.
-* project - name of the project defined in your `angular.json` to help locating the module to add the `EffectsModule` to.
-* module - name of file containing the module that you wish to add the import for the `EffectsModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`
-* minimal - By default true, only provide minimal setup for the root effects setup. Only registers `EffectsModule.forRoot()` in the provided `module` with an empty array.
-* group - Group effects file within `effects` folder
+| flag | description | value type | default value
+| --- | --- | --- | ---
+| `--path` | Path to the module that you wish to add the import for the `EffectsModule` to. | `string`
+| `--flat` | Indicate if a directory is to be created to hold your effects file. | `boolean` | `true`
+| `--skipTests` | When true, does not create test files. | `boolean` | `false`
+| `--project` | Name of the project defined in your `angular.json` to help locating the module to add the `EffectsModule` to. | `string`
+| `--module` | Name of file containing the module that you wish to add the import for the `EffectsModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts` | `string` | `app`
+| `--minimal` | When true, only provide minimal setup for the root effects setup. Only registers `EffectsModule.forRoot()` in the provided `module` with an empty array. | `boolean` | `true`
+| `--group` | Group effects file within `effects` folder. | `boolean` | `false`
 
 This command will automate the following steps:
 

--- a/projects/ngrx.io/content/guide/entity/install.md
+++ b/projects/ngrx.io/content/guide/entity/install.md
@@ -1,5 +1,18 @@
 # Installation
 
+## Installing with `ng add`
+
+You can install the Entity package to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+
+```sh
+ng add @ngrx/entity@latest
+```
+
+This command will automate the following steps:
+
+1. Update `package.json` > `dependencies` with `@ngrx/entity`.
+2. Run `npm install` to install those dependencies. 
+
 ## Installing with `npm`
 
 For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
@@ -15,17 +28,3 @@ For more information on using `yarn` check out the docs <a href="https://yarnpkg
 ```sh
 yarn add @ngrx/entity
 ```
-
-## Installing with `ng add`
-
-If your project is using the Angular CLI 6+ then you can install the Entity package to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
-
-```sh
-ng add @ngrx/entity@latest
-```
-
-This command will automate the following steps:
-
-1. Update `package.json` > `dependencies` with `@ngrx/entity`.
-2. Run `npm install` to install those dependencies. 
-

--- a/projects/ngrx.io/content/guide/eslint-plugin/install.md
+++ b/projects/ngrx.io/content/guide/eslint-plugin/install.md
@@ -2,7 +2,7 @@
 
 ## Installing with `ng add`
 
-You can install the plugin to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+You can install the ESLint plugin to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
 
 ```sh
 ng add @ngrx/eslint-plugin

--- a/projects/ngrx.io/content/guide/eslint-plugin/install.md
+++ b/projects/ngrx.io/content/guide/eslint-plugin/install.md
@@ -1,5 +1,15 @@
 # Installation
 
+## Installing with `ng add`
+
+You can install the plugin to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+
+```sh
+ng add @ngrx/eslint-plugin
+```
+
+The command will prompt you to select which config you would like to have preconfigured; you can read the detailed list of available configs [here](guide/eslint-plugin/#configurations).
+
 ## Installing with `npm`
 
 For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
@@ -15,13 +25,3 @@ For more information on using `yarn` check out the docs <a href="https://yarnpkg
 ```sh
 yarn add @ngrx/eslint-plugin -D
 ```
-
-## Installing with `ng add`
-
-If your project is using the Angular CLI 6+ then you can install the plugin to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
-
-```sh
-ng add @ngrx/eslint-plugin
-```
-
-The command will prompt you to select which config you would like to have preconfigured; you can read the detailed list of available configs [here](guide/eslint-plugin/#configurations).

--- a/projects/ngrx.io/content/guide/router-store/install.md
+++ b/projects/ngrx.io/content/guide/router-store/install.md
@@ -1,24 +1,8 @@
 # Installation
 
-## Installing with `npm`
-
-For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
-
-```sh
-npm install @ngrx/router-store --save
-```
-
-## Installing with `yarn`
-
-For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
-
-```sh
-yarn add @ngrx/router-store
-```
-
 ## Installing with `ng add`
 
-If your project is using the Angular CLI 6+ then you can install the Router Store to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+You can install the Router Store to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
 
 ```sh
 ng add @ngrx/router-store@latest
@@ -36,3 +20,18 @@ This command will automate the following steps:
 2. Run `npm install` to install those dependencies. 
 3. By default, will update  `src/app/app.module.ts` > `imports` array with `StoreRouterConnectingModule.forRoot()`. If you provided flags then the command will attempt to locate and update module found by the flags.
 
+## Installing with `npm`
+
+For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
+
+```sh
+npm install @ngrx/router-store --save
+```
+
+## Installing with `yarn`
+
+For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
+
+```sh
+yarn add @ngrx/router-store
+```

--- a/projects/ngrx.io/content/guide/router-store/install.md
+++ b/projects/ngrx.io/content/guide/router-store/install.md
@@ -10,9 +10,11 @@ ng add @ngrx/router-store@latest
 
 ### Optional `ng add` flags
 
-* path - path to the module that you wish to add the import for the `StoreRouterConnectingModule` to.
-* project - name of the project defined in your `angular.json` to help locating the module to add the `StoreRouterConnectingModule` to.
-* module - name of file containing the module that you wish to add the import for the `StoreRouterConnectingModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`;
+| flag | description | value type | default value |
+| --- | --- | --- | ---
+| `--path` | Path to the module that you wish to add the import for the `StoreRouterConnectingModule` to. | `string` |
+| `--project` | Name of the project defined in your `angular.json` to help locating the module to add the `StoreRouterConnectingModule` to. | `string`
+| `--module` | Name of file containing the module that you wish to add the import for the `StoreRouterConnectingModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`. | `string` | `app`
 
 This command will automate the following steps:
 

--- a/projects/ngrx.io/content/guide/schematics/install.md
+++ b/projects/ngrx.io/content/guide/schematics/install.md
@@ -1,5 +1,21 @@
 # Installation
 
+## Installing with `ng add`
+
+You can make `@ngrx/schematics` the default collection for your application with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+
+```sh
+ng add @ngrx/schematics@latest
+```
+
+### Optional `ng add` flags
+
+* defaultCollection - Use @ngrx/schematics as the default collection.
+
+This command will automate the following steps:
+
+1. Update `angular.json` > `cli > defaultCollection` with `@ngrx/schematics`.
+
 ## Installing with `npm`
 
 For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
@@ -15,19 +31,3 @@ For more information on using `yarn` check out the docs <a href="https://yarnpkg
 ```sh
 yarn add @ngrx/schematics --dev
 ```
-
-## Installing with `ng add`
-
-If your project is using the Angular CLI 6+ then you can make `@ngrx/schematics` the default collection for your application with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
-
-```sh
-ng add @ngrx/schematics@latest
-```
-
-### Optional `ng add` flags
-
-* defaultCollection - Use @ngrx/schematics as the default collection.
-
-This command will automate the following steps:
-
-1. Update `angular.json` > `cli > defaultCollection` with `@ngrx/schematics`.

--- a/projects/ngrx.io/content/guide/schematics/install.md
+++ b/projects/ngrx.io/content/guide/schematics/install.md
@@ -10,7 +10,9 @@ ng add @ngrx/schematics@latest
 
 ### Optional `ng add` flags
 
-* defaultCollection - Use @ngrx/schematics as the default collection.
+| flag | description | value type | default value |
+| --- | --- | --- | ---
+| `--defaultCollection` | Use @ngrx/schematics as the default collection. | `boolean` | `true`
 
 This command will automate the following steps:
 

--- a/projects/ngrx.io/content/guide/store-devtools/install.md
+++ b/projects/ngrx.io/content/guide/store-devtools/install.md
@@ -1,23 +1,8 @@
 # Installation
 
-## Installing with `npm`
-
-For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
-
-```sh
-npm install @ngrx/store-devtools --save
-```
-
-## Installing with `yarn`
-For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
-
-```sh
-yarn add @ngrx/store-devtools
-```
-
 ## Installing with `ng add`
 
-If your project is using the Angular CLI 6+ then you can install the Store Devtools to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+You can install the Store Devtools to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
 
 ```sh
 ng add @ngrx/store-devtools@latest
@@ -35,3 +20,19 @@ This command will automate the following steps:
 1. Update `package.json` > `dependencies` with `@ngrx/store-devtools`.
 2. Run `npm install` to install those dependencies. 
 3. Update your `src/app.module.ts` > `imports` array with `StoreDevtoolsModule.instrument({ maxAge: 25, logOnly: environment.production })`. The maxAge property will be set to the flag `maxAge` if provided. 
+
+
+## Installing with `npm`
+
+For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
+
+```sh
+npm install @ngrx/store-devtools --save
+```
+
+## Installing with `yarn`
+For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
+
+```sh
+yarn add @ngrx/store-devtools
+```

--- a/projects/ngrx.io/content/guide/store-devtools/install.md
+++ b/projects/ngrx.io/content/guide/store-devtools/install.md
@@ -10,10 +10,12 @@ ng add @ngrx/store-devtools@latest
 
 ### Optional `ng add` flags
 
-* path - path to the module that you wish to add the import for the `StoreDevtoolsModule` to.
-* project - name of the project defined in your `angular.json` to help locating the module to add the `StoreDevtoolsModule` to.
-* module - name of file containing the module that you wish to add the import for the `StoreDevtoolsModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`;
-* maxAge - number (>1) | 0 - maximum allowed actions to be stored in the history tree. The oldest actions are removed once maxAge is reached. It's critical for performance. 0 is infinite. Default is 25 for performance reasons.
+| flag | description | value type | default value |
+| --- | --- | --- | ---
+| `--path` | Path to the module that you wish to add the import for the `StoreDevtoolsModule` to. | `string` |
+| `--project` | Name of the project defined in your `angular.json` to help locating the module to add the `StoreDevtoolsModule` to. | `string` | 
+| `--module` | Name of file containing the module that you wish to add the import for the `StoreDevtoolsModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`. | `string` | `app`
+| `--maxAge` | Maximum allowed actions to be stored in the history tree. The oldest actions are removed once maxAge is reached. It's critical for performance. 0 is infinite. Must be greater than 1 or 0. | `number` | `25`
 
 This command will automate the following steps:
 

--- a/projects/ngrx.io/content/guide/store/install.md
+++ b/projects/ngrx.io/content/guide/store/install.md
@@ -9,13 +9,14 @@ ng add @ngrx/store@latest
 ```
 
 ### Optional `ng add` flags
-
-* path - path to the module that you wish to add the import for the `StoreModule` to.
-* project - name of the project defined in your `angular.json` to help locating the module to add the `StoreModule` to.
-* module - name of file containing the module that you wish to add the import for the `StoreModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`;
-* minimal - By default true, flag to only provide minimal setup for the root state management. Only registers `StoreModule.forRoot()` in the provided `module` with an empty object, and default runtime checks.
-* statePath - The file path to create the state in. By default, this is `reducers`.
-* stateInterface - The type literal of the defined interface for the state. By default, this is `State`.
+| flag | description | value type | default value |
+| --- | --- | --- | ---
+| `--path` | Path to the module that you wish to add the import for the StoreModule to. | `string` |
+| `--project` | Name of the project defined in your `angular.json` to help locating the module to add the `StoreModule` to. | `string` |
+| `--module` | Name of file containing the module that you wish to add the import for the `StoreModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`. | `string` | `app`
+| `--minimal` | Flag to only provide minimal setup for the root state management. Only registers `StoreModule.forRoot()` in the provided `module` with an empty object, and default runtime checks. | `boolean` |`true`
+| `--statePath` | The file path to create the state in. | `string` | `reducers` |
+| `--stateInterface` | The type literal of the defined interface for the state. | `string` | `State` |
 
 This command will automate the following steps:
 

--- a/projects/ngrx.io/content/guide/store/install.md
+++ b/projects/ngrx.io/content/guide/store/install.md
@@ -1,24 +1,8 @@
 # Installation
 
-## Installing with `npm`
-
-For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
-
-```sh
-npm install @ngrx/store --save
-```
-
-## Installing with `yarn`
-
-For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
-
-```sh
-yarn add @ngrx/store
-```
-
 ## Installing with `ng add`
 
-If your project is using the Angular CLI 6+ then you can install the Store to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
+You can install the Store to your project with the following `ng add` command <a href="https://angular.io/cli/add" target="_blank">(details here)</a>:
 
 ```sh
 ng add @ngrx/store@latest
@@ -50,3 +34,19 @@ This command will automate the following steps:
 3. Create a `src/app/reducers` folder, unless the `statePath` flag is provided, in which case this would be created based on the flag.
 4. Create a `src/app/reducers/index.ts` file with an empty `State` interface, an empty `reducers` map, and an empty `metaReducers` array. This may be created under a different directory if the `statePath` flag is provided.
 5. Update your `src/app/app.module.ts` > `imports` array with `StoreModule.forRoot(reducers, { metaReducers })`. If you provided flags then the command will attempt to locate and update module found by the flags.
+
+## Installing with `npm`
+
+For more information on using `npm` check out the docs <a href="https://docs.npmjs.com/cli/install" target="_blank">here</a>.
+
+```sh
+npm install @ngrx/store --save
+```
+
+## Installing with `yarn`
+
+For more information on using `yarn` check out the docs <a href="https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies" target="_blank">here</a>.
+
+```sh
+yarn add @ngrx/store
+```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

- The `ng add` command, which automatically makes useful changes to files related to the lib installation, is being shown after the `npm install` and `yarn install` commands.
- The optional flags are displayed as a list.

Closes #3434

## What is the new behavior?

- The `ng add` command is the first option in the installation guides.
- The optional flags are displayed in a markdown datatable.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

### Screenshot example

![ng-add](https://user-images.githubusercontent.com/13375865/170797110-a1d42544-948f-4654-a489-9e58e1c0a0dc.gif)
