### PR TITLE
perf(component): do not schedule render for synchronous events

### DIFF
--- a/modules/component/spec/core/render-event/handlers.spec.ts
+++ b/modules/component/spec/core/render-event/handlers.spec.ts
@@ -30,7 +30,7 @@ describe('combineRenderEventHandlers', () => {
   const suspenseEvent: SuspenseRenderEvent = {
     type: 'suspense',
     reset: true,
-    sync: true,
+    synchronous: true,
   };
   testRenderEvent(suspenseEvent);
 
@@ -38,7 +38,7 @@ describe('combineRenderEventHandlers', () => {
     type: 'next',
     value: 1,
     reset: true,
-    sync: false,
+    synchronous: false,
   };
   testRenderEvent(nextEvent);
 
@@ -46,14 +46,14 @@ describe('combineRenderEventHandlers', () => {
     type: 'error',
     error: 'ERROR!',
     reset: false,
-    sync: true,
+    synchronous: true,
   };
   testRenderEvent(errorEvent);
 
   const completeEvent: CompleteRenderEvent = {
     type: 'complete',
     reset: false,
-    sync: false,
+    synchronous: false,
   };
   testRenderEvent(completeEvent);
 });

--- a/modules/component/spec/core/render-event/handlers.spec.ts
+++ b/modules/component/spec/core/render-event/handlers.spec.ts
@@ -30,6 +30,7 @@ describe('combineRenderEventHandlers', () => {
   const suspenseEvent: SuspenseRenderEvent = {
     type: 'suspense',
     reset: true,
+    sync: true,
   };
   testRenderEvent(suspenseEvent);
 
@@ -37,6 +38,7 @@ describe('combineRenderEventHandlers', () => {
     type: 'next',
     value: 1,
     reset: true,
+    sync: false,
   };
   testRenderEvent(nextEvent);
 
@@ -44,12 +46,14 @@ describe('combineRenderEventHandlers', () => {
     type: 'error',
     error: 'ERROR!',
     reset: false,
+    sync: true,
   };
   testRenderEvent(errorEvent);
 
   const completeEvent: CompleteRenderEvent = {
     type: 'complete',
     reset: false,
+    sync: false,
   };
   testRenderEvent(completeEvent);
 });

--- a/modules/component/spec/core/render-event/manager.spec.ts
+++ b/modules/component/spec/core/render-event/manager.spec.ts
@@ -46,11 +46,11 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
       });
 
-      it('should call next handler with sync and without reset flag when another value is emitted synchronously', () => {
+      it('should call next handler with synchronous and without reset flag when another value is emitted synchronously', () => {
         const { renderEventManager, nextHandler } = setup<string>();
 
         renderEventManager.nextPotentialObservable(of('angular', 'ngrx'));
@@ -58,18 +58,18 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'angular',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler.mock.calls[1][0]).toEqual({
           type: 'next',
           value: 'ngrx',
           reset: false,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler).toHaveBeenCalledTimes(2);
       });
 
-      it('should call next handler without reset and sync flags when another value is emitted asynchronously', () => {
+      it('should call next handler without reset and synchronous flags when another value is emitted asynchronously', () => {
         const { renderEventManager, nextHandler } = setup<string>();
         const subject = new BehaviorSubject('ngrx');
 
@@ -80,13 +80,13 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler.mock.calls[1][0]).toEqual({
           type: 'next',
           value: 'angular',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
         expect(nextHandler).toHaveBeenCalledTimes(2);
       });
@@ -101,13 +101,13 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler.mock.calls[1][0]).toEqual({
           type: 'next',
           value: 'component',
           reset: false,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler).toHaveBeenCalledTimes(2);
       });
@@ -126,13 +126,13 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'angular',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler.mock.calls[1][0]).toEqual({
           type: 'next',
           value: 'ngrx/component',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
         expect(nextHandler).toHaveBeenCalledTimes(2);
       }));
@@ -152,18 +152,18 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler.mock.calls[1][0]).toEqual({
           type: 'next',
           value: 'component',
           reset: false,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler).toHaveBeenCalledTimes(2);
       }));
 
