### PR TITLE
fix(component-store): make synchronous updater errors catchable

### DIFF
--- a/modules/component-store/spec/component-store.spec.ts
+++ b/modules/component-store/spec/component-store.spec.ts
@@ -79,19 +79,8 @@ describe('Component Store', () => {
     it(
       'throws an Error when setState with a function/callback is called' +
         ' before initialization',
-      marbles((m) => {
+      () => {
         const componentStore = new ComponentStore();
-
-        m.expect(componentStore.state$).toBeObservable(
-          m.hot(
-            '#',
-            {},
-            new Error(
-              'ComponentStore has not been initialized yet. ' +
-                'Please make sure it is initialized before updating/getting.'
-            )
-          )
-        );
 
         expect(() => {
           componentStore.setState(() => ({ setState: 'new state' }));
@@ -101,7 +90,7 @@ describe('Component Store', () => {
               'Please make sure it is initialized before updating/getting.'
           )
         );
-      })
+      }
     );
 
     it('throws an Error when patchState with an object is called before initialization', () => {
@@ -147,54 +136,29 @@ describe('Component Store', () => {
       }
     );
 
-    it(
-      'throws an Error when updater is called before initialization',
-      marbles((m) => {
-        const componentStore = new ComponentStore();
+    it('throws an Error when updater is called before initialization', () => {
+      const componentStore = new ComponentStore();
 
-        m.expect(componentStore.state$).toBeObservable(
-          m.hot(
-            '#',
-            {},
-            new Error(
-              'ComponentStore has not been initialized yet. ' +
-                'Please make sure it is initialized before updating/getting.'
-            )
-          )
-        );
-
-        expect(() => {
-          componentStore.updater((state, value: object) => value)({
-            updater: 'new state',
-          });
-        }).toThrow(
-          new Error(
-            'ComponentStore has not been initialized yet. ' +
-              'Please make sure it is initialized before updating/getting.'
-          )
-        );
-      })
-    );
+      expect(() => {
+        componentStore.updater((state, value: object) => value)({
+          updater: 'new state',
+        });
+      }).toThrow(
+        new Error(
+          'ComponentStore has not been initialized yet. ' +
+            'Please make sure it is initialized before updating/getting.'
+        )
+      );
+    });
 
     it(
       'throws an Error when updater is called with sync Observable' +
         ' before initialization',
-      marbles((m) => {
+      () => {
         const componentStore = new ComponentStore();
         const syncronousObservable$ = of({
           updater: 'new state',
         });
-
-        m.expect(componentStore.state$).toBeObservable(
-          m.hot(
-            '#',
-            {},
-            new Error(
-              'ComponentStore has not been initialized yet. ' +
-                'Please make sure it is initialized before updating/getting.'
-            )
-          )
-        );
 
         expect(() => {
           componentStore.updater<object>((state, value) => value)(
@@ -206,39 +170,32 @@ describe('Component Store', () => {
               'Please make sure it is initialized before updating/getting.'
           )
         );
-      })
+      }
     );
 
     it(
-      'does not throw an Error when updater is called with async Observable' +
-        ' before initialization, however closes the subscription and does not' +
-        ' update the state and sends error in state$',
+      'throws an Error asynchronously when updater is called with async' +
+        ' Observable before initialization, however closes the subscription' +
+        ' and does not update the state',
       marbles((m) => {
         const componentStore = new ComponentStore();
-        const asyncronousObservable$ = m.cold('-u', {
+        const asynchronousObservable$ = m.cold('-u', {
           u: { updater: 'new state' },
         });
 
         let subscription: Subscription | undefined;
 
-        m.expect(componentStore.state$).toBeObservable(
-          m.hot(
-            '-#',
-            {},
-            new Error(
-              'ComponentStore has not been initialized yet. ' +
-                'Please make sure it is initialized before updating/getting.'
-            )
-          )
-        );
-
         expect(() => {
           subscription = componentStore.updater(
             (state, value: object) => value
-          )(asyncronousObservable$);
-        }).not.toThrow();
-
-        m.flush();
+          )(asynchronousObservable$);
+          m.flush();
+        }).toThrow(
+          new Error(
+            'ComponentStore has not been initialized yet. ' +
+              'Please make sure it is initialized before updating/getting.'
+          )
+        );
 
         expect(subscription!.closed).toBe(true);
       })
@@ -634,6 +591,69 @@ describe('Component Store', () => {
             s: { ...INIT_STATE, value2: { foo: 'bar2' } },
           })
         );
+      })
+    );
+  });
+
+  describe('throws an error', () => {
+    it('when synchronous error is thrown within updater', () => {
+      const componentStore = new ComponentStore({});
+      const error = new Error('ERROR!');
+      const updater = componentStore.updater(() => {
+        throw error;
+      });
+
+      expect(() => updater()).toThrow(error);
+    });
+
+    it('when synchronous error is thrown within setState callback', () => {
+      const componentStore = new ComponentStore({});
+      const error = new Error('ERROR!');
+
+      expect(() => {
+        componentStore.setState(() => {
+          throw error;
+        });
+      }).toThrow(error);
+    });
+
+    it('when synchronous error is thrown within patchState callback', () => {
+      const componentStore = new ComponentStore({});
+      const error = new Error('ERROR!');
+
+      expect(() => {
+        componentStore.patchState(() => {
+          throw error;
+        });
+      }).toThrow(error);
+    });
+
+    it(
+      'when asynchronous observable throws an error with updater',
+      marbles((m) => {
+        const componentStore = new ComponentStore({});
+        const error = new Error('ERROR!');
+        const updater = componentStore.updater<unknown>(() => ({}));
+        const asyncObs$ = m.cold('-#', {}, error);
+
+        expect(() => {
+          updater(asyncObs$);
+          m.flush();
+        }).toThrow(error);
+      })
+    );
+
+    it(
+      'when asynchronous observable throws an error with patchState',
+      marbles((m) => {
+        const componentStore = new ComponentStore({});
+        const error = new Error('ERROR!');
+        const asyncObs$ = m.cold('-#', {}, error);
+
+        expect(() => {
+          componentStore.patchState(asyncObs$);
+          m.flush();
+        }).toThrow(error);
       })
     );
   });

--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -113,6 +113,8 @@ export class ComponentStore<T extends object> implements OnDestroy {
     return ((
       observableOrValue?: OriginType | Observable<OriginType>
     ): Subscription => {
+      // We need to explicitly throw an error if a synchronous error occurs.
+      // This is necessary to make synchronous errors catchable.
       let isSyncUpdate = true;
       let syncError: unknown;
       // We can receive either the value or an observable. In case it's a

--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -10,6 +10,7 @@ import {
   queueScheduler,
   scheduled,
   asyncScheduler,
+  EMPTY,
 } from 'rxjs';
 import {
   concatMap,
@@ -19,6 +20,8 @@ import {
   distinctUntilChanged,
   shareReplay,
   take,
+  tap,
+  catchError,
 } from 'rxjs/operators';
 import { debounceSync } from './debounce-sync';
 import {
@@ -110,7 +113,8 @@ export class ComponentStore<T extends object> implements OnDestroy {
     return ((
       observableOrValue?: OriginType | Observable<OriginType>
     ): Subscription => {
-      let initializationError: Error | undefined;
+      let isSyncUpdate = true;
+      let syncError: unknown;
       // We can receive either the value or an observable. In case it's a
       // simple value, we'll wrap it with `of` operator to turn it into
       // Observable.
@@ -128,23 +132,26 @@ export class ComponentStore<T extends object> implements OnDestroy {
               : // If state was not initialized, we'll throw an error.
                 throwError(() => new Error(this.notInitializedErrorMessage))
           ),
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          map(([value, currentState]) => updaterFn(currentState, value!)),
+          tap((newState) => this.stateSubject$.next(newState)),
+          catchError((error: unknown) => {
+            if (isSyncUpdate) {
+              syncError = error;
+              return EMPTY;
+            }
+
+            return throwError(() => error);
+          }),
           takeUntil(this.destroy$)
         )
-        .subscribe({
-          next: ([value, currentState]) => {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            this.stateSubject$.next(updaterFn(currentState, value!));
-          },
-          error: (error: Error) => {
-            initializationError = error;
-            this.stateSubject$.error(error);
-          },
-        });
+        .subscribe();
 
-      if (initializationError) {
-        // prettier-ignore
-        throw /** @type {!Error} */ (initializationError);
+      if (syncError) {
+        throw syncError;
       }
+      isSyncUpdate = false;
+
       return subscription;
     }) as unknown as ReturnType;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3266 

## What is the new behavior?

All synchronous errors are now catchable. Also, error handling is changed - an error will not be emitted to the `stateSubject$` anymore, it will be thrown instead.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

As we discussed at the last team meeting, this should not be considered a breaking change.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
