### PR TITLE
fix(component-store): move isInitialized check to queueScheduler context on state update

### DIFF
--- a/modules/component-store/spec/component-store.spec.ts
+++ b/modules/component-store/spec/component-store.spec.ts
@@ -203,7 +203,7 @@ describe('Component Store', () => {
     );
 
     it(
-      'does not throws an Error when updater is called with async Observable' +
+      'does not throw an Error when updater is called with async Observable' +
         ' before initialization, that emits the value after initialization',
       marbles((m) => {
         const componentStore = new ComponentStore();
@@ -235,6 +235,19 @@ describe('Component Store', () => {
           m.hot('(iu)', { i: INIT_STATE, u: UPDATED_STATE })
         );
       })
+    );
+
+    it(
+      'does not throw an Error when ComponentStore initialization and' +
+        ' state update are scheduled via queueScheduler',
+      () => {
+        expect(() => {
+          queueScheduler.schedule(() => {
+            const componentStore = new ComponentStore({ foo: false });
+            componentStore.patchState({ foo: true });
+          });
+        }).not.toThrow();
+      }
     );
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2991

## What is the new behavior?

There is no initialization error when ComponentStore initialization and state update are scheduled via `queueScheduler`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
 