-      it('should call error handler with reset and sync flags when error is emitted', () => {
+      it('should call error handler with reset and synchronous flags when error is emitted', () => {
         const { renderEventManager, errorHandler } = setup<number>();
 
         renderEventManager.nextPotentialObservable(throwError(() => 'ERROR!'));
@@ -171,11 +171,11 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
       });
 
-      it('should call error handler with sync and without reset flag when error is emitted synchronously as second event', () => {
+      it('should call error handler with synchronous and without reset flag when error is emitted synchronously as second event', () => {
         const { renderEventManager, errorHandler, nextHandler } =
           setup<number>();
 
@@ -190,20 +190,20 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 1,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(errorHandler).toHaveBeenCalledWith({
           type: 'error',
           error: 'ERROR!!!',
           reset: false,
-          sync: true,
+          synchronous: true,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
         expect(errorHandler).toHaveBeenCalledTimes(1);
       });
 
-      it('should call error handler without reset and sync flags when error is emitted asynchronously as second event', () => {
+      it('should call error handler without reset and synchronous flags when error is emitted asynchronously as second event', () => {
         const { renderEventManager, errorHandler, nextHandler } =
           setup<number>();
         const subject = new BehaviorSubject(100);
@@ -215,31 +215,31 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 100,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(errorHandler).toHaveBeenCalledWith({
           type: 'error',
           error: 'ERROR!',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
         expect(errorHandler).toHaveBeenCalledTimes(1);
       });
 
-      it('should call complete handler with reset and sync flags when complete is emitted', () => {
+      it('should call complete handler with reset and synchronous flags when complete is emitted', () => {
         const { renderEventManager, completeHandler } = setup<boolean>();
 
         renderEventManager.nextPotentialObservable(EMPTY);
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
       });
 
-      it('should call complete handler with sync and without reset flag when complete is emitted synchronously as second event', () => {
+      it('should call complete handler with synchronous and without reset flag when complete is emitted synchronously as second event', () => {
         const { renderEventManager, nextHandler, completeHandler } =
           setup<number>();
 
@@ -249,19 +249,19 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 100,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
-          sync: true,
+          synchronous: true,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
         expect(completeHandler).toHaveBeenCalledTimes(1);
       });
 
-      it('should call complete handler without reset and sync flags when complete is emitted asynchronously as second event', () => {
+      it('should call complete handler without reset and synchronous flags when complete is emitted asynchronously as second event', () => {
         const { renderEventManager, nextHandler, completeHandler } =
           setup<boolean>();
         const subject = new BehaviorSubject(true);
@@ -273,12 +273,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: true,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
@@ -296,7 +296,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler).not.toHaveBeenCalled();
 
@@ -306,7 +306,7 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
       }));
 
@@ -321,7 +321,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(errorHandler).not.toHaveBeenCalled();
 
@@ -331,7 +331,7 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
       }));
 
@@ -346,7 +346,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(completeHandler).not.toHaveBeenCalled();
 
@@ -355,7 +355,7 @@ describe('createRenderEventManager', () => {
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
       }));
     });
@@ -368,7 +368,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
       });
     });
@@ -383,7 +383,7 @@ describe('createRenderEventManager', () => {
     }
 
     describe('that emits first event synchronously', () => {
-      it('should call next handler with reset and sync flags when first value is emitted', () => {
+      it('should call next handler with reset and synchronous flags when first value is emitted', () => {
         const {
           renderEventManager,
           nextHandler,
@@ -398,7 +398,7 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
 
         // next observable
@@ -406,12 +406,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 100,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
-          sync: true,
+          synchronous: true,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
@@ -419,7 +419,7 @@ describe('createRenderEventManager', () => {
         expect(completeHandler).toHaveBeenCalledTimes(1);
       });
 
-      it('should call next handler with sync and without reset flag when another value is emitted synchronously', () => {
+      it('should call next handler with synchronous and without reset flag when another value is emitted synchronously', () => {
         const { renderEventManager, nextHandler } = withNextObservableSetup(
           new BehaviorSubject(1)
         );
@@ -436,7 +436,7 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 1,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
 
         // next observable
@@ -444,19 +444,19 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 10,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler.mock.calls[2][0]).toEqual({
           type: 'next',
           value: 100,
           reset: false,
-          sync: true,
+          synchronous: true,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(3);
       });
 
-      it('should call next handler without reset and sync flags when another value is emitted asynchronously', () => {
+      it('should call next handler without reset and synchronous flags when another value is emitted asynchronously', () => {
         const { renderEventManager, nextHandler } = withNextObservableSetup(
           new BehaviorSubject(1)
         );
@@ -470,7 +470,7 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 1,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
 
         // next observable
@@ -478,13 +478,13 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 10,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler.mock.calls[2][0]).toEqual({
           type: 'next',
           value: 100,
           reset: false,
-          sync: false,
+          synchronous: false,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(3);
@@ -501,12 +501,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 100,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler).toHaveBeenCalledTimes(1);
       });
 
-      it('should call error handler with reset and sync flags when error is emitted', () => {
+      it('should call error handler with reset and synchronous flags when error is emitted', () => {
         const {
           renderEventManager,
           nextHandler,
@@ -521,12 +521,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 200,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
-          sync: true,
+          synchronous: true,
         });
 
         // next observable
@@ -534,7 +534,7 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
@@ -554,7 +554,7 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'SAME_ERROR!',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(errorHandler).toHaveBeenCalledTimes(1);
       });
@@ -570,19 +570,19 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 1,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(completeHandler.mock.calls[0][0]).toEqual({
           type: 'complete',
           reset: false,
-          sync: true,
+          synchronous: true,
         });
 
         // next observable
         expect(completeHandler.mock.calls[1][0]).toEqual({
           type: 'complete',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
 
         expect(completeHandler).toHaveBeenCalledTimes(2);
@@ -597,7 +597,7 @@ describe('createRenderEventManager', () => {
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(completeHandler).toHaveBeenCalledTimes(1);
       });
@@ -617,14 +617,14 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
 
         // next observable
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(nextHandler.mock.calls[1]).not.toBeDefined();
 
@@ -634,7 +634,7 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'component',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
 
         expect(suspenseHandler).toHaveBeenCalledTimes(1);
@@ -658,14 +658,14 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx/component',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
 
         // next observable
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(errorHandler).not.toHaveBeenCalled();
 
@@ -675,7 +675,7 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
 
         expect(suspenseHandler).toHaveBeenCalledTimes(1);
@@ -700,14 +700,14 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: false,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
 
         // next observable
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(completeHandler).not.toHaveBeenCalled();
 
@@ -716,7 +716,7 @@ describe('createRenderEventManager', () => {
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
-          sync: false,
+          synchronous: false,
         });
 
         expect(suspenseHandler).toHaveBeenCalledTimes(1);
@@ -735,12 +735,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 10,
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
       });
 
@@ -753,7 +753,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
-          sync: true,
+          synchronous: true,
         });
         expect(suspenseHandler).toHaveBeenCalledTimes(1);
       });

--- a/modules/component/spec/core/render-event/manager.spec.ts
+++ b/modules/component/spec/core/render-event/manager.spec.ts
@@ -3,6 +3,7 @@ import {
   BehaviorSubject,
   delay,
   EMPTY,
+  merge,
   NEVER,
   Observable,
   of,
@@ -45,10 +46,30 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: true,
+          sync: true,
         });
       });
 
-      it('should call next handler without reset flag when another value is emitted', () => {
+      it('should call next handler with sync and without reset flag when another value is emitted synchronously', () => {
+        const { renderEventManager, nextHandler } = setup<string>();
+
+        renderEventManager.nextPotentialObservable(of('angular', 'ngrx'));
+        expect(nextHandler.mock.calls[0][0]).toEqual({
+          type: 'next',
+          value: 'angular',
+          reset: true,
+          sync: true,
+        });
+        expect(nextHandler.mock.calls[1][0]).toEqual({
+          type: 'next',
+          value: 'ngrx',
+          reset: false,
+          sync: true,
+        });
+        expect(nextHandler).toHaveBeenCalledTimes(2);
+      });
+
+      it('should call next handler without reset and sync flags when another value is emitted asynchronously', () => {
         const { renderEventManager, nextHandler } = setup<string>();
         const subject = new BehaviorSubject('ngrx');
 
@@ -59,16 +80,39 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: true,
+          sync: true,
         });
         expect(nextHandler.mock.calls[1][0]).toEqual({
           type: 'next',
           value: 'angular',
           reset: false,
+          sync: false,
         });
         expect(nextHandler).toHaveBeenCalledTimes(2);
       });
 
-      it('should not call next handler second time when same value is emitted twice', fakeAsync(() => {
+      it('should not call next handler second time when same value is emitted twice synchronously', () => {
+        const { renderEventManager, nextHandler } = setup<string>();
+
+        renderEventManager.nextPotentialObservable(
+          of('ngrx', 'component', 'component')
+        );
+        expect(nextHandler.mock.calls[0][0]).toEqual({
+          type: 'next',
+          value: 'ngrx',
+          reset: true,
+          sync: true,
+        });
+        expect(nextHandler.mock.calls[1][0]).toEqual({
+          type: 'next',
+          value: 'component',
+          reset: false,
+          sync: true,
+        });
+        expect(nextHandler).toHaveBeenCalledTimes(2);
+      });
+
+      it('should not call next handler second time when same value is emitted twice asynchronously', fakeAsync(() => {
         const { renderEventManager, nextHandler } = setup<string>();
         const subject = new BehaviorSubject('angular');
 
@@ -82,16 +126,44 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'angular',
           reset: true,
+          sync: true,
         });
         expect(nextHandler.mock.calls[1][0]).toEqual({
           type: 'next',
           value: 'ngrx/component',
           reset: false,
+          sync: false,
         });
         expect(nextHandler).toHaveBeenCalledTimes(2);
       }));
 
-      it('should call error handler with reset flag when error is emitted', () => {
+      it('should not call next handler second time when same value is emitted first synchronously then asynchronously', fakeAsync(() => {
+        const { renderEventManager, nextHandler } = setup<string>();
+
+        renderEventManager.nextPotentialObservable(
+          merge(
+            of('ngrx', 'component'),
+            timer(10).pipe(switchMap(() => of('component')))
+          )
+        );
+        tick(10);
+
+        expect(nextHandler.mock.calls[0][0]).toEqual({
+          type: 'next',
+          value: 'ngrx',
+          reset: true,
+          sync: true,
+        });
+        expect(nextHandler.mock.calls[1][0]).toEqual({
+          type: 'next',
+          value: 'component',
+          reset: false,
+          sync: true,
+        });
+        expect(nextHandler).toHaveBeenCalledTimes(2);
+      }));
+
+      it('should call error handler with reset and sync flags when error is emitted', () => {
         const { renderEventManager, errorHandler } = setup<number>();
 
         renderEventManager.nextPotentialObservable(throwError(() => 'ERROR!'));
@@ -99,10 +171,39 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: true,
+          sync: true,
         });
       });
 
-      it('should call error handler without reset flag when error is emitted as second event', () => {
+      it('should call error handler with sync and without reset flag when error is emitted synchronously as second event', () => {
+        const { renderEventManager, errorHandler, nextHandler } =
+          setup<number>();
+
+        renderEventManager.nextPotentialObservable(
+          new Observable<number>((subscriber) => {
+            subscriber.next(1);
+            subscriber.error('ERROR!!!');
+          })
+        );
+
+        expect(nextHandler).toHaveBeenCalledWith({
+          type: 'next',
+          value: 1,
+          reset: true,
+          sync: true,
+        });
+        expect(errorHandler).toHaveBeenCalledWith({
+          type: 'error',
+          error: 'ERROR!!!',
+          reset: false,
+          sync: true,
+        });
+
+        expect(nextHandler).toHaveBeenCalledTimes(1);
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+      });
+
+      it('should call error handler without reset and sync flags when error is emitted asynchronously as second event', () => {
         const { renderEventManager, errorHandler, nextHandler } =
           setup<number>();
         const subject = new BehaviorSubject(100);
@@ -114,28 +215,53 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 100,
           reset: true,
+          sync: true,
         });
         expect(errorHandler).toHaveBeenCalledWith({
           type: 'error',
           error: 'ERROR!',
           reset: false,
+          sync: false,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
         expect(errorHandler).toHaveBeenCalledTimes(1);
       });
 
-      it('should call complete handler with reset flag when complete is emitted', () => {
+      it('should call complete handler with reset and sync flags when complete is emitted', () => {
         const { renderEventManager, completeHandler } = setup<boolean>();
 
         renderEventManager.nextPotentialObservable(EMPTY);
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: true,
+          sync: true,
         });
       });
 
-      it('should call complete handler without reset flag when complete is emitted as second event', () => {
+      it('should call complete handler with sync and without reset flag when complete is emitted synchronously as second event', () => {
+        const { renderEventManager, nextHandler, completeHandler } =
+          setup<number>();
+
+        renderEventManager.nextPotentialObservable(of(100));
+
+        expect(nextHandler).toHaveBeenCalledWith({
+          type: 'next',
+          value: 100,
+          reset: true,
+          sync: true,
+        });
+        expect(completeHandler).toHaveBeenCalledWith({
+          type: 'complete',
+          reset: false,
+          sync: true,
+        });
+
+        expect(nextHandler).toHaveBeenCalledTimes(1);
+        expect(completeHandler).toHaveBeenCalledTimes(1);
+      });
+
+      it('should call complete handler without reset and sync flags when complete is emitted asynchronously as second event', () => {
         const { renderEventManager, nextHandler, completeHandler } =
           setup<boolean>();
         const subject = new BehaviorSubject(true);
@@ -147,10 +273,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: true,
           reset: true,
+          sync: true,
         });
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
+          sync: false,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
@@ -168,6 +296,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
+          sync: true,
         });
         expect(nextHandler).not.toHaveBeenCalled();
 
@@ -177,6 +306,7 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: false,
+          sync: false,
         });
       }));
 
@@ -191,6 +321,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
+          sync: true,
         });
         expect(errorHandler).not.toHaveBeenCalled();
 
@@ -200,10 +331,11 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: false,
+          sync: false,
         });
       }));
 
-      it('should call complete handler immediately and error handler when error is emitted', fakeAsync(() => {
+      it('should call suspense handler immediately and complete handler when complete is emitted', fakeAsync(() => {
         const { renderEventManager, suspenseHandler, completeHandler } =
           setup<boolean>();
 
@@ -214,6 +346,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
+          sync: true,
         });
         expect(completeHandler).not.toHaveBeenCalled();
 
@@ -222,6 +355,7 @@ describe('createRenderEventManager', () => {
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
+          sync: false,
         });
       }));
     });
@@ -234,6 +368,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
+          sync: true,
         });
       });
     });
