### PR TITLE
fix(component): do not exclude falsy types from LetDirective's input type

### DIFF
--- a/modules/component/src/let/let.directive.ts
+++ b/modules/component/src/let/let.directive.ts
@@ -105,8 +105,6 @@ export interface LetViewContext<PO> {
  */
 @Directive({ selector: '[ngrxLet]' })
 export class LetDirective<PO> implements OnInit, OnDestroy {
-  static ngTemplateGuard_ngrxLet: 'binding';
-
   private isMainViewCreated = false;
   private isSuspenseViewCreated = false;
   private readonly viewContext: LetViewContext<PO | undefined> = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

If we pass the property that contains falsy types to the `LetDirective` as follows:

```ts
@Component({
  selector: 'app-foo',
  template: `
    <div *ngrxLet="prop as alias">
      {{ prop }}
      {{ alias }}
    </div>
  `,
})
export class FooComponent {
  prop: Observable<string> | null | false = of('marko');
}
```

The type of `prop` within the embedded template will be `Observable<string>` (falsy types are excluded).
Fortunately, the type of the `alias` variable is correctly inferred (`string | null | false`).

## What is the new behavior?

The type of both `alias` and `prop` is correctly inferred:

- `prop: Observable<string> | null | false`
- `alias: string | null | false`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
