### PR TITLE
feat(component): add ability to pass non-observable values & fix types

### DIFF
--- a/modules/component/spec/core/potential-observable.spec.ts
+++ b/modules/component/spec/core/potential-observable.spec.ts
@@ -11,30 +11,30 @@ describe('fromPotentialObservable', () => {
     };
   }
 
-  function testNullishInput(input: null | undefined): void {
-    it(`should create observable from ${input}`, () => {
+  function testNonObservableInput(input: any, label = input): void {
+    it(`should create observable from ${label}`, () => {
       const { testScheduler } = setup();
 
       testScheduler.run(({ expectObservable }) => {
         const obs$ = fromPotentialObservable(input);
-        expectObservable(obs$).toBe('(x|)', { x: input });
+        expectObservable(obs$).toBe('x', { x: input });
       });
     });
   }
 
-  testNullishInput(null);
+  testNonObservableInput(null);
 
-  testNullishInput(undefined);
+  testNonObservableInput(undefined);
 
-  it('should create observable from array', () => {
-    const { testScheduler } = setup();
-    const array = [1, 2, 3];
+  testNonObservableInput(100, 'number');
 
-    testScheduler.run(({ expectObservable }) => {
-      const obs$ = fromPotentialObservable(array);
-      expectObservable(obs$).toBe('(xyz|)', { x: 1, y: 2, z: 3 });
-    });
-  });
+  testNonObservableInput('ngrx', 'string');
+
+  testNonObservableInput(true, 'boolean');
+
+  testNonObservableInput({ ngrx: 'component' }, 'object');
+
+  testNonObservableInput([1, 2, 3], 'array');
 
   it('should create observable from promise', (done) => {
     const promise = Promise.resolve(100);

--- a/modules/component/spec/helpers.ts
+++ b/modules/component/spec/helpers.ts
@@ -1,0 +1,7 @@
+export function stripSpaces(str: string): string {
+  return str.replace(/[\n\r\s]+/g, '');
+}
+
+export function wrapWithSpace(str: string): string {
+  return ' ' + str + ' ';
+}

--- a/modules/component/spec/push/push.pipe.spec.ts
+++ b/modules/component/spec/push/push.pipe.spec.ts
@@ -6,34 +6,23 @@ import {
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
-import {
-  BehaviorSubject,
-  EMPTY,
-  NEVER,
-  Observable,
-  ObservableInput,
-  of,
-  throwError,
-} from 'rxjs';
+import { BehaviorSubject, EMPTY, NEVER, of, throwError } from 'rxjs';
 import { PushPipe } from '../../src/push/push.pipe';
 import { MockChangeDetectorRef, MockErrorHandler } from '../fixtures/fixtures';
+import { stripSpaces, wrapWithSpace } from '../helpers';
 
 let pushPipe: PushPipe;
-
-function wrapWithSpace(str: string): string {
-  return ' ' + str + ' ';
-}
 
 @Component({
   template: ` {{ (value$ | ngrxPush | json) || 'undefined' }} `,
 })
 class PushPipeTestComponent {
-  value$: Observable<number> = of(42);
+  value$: unknown = of(42);
 }
 
 let fixturePushPipeTestComponent: ComponentFixture<PushPipeTestComponent>;
 let pushPipeTestComponent: {
-  value$: ObservableInput<any> | undefined | null;
+  value$: unknown;
 };
 let componentNativeElement: any;
 
@@ -63,6 +52,28 @@ describe('PushPipe', () => {
 
       it('should return null as value when initially null was passed (as no value ever was emitted)', () => {
         expect(pushPipe.transform(null)).toBe(null);
+      });
+
+      it('should return initially passed number', () => {
+        expect(pushPipe.transform(10)).toBe(10);
+      });
+
+      it('should return initially passed string', () => {
+        expect(pushPipe.transform('ngrx')).toBe('ngrx');
+      });
+
+      it('should return initially passed boolean', () => {
+        expect(pushPipe.transform(true)).toBe(true);
+      });
+
+      it('should return initially passed object', () => {
+        const obj = { ngrx: 'component' };
+        expect(pushPipe.transform(obj)).toBe(obj);
+      });
+
+      it('should return initially passed array', () => {
+        const arr = [1, 2, 3];
+        expect(pushPipe.transform(arr)).toBe(arr);
       });
 
       it('should return undefined as value when initially of(undefined) was passed (as undefined was emitted)', () => {
@@ -113,6 +124,16 @@ describe('PushPipe', () => {
         expect(pushPipe.transform(of(10))).toBe(10);
         expect(pushPipe.transform(throwError(() => 'ERROR!'))).toBe(undefined);
       });
+
+      it('should return non-observable value when it was passed after observable', () => {
+        expect(pushPipe.transform(of('ngrx'))).toBe('ngrx');
+        expect(pushPipe.transform('component')).toBe('component');
+      });
+
+      it('should return non-observable value when it was passed after another non-observable', () => {
+        expect(pushPipe.transform(100)).toBe(100);
+        expect(pushPipe.transform('ngrx')).toBe('ngrx');
+      });
     });
   });
 
@@ -137,7 +158,7 @@ describe('PushPipe', () => {
     });
 
     describe('transform function', () => {
-      it('should return undefined as value when initially undefined was passed (as no value ever was emitted)', () => {
+      it('should render undefined as value when initially undefined was passed (as no value ever was emitted)', () => {
         pushPipeTestComponent.value$ = undefined;
         fixturePushPipeTestComponent.detectChanges();
         expect(componentNativeElement.textContent).toBe(
@@ -145,13 +166,47 @@ describe('PushPipe', () => {
         );
       });
 
-      it('should return null as value when initially null was passed (as no value ever was emitted)', () => {
+      it('should render null as value when initially null was passed (as no value ever was emitted)', () => {
         pushPipeTestComponent.value$ = null;
         fixturePushPipeTestComponent.detectChanges();
         expect(componentNativeElement.textContent).toBe(wrapWithSpace('null'));
       });
 
-      it('should return undefined as value when initially of(undefined) was passed (as undefined was emitted)', () => {
+      it('should render initially passed number', () => {
+        pushPipeTestComponent.value$ = 1000;
+        fixturePushPipeTestComponent.detectChanges();
+        expect(componentNativeElement.textContent).toBe(wrapWithSpace('1000'));
+      });
+
+      it('should render initially passed string', () => {
+        pushPipeTestComponent.value$ = 'ngrx';
+        fixturePushPipeTestComponent.detectChanges();
+        expect(componentNativeElement.textContent).toBe(
+          wrapWithSpace('"ngrx"')
+        );
+      });
+
+      it('should render initially passed boolean', () => {
+        pushPipeTestComponent.value$ = true;
+        fixturePushPipeTestComponent.detectChanges();
+        expect(componentNativeElement.textContent).toBe(wrapWithSpace('true'));
+      });
+
+      it('should render initially passed object', () => {
+        pushPipeTestComponent.value$ = { ngrx: 'component' };
+        fixturePushPipeTestComponent.detectChanges();
+        expect(stripSpaces(componentNativeElement.textContent)).toBe(
+          '{"ngrx":"component"}'
+        );
+      });
+
+      it('should render initially passed array', () => {
+        pushPipeTestComponent.value$ = [1, 2, 3];
+        fixturePushPipeTestComponent.detectChanges();
+        expect(stripSpaces(componentNativeElement.textContent)).toBe('[1,2,3]');
+      });
+
+      it('should render undefined as value when initially of(undefined) was passed (as undefined was emitted)', () => {
         pushPipeTestComponent.value$ = of(undefined);
         fixturePushPipeTestComponent.detectChanges();
         expect(componentNativeElement.textContent).toBe(
@@ -159,13 +214,13 @@ describe('PushPipe', () => {
         );
       });
 
-      it('should return null as value when initially of(null) was passed (as null was emitted)', () => {
+      it('should render null as value when initially of(null) was passed (as null was emitted)', () => {
         pushPipeTestComponent.value$ = of(null);
         fixturePushPipeTestComponent.detectChanges();
         expect(componentNativeElement.textContent).toBe(wrapWithSpace('null'));
       });
 
-      it('should return undefined as value when initially EMPTY was passed (as no value ever was emitted)', () => {
+      it('should render undefined as value when initially EMPTY was passed (as no value ever was emitted)', () => {
         pushPipeTestComponent.value$ = EMPTY;
         fixturePushPipeTestComponent.detectChanges();
         expect(componentNativeElement.textContent).toBe(
@@ -173,7 +228,7 @@ describe('PushPipe', () => {
         );
       });
 
-      it('should return undefined as value when initially NEVER was passed (as no value ever was emitted)', () => {
+      it('should render undefined as value when initially NEVER was passed (as no value ever was emitted)', () => {
         pushPipeTestComponent.value$ = NEVER;
         fixturePushPipeTestComponent.detectChanges();
         expect(componentNativeElement.textContent).toBe(
@@ -196,13 +251,13 @@ describe('PushPipe', () => {
         expect(errorHandler.handleError).toHaveBeenCalledWith('ERROR!');
       });
 
-      it('should emitted value from passed observable without changing it', () => {
+      it('should render emitted value from passed observable without changing it', () => {
         pushPipeTestComponent.value$ = of(42);
         fixturePushPipeTestComponent.detectChanges();
         expect(componentNativeElement.textContent).toBe(wrapWithSpace('42'));
       });
 
-      it('should emitted value from passed promise without changing it', fakeAsync(() => {
+      it('should render emitted value from passed promise without changing it', fakeAsync(() => {
         pushPipeTestComponent.value$ = Promise.resolve(42);
         fixturePushPipeTestComponent.detectChanges();
         flushMicrotasks();
@@ -210,7 +265,7 @@ describe('PushPipe', () => {
         expect(componentNativeElement.textContent).toBe(wrapWithSpace('42'));
       }));
 
-      it('should return undefined as value when a new observable NEVER was passed (as no value ever was emitted from new observable)', () => {
+      it('should render undefined as value when a new observable NEVER was passed (as no value ever was emitted from new observable)', () => {
         pushPipeTestComponent.value$ = of(42);
         fixturePushPipeTestComponent.detectChanges();
         expect(componentNativeElement.textContent).toBe(wrapWithSpace('42'));
@@ -240,6 +295,28 @@ describe('PushPipe', () => {
         expect(componentNativeElement.textContent).toBe(
           wrapWithSpace('undefined')
         );
+      });
+
+      it('should render non-observable value when it was passed after observable', () => {
+        pushPipeTestComponent.value$ = of('ngrx');
+        fixturePushPipeTestComponent.detectChanges();
+        expect(componentNativeElement.textContent).toBe(
+          wrapWithSpace('"ngrx"')
+        );
+        pushPipeTestComponent.value$ = 'component';
+        fixturePushPipeTestComponent.detectChanges();
+        expect(componentNativeElement.textContent).toBe(
+          wrapWithSpace('"component"')
+        );
+      });
+
+      it('should return non-observable value when it was passed after another non-observable', () => {
+        pushPipeTestComponent.value$ = 10;
+        fixturePushPipeTestComponent.detectChanges();
+        expect(componentNativeElement.textContent).toBe(wrapWithSpace('10'));
+        pushPipeTestComponent.value$ = 100;
+        fixturePushPipeTestComponent.detectChanges();
+        expect(componentNativeElement.textContent).toBe(wrapWithSpace('100'));
       });
     });
   });

--- a/modules/component/spec/types/let.directive.types.spec.ts
+++ b/modules/component/spec/types/let.directive.types.spec.ts
@@ -1,0 +1,80 @@
+import { potentialObservableExpecter } from './utils';
+
+describe('LetDirective', () => {
+  const expectPotentialObservable = potentialObservableExpecter(
+    (potentialObservableType) => `
+      import { Observable } from 'rxjs';
+      import { LetDirective } from '@ngrx/component';
+
+      const directive = {} as LetDirective<${potentialObservableType}>;
+      const ctx = {};
+
+      if (LetDirective.ngTemplateContextGuard(directive, ctx)) {
+        const value = ctx.$implicit;
+      }
+    `
+  );
+
+  it('should infer the value when potential observable is a non-observable', () => {
+    expectPotentialObservable('number').toBeInferredAs('number');
+    expectPotentialObservable('null').toBeInferredAs('null');
+    expectPotentialObservable('string[]').toBeInferredAs('string[]');
+    expectPotentialObservable('{ ngrx: boolean; }').toBeInferredAs(
+      '{ ngrx: boolean; }'
+    );
+  });
+
+  it('should infer the value when potential observable is a union of non-observables', () => {
+    expectPotentialObservable(
+      'string | { ngrx: boolean; } | null'
+    ).toBeInferredAs('string | { ngrx: boolean; } | null');
+  });
+
+  it('should infer the value when potential observable is a promise', () => {
+    expectPotentialObservable('Promise<{ ngrx: number; }>').toBeInferredAs(
+      '{ ngrx: number; }'
+    );
+  });
+
+  it('should infer the value when potential observable is a union of promises', () => {
+    expectPotentialObservable(
+      'Promise<string> | Promise<boolean | { ngrx: number; }>'
+    ).toBeInferredAs('string | boolean | { ngrx: number; }');
+  });
+
+  it('should infer the value when potential observable is a union of promise and non-observable', () => {
+    expectPotentialObservable(
+      'Promise<{ ngrx: string; }> | number[] | null'
+    ).toBeInferredAs('{ ngrx: string; } | number[] | null');
+  });
+
+  it('should infer the value when potential observable is an observable', () => {
+    expectPotentialObservable(
+      'Observable<{ component: boolean; }>'
+    ).toBeInferredAs('{ component: boolean; }');
+  });
+
+  it('should infer the value when potential observable is a union of observables', () => {
+    expectPotentialObservable(
+      'Observable<string> | Observable<{ ngrx: number; } | null>'
+    ).toBeInferredAs('string | { ngrx: number; } | null');
+  });
+
+  it('should infer the value when potential observable is a union of observable and promise', () => {
+    expectPotentialObservable(
+      'Observable<{ component: number; }> | Promise<string | undefined>'
+    ).toBeInferredAs('string | { component: number; } | undefined');
+  });
+
+  it('should infer the value when potential observable is a union of observable and non-observable', () => {
+    expectPotentialObservable(
+      'Observable<Record<string, unknown>> | boolean[] | undefined'
+    ).toBeInferredAs('Record<string, unknown> | boolean[] | undefined');
+  });
+
+  it('should infer the value when potential observable is a union of observable, promise, and non-observable', () => {
+    expectPotentialObservable(
+      'Observable<number> | Promise<{ ngrx: string; }> | boolean | null'
+    ).toBeInferredAs('number | boolean | { ngrx: string; } | null');
+  });
+});

--- a/modules/component/spec/types/push.pipe.types.spec.ts
+++ b/modules/component/spec/types/push.pipe.types.spec.ts
@@ -1,0 +1,77 @@
+import { potentialObservableExpecter } from './utils';
+
+describe('PushPipe', () => {
+  const expectPotentialObservable = potentialObservableExpecter(
+    (potentialObservableType) => `
+      import { Observable } from 'rxjs';
+      import { PushPipe } from '@ngrx/component';
+
+      const anyVal = {} as any;
+      const pushPipe = new PushPipe(anyVal, anyVal, anyVal);
+      const value = pushPipe.transform(anyVal as ${potentialObservableType});
+    `
+  );
+
+  it('should infer the result when potential observable is a non-observable', () => {
+    expectPotentialObservable('string').toBeInferredAs('string');
+    expectPotentialObservable('undefined').toBeInferredAs('undefined');
+    expectPotentialObservable('boolean[]').toBeInferredAs('boolean[]');
+    expectPotentialObservable(
+      '{ x: number; y: string; z: symbol; }'
+    ).toBeInferredAs('{ x: number; y: string; z: symbol; }');
+  });
+
+  it('should infer the result when potential observable is a union of non-observables', () => {
+    expectPotentialObservable('number | { x: symbol; } | null').toBeInferredAs(
+      'number | { x: symbol; } | null'
+    );
+  });
+
+  it('should infer the result when potential observable is a promise', () => {
+    expectPotentialObservable('Promise<string>').toBeInferredAs(
+      'string | undefined'
+    );
+  });
+
+  it('should infer the result when potential observable is a union of promises', () => {
+    expectPotentialObservable(
+      'Promise<{ y: number[]; }> | Promise<string | { z: boolean; }>'
+    ).toBeInferredAs('string | { y: number[]; } | { z: boolean; } | undefined');
+  });
+
+  it('should infer the result when potential observable is a union of promise and non-observable', () => {
+    expectPotentialObservable(
+      'Promise<string[]> | boolean[] | null'
+    ).toBeInferredAs('string[] | boolean[] | null | undefined');
+  });
+
+  it('should infer the result when potential observable is an observable', () => {
+    expectPotentialObservable('Observable<{ x: number; }>').toBeInferredAs(
+      '{ x: number; } | undefined'
+    );
+  });
+
+  it('should infer the result when potential observable is a union of observables', () => {
+    expectPotentialObservable(
+      'Observable<symbol> | Observable<{ z: string; }> | null'
+    ).toBeInferredAs('symbol | { z: string; } | null | undefined');
+  });
+
+  it('should infer the result when potential observable is a union of observable and promise', () => {
+    expectPotentialObservable(
+      'Observable<boolean> | Promise<string | undefined>'
+    ).toBeInferredAs('string | boolean | undefined');
+  });
+
+  it('should infer the result when potential observable is a union of observable and non-observable', () => {
+    expectPotentialObservable(
+      'Observable<number[]> | Record<string, unknown>'
+    ).toBeInferredAs('number[] | Record<string, unknown> | undefined');
+  });
+
+  it('should infer the result when potential observable is a union of observable, promise, and non-observable', () => {
+    expectPotentialObservable(
+      'Observable<{ z: symbol; }> | Promise<number[]> | boolean | null'
+    ).toBeInferredAs('boolean | { z: symbol; } | number[] | null | undefined');
+  });
+});

--- a/modules/component/spec/types/utils.ts
+++ b/modules/component/spec/types/utils.ts
@@ -1,0 +1,30 @@
+import { expecter } from 'ts-snippet';
+
+export const compilerOptions = () => ({
+  moduleResolution: 'node',
+  target: 'es2017',
+  baseUrl: '.',
+  experimentalDecorators: true,
+  strict: true,
+  paths: {
+    '@ngrx/component': ['./modules/component'],
+  },
+});
+
+export function potentialObservableExpecter(
+  snippetFactory: (potentialObservableType: string) => string
+) {
+  if (!snippetFactory('').includes('const value')) {
+    throw new Error('Snippet must include a constant named `value`!');
+  }
+
+  return (potentialObservableType: string) => {
+    const expectSnippet = expecter(snippetFactory, compilerOptions());
+
+    return {
+      toBeInferredAs(valueType: string): void {
+        expectSnippet(potentialObservableType).toInfer('value', valueType);
+      },
+    };
+  };
+}

--- a/modules/component/src/core/render-event/manager.ts
+++ b/modules/component/src/core/render-event/manager.ts
@@ -15,7 +15,6 @@ import {
 
 export interface RenderEventManager<T> {
   nextPotentialObservable(potentialObservable: PotentialObservable<T>): void;
-
   handlePotentialObservableChanges(): Observable<RenderEvent<T>>;
 }
 

--- a/modules/component/src/core/render-event/models.ts
+++ b/modules/component/src/core/render-event/models.ts
@@ -9,7 +9,7 @@ export interface ResetRenderEvent extends BaseRenderEvent {
 
 export interface NextRenderEvent<T> extends BaseRenderEvent {
   type: 'next';
-  value: T | null | undefined;
+  value: T;
 }
 
 export interface ErrorRenderEvent extends BaseRenderEvent {

--- a/modules/component/src/push/push.pipe.ts
+++ b/modules/component/src/push/push.pipe.ts
@@ -6,10 +6,14 @@ import {
   Pipe,
   PipeTransform,
 } from '@angular/core';
-import { ObservableInput, Unsubscribable } from 'rxjs';
-import { PotentialObservable } from '../core/potential-observable';
+import { Unsubscribable } from 'rxjs';
+import { ObservableOrPromise } from '../core/potential-observable';
 import { createRenderScheduler } from '../core/render-scheduler';
 import { createRenderEventManager } from '../core/render-event/manager';
+
+type PushPipeResult<PO> = PO extends ObservableOrPromise<infer R>
+  ? R | undefined
+  : PO;
 
 /**
  * @ngModule ReactiveComponentModule
@@ -66,14 +70,9 @@ export class PushPipe implements PipeTransform, OnDestroy {
       .subscribe();
   }
 
-  transform<T>(potentialObservable: null): null;
-  transform<T>(potentialObservable: undefined): undefined;
-  transform<T>(potentialObservable: ObservableInput<T>): T | undefined;
-  transform<T>(
-    potentialObservable: PotentialObservable<T>
-  ): T | null | undefined {
+  transform<PO>(potentialObservable: PO): PushPipeResult<PO> {
     this.renderEventManager.nextPotentialObservable(potentialObservable);
-    return this.renderedValue as T | null | undefined;
+    return this.renderedValue as PushPipeResult<PO>;
   }
 
   ngOnDestroy(): void {

--- a/projects/ngrx.io/content/guide/component/index.md
+++ b/projects/ngrx.io/content/guide/component/index.md
@@ -14,6 +14,7 @@ This package is still experimental and may change during development.
 
 - Rendering observable events in a performant way.
 - Displaying different content based on the current state of an observable.
+- Creating readable templates by using aliases for nested properties.
 - Building fully reactive Angular applications regardless of whether `zone.js` is present or not.
 
 ## Installation

--- a/projects/ngrx.io/content/guide/component/let.md
+++ b/projects/ngrx.io/content/guide/component/let.md
@@ -88,6 +88,22 @@ An observable is in a suspense state until it emits the first event (next, error
 In case a new observable is passed to the `*ngrxLet` directive at runtime,
 the suspense template will be displayed again until the new observable emits the first event.
 
+## Using Aliases for Non-Observable Values
+
+The `*ngrxLet` directive can also accept static (non-observable) values as input argument.
+This feature provides the ability to create readable templates by using aliases for deeply nested properties:
+
+```html
+<ng-container *ngrxLet="userForm.controls.email as email">
+  <input type="text" [formControl]="email" />
+
+  <ng-container *ngIf="email.errors && (email.touched || email.dirty)">
+    <p *ngIf="email.errors.required">This field is required.</p>
+    <p *ngIf="email.errors.email">This field must be an email.</p>
+  </ng-container>
+</ng-container>
+```
+
 ## Included Features
 
 - Binding is present even for falsy values.
@@ -95,6 +111,7 @@ the suspense template will be displayed again until the new observable emits the
 - Takes away the multiple usages of the `async` or `ngrxPush` pipe.
 - Allows displaying different content based on the current state of an observable.
 - Provides a unified/structured way of handling `null` and `undefined`.
+- Provides the ability to create readable templates by using aliases for nested properties.
 - Triggers the change detection differently if `zone.js` is present or not
   using `ChangeDetectorRef.markForCheck` or `ɵmarkDirty`.
 - Distinct the same values in a row for better performance.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3344, #3345

## What is the new behavior?

1. Added the ability to pass "non-observable" values to `LetDirective`/`PushPipe`. With this feature, we can create readable templates by using aliases for deeply nested properties:

```html
<ng-container *ngrxLet="userForm.controls.email as email">
  <input type="text" [formControl]="email" />

  <ng-container *ngIf="email.errors && (email.touched || email.dirty)">
    <p *ngIf="email.errors.required">This field is required.</p>
    <p *ngIf="email.errors.email">This field must be an email.</p>
  </ng-container>
</ng-container>
```

2. Fixed typing issues. With this feature, we can pass various unions of observables, promises, and static values to `LetDirective`/`PushPipe` and have strongly typed results in the template:

```html
<!-- value$: Observable<{ ngrx: string }> | Promise<number> | boolean[] | null -->

<!-- v: { ngrx: string } | number | boolean[] | null -->
<p *ngrxLet="value$ as v"></p>

<!-- v: { ngrx: string } | number | boolean[] | null | undefined -->
<p *ngIf="value$ | ngrxPush as v"></p>
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No

BREAKING CHANGES:

1. The context of `LetDirective` is strongly typed when `null` or
`undefined` is passed as input.

BEFORE:

<p *ngrxLet="null as n">{{ n }}</p>
<p *ngrxLet="undefined as u">{{ u }}</p>

- The type of `n` is `any`.
- The type of `u` is `any`.

AFTER:

<p *ngrxLet="null as n">{{ n }}</p>
<p *ngrxLet="undefined as u">{{ u }}</p>

- The type of `n` is `null`.
- The type of `u` is `undefined`.

---

2. Arrays, iterables, generator functions, and readable streams are
not treated as observable-like inputs anymore. To keep the same behavior
as in v13, convert the array/iterable/generator function/readable stream
to observable using the `from` function from the `rxjs` package
before passing it to the `LetDirective`/`PushPipe`.

BEFORE:

@Component({
  template: `
    <p *ngrxLet="numbers as n">{{ n }}</p>
    <p>{{ numbers | ngrxPush }}</p>
  `,
})
export class NumbersComponent {
  numbers = [1, 2, 3];
}

AFTER:

@Component({
  template: `
    <p *ngrxLet="numbers$ as n">{{ n }}</p>
    <p>{{ numbers$ | ngrxPush }}</p>
  `,
})
export class NumbersComponent {
  numbers$ = from([1, 2, 3]);
}
```