@@ -248,7 +383,7 @@ describe('createRenderEventManager', () => {
     }
 
     describe('that emits first event synchronously', () => {
-      it('should call next handler with reset flag when first value is emitted', () => {
+      it('should call next handler with reset and sync flags when first value is emitted', () => {
         const {
           renderEventManager,
           nextHandler,
@@ -263,6 +398,7 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: true,
+          sync: true,
         });
 
         // next observable
@@ -270,10 +406,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 100,
           reset: true,
+          sync: true,
         });
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
+          sync: true,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
@@ -281,7 +419,44 @@ describe('createRenderEventManager', () => {
         expect(completeHandler).toHaveBeenCalledTimes(1);
       });
 
-      it('should call next handler without reset flag when another value is emitted', () => {
+      it('should call next handler with sync and without reset flag when another value is emitted synchronously', () => {
+        const { renderEventManager, nextHandler } = withNextObservableSetup(
+          new BehaviorSubject(1)
+        );
+
+        renderEventManager.nextPotentialObservable(
+          new Observable((subscriber) => {
+            subscriber.next(10);
+            subscriber.next(100);
+          })
+        );
+
+        // first observable
+        expect(nextHandler.mock.calls[0][0]).toEqual({
+          type: 'next',
+          value: 1,
+          reset: true,
+          sync: true,
+        });
+
+        // next observable
+        expect(nextHandler.mock.calls[1][0]).toEqual({
+          type: 'next',
+          value: 10,
+          reset: true,
+          sync: true,
+        });
+        expect(nextHandler.mock.calls[2][0]).toEqual({
+          type: 'next',
+          value: 100,
+          reset: false,
+          sync: true,
+        });
+
+        expect(nextHandler).toHaveBeenCalledTimes(3);
+      });
+
+      it('should call next handler without reset and sync flags when another value is emitted asynchronously', () => {
         const { renderEventManager, nextHandler } = withNextObservableSetup(
           new BehaviorSubject(1)
         );
@@ -295,6 +470,7 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 1,
           reset: true,
+          sync: true,
         });
 
         // next observable
@@ -302,11 +478,13 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 10,
           reset: true,
+          sync: true,
         });
         expect(nextHandler.mock.calls[2][0]).toEqual({
           type: 'next',
           value: 100,
           reset: false,
+          sync: false,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(3);
@@ -323,11 +501,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 100,
           reset: true,
+          sync: true,
         });
         expect(nextHandler).toHaveBeenCalledTimes(1);
       });
 
-      it('should call error handler with reset flag when error is emitted', () => {
+      it('should call error handler with reset and sync flags when error is emitted', () => {
         const {
           renderEventManager,
           nextHandler,
@@ -342,10 +521,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 200,
           reset: true,
+          sync: true,
         });
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
+          sync: true,
         });
 
         // next observable
@@ -353,6 +534,7 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: true,
+          sync: true,
         });
 
         expect(nextHandler).toHaveBeenCalledTimes(1);
@@ -372,6 +554,7 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'SAME_ERROR!',
           reset: true,
+          sync: true,
         });
         expect(errorHandler).toHaveBeenCalledTimes(1);
       });
