### PR TITLE
fix(component): import operators from rxjs/operators

### DIFF
--- a/modules/component/src/core/render-event/manager.ts
+++ b/modules/component/src/core/render-event/manager.ts
@@ -1,11 +1,5 @@
-import {
-  distinctUntilChanged,
-  Observable,
-  pipe,
-  ReplaySubject,
-  switchMap,
-  tap,
-} from 'rxjs';
+import { Observable, pipe, ReplaySubject } from 'rxjs';
+import { distinctUntilChanged, switchMap, tap } from 'rxjs/operators';
 import { ErrorRenderEvent, NextRenderEvent, RenderEvent } from './models';
 import { combineRenderEventHandlers, RenderEventHandlers } from './handlers';
 import {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Related to #3464 & #3465
Import RxJS operators from `rxjs/operators` instead of `rxjs`. Otherwise the build fails with latest rxjs v6.

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
