### PR TITLE
docs: add ngrx-traits to the list of libraries in resources

### DIFF
--- a/projects/ngrx.io/content/marketing/resources.json
+++ b/projects/ngrx.io/content/marketing/resources.json
@@ -209,6 +209,12 @@
             "url": "https://github.com/nartc/ngrx-slice",
             "rev": true
           },
+          "ngrx-traits": {
+            "title": "ngrx-traits",
+            "desc": "A library to help you reuse and compose a set of NGRX actions, selectors, reducers, and effects across your app",
+            "url": "https://github.com/gabrielguerrero/ngrx-traits",
+            "rev": true
+          },
           "ngrx-wieder": {
             "title": "ngrx-wieder",
             "desc": "Lightweight & configurable solution for implementing undo-redo based on NgRx and immer",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The resources page of ngrx.io doesn't have ngrx-traits on the list of libraries

Closes #
Did not create any issue for this, I will imagine is not needed for this case but I can if requested

## What is the new behavior?

In the resources page of ngrx.io add to the libraries section ngrx-traits lib ( see https://github.com/gabrielguerrero/ngrx-traits), @brandonroberts  ask me in the ngrx  Discord channel to create a PR to added it

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```