@@ -387,16 +570,19 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 1,
           reset: true,
+          sync: true,
         });
         expect(completeHandler.mock.calls[0][0]).toEqual({
           type: 'complete',
           reset: false,
+          sync: true,
         });
 
         // next observable
         expect(completeHandler.mock.calls[1][0]).toEqual({
           type: 'complete',
           reset: true,
+          sync: true,
         });
 
         expect(completeHandler).toHaveBeenCalledTimes(2);
@@ -411,6 +597,7 @@ describe('createRenderEventManager', () => {
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: true,
+          sync: true,
         });
         expect(completeHandler).toHaveBeenCalledTimes(1);
       });
@@ -430,12 +617,14 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx',
           reset: true,
+          sync: true,
         });
 
         // next observable
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
+          sync: true,
         });
         expect(nextHandler.mock.calls[1]).not.toBeDefined();
 
@@ -445,6 +634,7 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'component',
           reset: false,
+          sync: false,
         });
 
         expect(suspenseHandler).toHaveBeenCalledTimes(1);
@@ -468,12 +658,14 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 'ngrx/component',
           reset: true,
+          sync: true,
         });
 
         // next observable
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
+          sync: true,
         });
         expect(errorHandler).not.toHaveBeenCalled();
 
@@ -483,6 +675,7 @@ describe('createRenderEventManager', () => {
           type: 'error',
           error: 'ERROR!',
           reset: false,
+          sync: false,
         });
 
         expect(suspenseHandler).toHaveBeenCalledTimes(1);
@@ -490,7 +683,7 @@ describe('createRenderEventManager', () => {
         expect(errorHandler).toHaveBeenCalledTimes(1);
       }));
 
-      it('should call complete handler immediately and error handler when error is emitted', fakeAsync(() => {
+      it('should call suspense handler immediately and complete handler when complete is emitted', fakeAsync(() => {
         const {
           renderEventManager,
           suspenseHandler,
@@ -507,12 +700,14 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: false,
           reset: true,
+          sync: true,
         });
 
         // next observable
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
+          sync: true,
         });
         expect(completeHandler).not.toHaveBeenCalled();
 
@@ -521,6 +716,7 @@ describe('createRenderEventManager', () => {
         expect(completeHandler).toHaveBeenCalledWith({
           type: 'complete',
           reset: false,
+          sync: false,
         });
 
         expect(suspenseHandler).toHaveBeenCalledTimes(1);
@@ -539,10 +735,12 @@ describe('createRenderEventManager', () => {
           type: 'next',
           value: 10,
           reset: true,
+          sync: true,
         });
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
+          sync: true,
         });
       });
 
@@ -555,6 +753,7 @@ describe('createRenderEventManager', () => {
         expect(suspenseHandler).toHaveBeenCalledWith({
           type: 'suspense',
           reset: true,
+          sync: true,
         });
         expect(suspenseHandler).toHaveBeenCalledTimes(1);
       });

--- a/modules/component/src/core/render-event/manager.ts
+++ b/modules/component/src/core/render-event/manager.ts
@@ -40,30 +40,29 @@ function switchMapToRenderEvent<T>(): (
     switchMap((potentialObservable) => {
       const observable$ = fromPotentialObservable(potentialObservable);
       let reset = true;
-      let sync = true;
+      let synchronous = true;
 
       return new Observable<RenderEvent<T>>((subscriber) => {
         const subscription = observable$.subscribe({
           next(value) {
-            subscriber.next({ type: 'next', value, reset, sync });
+            subscriber.next({ type: 'next', value, reset, synchronous });
             reset = false;
           },
           error(error) {
-            subscriber.next({ type: 'error', error, reset, sync });
+            subscriber.next({ type: 'error', error, reset, synchronous });
             reset = false;
           },
           complete() {
-            subscriber.next({ type: 'complete', reset, sync });
+            subscriber.next({ type: 'complete', reset, synchronous });
             reset = false;
           },
         });
 
         if (reset) {
-          subscriber.next({ type: 'suspense', reset, sync: true });
+          subscriber.next({ type: 'suspense', reset, synchronous: true });
+          reset = false;
         }
-
-        reset = false;
-        sync = false;
+        synchronous = false;
 
         return subscription;
       });

--- a/modules/component/src/core/render-event/manager.ts
+++ b/modules/component/src/core/render-event/manager.ts
@@ -40,27 +40,30 @@ function switchMapToRenderEvent<T>(): (
     switchMap((potentialObservable) => {
       const observable$ = fromPotentialObservable(potentialObservable);
       let reset = true;
+      let sync = true;
 
       return new Observable<RenderEvent<T>>((subscriber) => {
         const subscription = observable$.subscribe({
           next(value) {
-            subscriber.next({ type: 'next', value, reset });
+            subscriber.next({ type: 'next', value, reset, sync });
             reset = false;
           },
           error(error) {
-            subscriber.next({ type: 'error', error, reset });
+            subscriber.next({ type: 'error', error, reset, sync });
             reset = false;
           },
           complete() {
-            subscriber.next({ type: 'complete', reset });
+            subscriber.next({ type: 'complete', reset, sync });
             reset = false;
           },
         });
 
         if (reset) {
-          subscriber.next({ type: 'suspense', reset });
-          reset = false;
+          subscriber.next({ type: 'suspense', reset, sync: true });
         }
+
+        reset = false;
+        sync = false;
 
         return subscription;
       });

--- a/modules/component/src/core/render-event/models.ts
+++ b/modules/component/src/core/render-event/models.ts
@@ -6,13 +6,13 @@ interface BaseRenderEvent {
   /**
    * true if the synchronous event is emitted
    */
-  sync: boolean;
+  synchronous: boolean;
 }
 
 export interface SuspenseRenderEvent extends BaseRenderEvent {
   type: 'suspense';
   reset: true;
-  sync: true;
+  synchronous: true;
 }
 
 export interface NextRenderEvent<T> extends BaseRenderEvent {

--- a/modules/component/src/core/render-event/models.ts
+++ b/modules/component/src/core/render-event/models.ts
@@ -1,10 +1,18 @@
 interface BaseRenderEvent {
+  /**
+   * true if the event is emitted by a new source
+   */
   reset: boolean;
+  /**
+   * true if the synchronous event is emitted
+   */
+  sync: boolean;
 }
 
 export interface SuspenseRenderEvent extends BaseRenderEvent {
   type: 'suspense';
   reset: true;
+  sync: true;
 }
 
 export interface NextRenderEvent<T> extends BaseRenderEvent {

--- a/modules/component/src/let/let.directive.ts
+++ b/modules/component/src/let/let.directive.ts
@@ -140,7 +140,7 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
         this.viewContext.$complete = false;
       }
 
-      this.renderMainView();
+      this.renderMainView(event.sync);
     },
     error: (event) => {
       this.viewContext.$error = event.error;
@@ -152,7 +152,7 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
         this.viewContext.$complete = false;
       }
 
-      this.renderMainView();
+      this.renderMainView(event.sync);
       this.errorHandler.handleError(event.error);
     },
     complete: (event) => {
@@ -165,7 +165,7 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
         this.viewContext.$error = undefined;
       }
 
-      this.renderMainView();
+      this.renderMainView(event.sync);
     },
   });
   private readonly subscription = new Subscription();
@@ -206,7 +206,7 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
-  private renderMainView(): void {
+  private renderMainView(isSyncEvent: boolean): void {
     if (this.isSuspenseViewCreated) {
       this.isSuspenseViewCreated = false;
       this.viewContainerRef.clear();
@@ -220,7 +220,9 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
       );
     }
 
-    this.renderScheduler.schedule();
+    if (!isSyncEvent) {
+      this.renderScheduler.schedule();
+    }
   }
 
   private renderSuspenseView(): void {
@@ -232,10 +234,6 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
     if (this.suspenseTemplateRef && !this.isSuspenseViewCreated) {
       this.isSuspenseViewCreated = true;
       this.viewContainerRef.createEmbeddedView(this.suspenseTemplateRef);
-    }
-
-    if (this.isMainViewCreated || this.isSuspenseViewCreated) {
-      this.renderScheduler.schedule();
     }
   }
 }

--- a/modules/component/src/let/let.directive.ts
+++ b/modules/component/src/let/let.directive.ts
@@ -140,7 +140,7 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
         this.viewContext.$complete = false;
       }
 
-      this.renderMainView(event.sync);
+      this.renderMainView(event.synchronous);
     },
     error: (event) => {
       this.viewContext.$error = event.error;
@@ -152,7 +152,7 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
         this.viewContext.$complete = false;
       }
 
-      this.renderMainView(event.sync);
+      this.renderMainView(event.synchronous);
       this.errorHandler.handleError(event.error);
     },
     complete: (event) => {
@@ -165,7 +165,7 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
         this.viewContext.$error = undefined;
       }
 
-      this.renderMainView(event.sync);
+      this.renderMainView(event.synchronous);
     },
   });
   private readonly subscription = new Subscription();

--- a/modules/component/src/push/push.pipe.ts
+++ b/modules/component/src/push/push.pipe.ts
@@ -44,17 +44,17 @@ export class PushPipe implements PipeTransform, OnDestroy {
     cdRef: this.cdRef,
   });
   private readonly renderEventManager = createRenderEventManager({
-    suspense: (event) => this.setRenderedValue(undefined, event.sync),
-    next: (event) => this.setRenderedValue(event.value, event.sync),
+    suspense: (event) => this.setRenderedValue(undefined, event.synchronous),
+    next: (event) => this.setRenderedValue(event.value, event.synchronous),
     error: (event) => {
       if (event.reset) {
-        this.setRenderedValue(undefined, event.sync);
+        this.setRenderedValue(undefined, event.synchronous);
       }
       this.errorHandler.handleError(event.error);
     },
     complete: (event) => {
       if (event.reset) {
-        this.setRenderedValue(undefined, event.sync);
+        this.setRenderedValue(undefined, event.synchronous);
       }
     },
   });

--- a/modules/component/src/push/push.pipe.ts
+++ b/modules/component/src/push/push.pipe.ts
@@ -44,17 +44,17 @@ export class PushPipe implements PipeTransform, OnDestroy {
     cdRef: this.cdRef,
   });
   private readonly renderEventManager = createRenderEventManager({
-    suspense: () => this.setRenderedValue(undefined),
-    next: (event) => this.setRenderedValue(event.value),
+    suspense: (event) => this.setRenderedValue(undefined, event.sync),
+    next: (event) => this.setRenderedValue(event.value, event.sync),
     error: (event) => {
       if (event.reset) {
-        this.setRenderedValue(undefined);
+        this.setRenderedValue(undefined, event.sync);
       }
       this.errorHandler.handleError(event.error);
     },
     complete: (event) => {
       if (event.reset) {
-        this.setRenderedValue(undefined);
+        this.setRenderedValue(undefined, event.sync);
       }
     },
   });
@@ -79,10 +79,13 @@ export class PushPipe implements PipeTransform, OnDestroy {
     this.subscription.unsubscribe();
   }
 
-  private setRenderedValue(value: unknown): void {
+  private setRenderedValue(value: unknown, isSyncEvent: boolean): void {
     if (value !== this.renderedValue) {
       this.renderedValue = value;
-      this.renderScheduler.schedule();
+
+      if (!isSyncEvent) {
+        this.renderScheduler.schedule();
+      }
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Performance improvements
```

## What is the current behavior?

The render scheduler unnecessarily schedules render/marks a component as dirty when synchronous events are emitted.

For instance, in the following example:

```ts
@Component({
  template: `
    <p>{{ obs$ | ngrxPush }}</p>
  `
})
export class TestComponent {
  obs$ = of(1, 2, 3);
}
```

The PushPipe will mark `TestComponent` as dirty (and schedule tick in zone-less mode) 4 times (3 next, and 1 complete event) which is not needed because all these events will be emitted synchronously, so the last value will be visible in the template without scheduling render/marking it as dirty.

## What is the new behavior?

The render scheduler schedules render/marks a component as dirty only when asynchronous events are emitted.

- [Zone-Full Playground](https://stackblitz.com/edit/angular-zy74xp?file=src/app/app.component.html)
- [Zone-Less Playground](https://stackblitz.com/edit/angular-zy74xp-g52skq?file=src/app/app.component.html)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
