### PR TITLE
refactor(component): use RenderScheduler as a service

### DIFF
--- a/modules/component/spec/core/render-scheduler.spec.ts
+++ b/modules/component/spec/core/render-scheduler.spec.ts
@@ -21,7 +21,7 @@ describe('createRenderScheduler', () => {
     });
 
     const renderScheduler = TestBed.inject(Service).renderScheduler;
-    expect(renderScheduler instanceof RenderScheduler).toBe(true);
+    expect(renderScheduler).toBeInstanceOf(RenderScheduler);
   });
 
   it('should throw an error out of injection context', () => {

--- a/modules/component/spec/core/render-scheduler.spec.ts
+++ b/modules/component/spec/core/render-scheduler.spec.ts
@@ -21,11 +21,11 @@ describe('createRenderScheduler', () => {
     });
 
     const renderScheduler = TestBed.inject(Service).renderScheduler;
-    expect(renderScheduler).toBeDefined();
+    expect(renderScheduler instanceof RenderScheduler).toBe(true);
   });
 
   it('should throw an error out of injection context', () => {
-    expect(() => createRenderScheduler()).toThrow();
+    expect(() => createRenderScheduler()).toThrowError();
   });
 });
 

--- a/modules/component/spec/core/render-scheduler.spec.ts
+++ b/modules/component/spec/core/render-scheduler.spec.ts
@@ -1,13 +1,40 @@
-import { createRenderScheduler } from '../../src/core/render-scheduler';
+import {
+  createRenderScheduler,
+  RenderScheduler,
+} from '../../src/core/render-scheduler';
 import { NoopTickScheduler } from '../../src/core/tick-scheduler';
 import { MockChangeDetectorRef } from '../fixtures/fixtures';
+import { TestBed } from '@angular/core/testing';
+import { ChangeDetectorRef, Injectable } from '@angular/core';
 
 describe('createRenderScheduler', () => {
+  it('should initialize within injection context', () => {
+    @Injectable({ providedIn: 'root' })
+    class Service {
+      readonly renderScheduler = createRenderScheduler();
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ChangeDetectorRef, useClass: MockChangeDetectorRef },
+      ],
+    });
+
+    const renderScheduler = TestBed.inject(Service).renderScheduler;
+    expect(renderScheduler).toBeDefined();
+  });
+
+  it('should throw an error out of injection context', () => {
+    expect(() => createRenderScheduler()).toThrow();
+  });
+});
+
+describe('RenderScheduler', () => {
   function setup() {
     const cdRef = new MockChangeDetectorRef();
     const tickScheduler = new NoopTickScheduler();
     jest.spyOn(tickScheduler, 'schedule');
-    const renderScheduler = createRenderScheduler({ cdRef, tickScheduler });
+    const renderScheduler = new RenderScheduler(cdRef, tickScheduler);
 
     return { cdRef, renderScheduler, tickScheduler };
   }

--- a/modules/component/spec/types/push.pipe.types.spec.ts
+++ b/modules/component/spec/types/push.pipe.types.spec.ts
@@ -6,9 +6,9 @@ describe('PushPipe', () => {
       import { Observable } from 'rxjs';
       import { PushPipe } from '@ngrx/component';
 
-      const anyVal = {} as any;
-      const pushPipe = new PushPipe(anyVal, anyVal, anyVal);
-      const value = pushPipe.transform(anyVal as ${potentialObservableType});
+      const unknownVal: unknown = {};
+      const pushPipe = unknownVal as PushPipe;
+      const value = pushPipe.transform(unknownVal as ${potentialObservableType});
     `
   );
 

--- a/modules/component/src/core/render-scheduler.ts
+++ b/modules/component/src/core/render-scheduler.ts
@@ -1,22 +1,19 @@
-import { ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectorRef, inject, Injectable } from '@angular/core';
 import { TickScheduler } from './tick-scheduler';
 
-export interface RenderScheduler {
-  schedule(): void;
-}
+@Injectable()
+export class RenderScheduler {
+  constructor(
+    private cdRef: ChangeDetectorRef,
+    private tickScheduler: TickScheduler
+  ) {}
 
-export interface RenderSchedulerConfig {
-  cdRef: ChangeDetectorRef;
-  tickScheduler: TickScheduler;
-}
-
-export function createRenderScheduler(
-  config: RenderSchedulerConfig
-): RenderScheduler {
-  function schedule(): void {
-    config.cdRef.markForCheck();
-    config.tickScheduler.schedule();
+  schedule(): void {
+    this.cdRef.markForCheck();
+    this.tickScheduler.schedule();
   }
+}
 
-  return { schedule };
+export function createRenderScheduler(): RenderScheduler {
+  return new RenderScheduler(inject(ChangeDetectorRef), inject(TickScheduler));
 }

--- a/modules/component/src/core/render-scheduler.ts
+++ b/modules/component/src/core/render-scheduler.ts
@@ -4,8 +4,8 @@ import { TickScheduler } from './tick-scheduler';
 @Injectable()
 export class RenderScheduler {
   constructor(
-    private cdRef: ChangeDetectorRef,
-    private tickScheduler: TickScheduler
+    private readonly cdRef: ChangeDetectorRef,
+    private readonly tickScheduler: TickScheduler
   ) {}
 
   schedule(): void {

--- a/modules/component/src/let/let.directive.ts
+++ b/modules/component/src/let/let.directive.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectorRef,
   Directive,
   ErrorHandler,
   Input,
@@ -13,9 +12,8 @@ import {
   ObservableOrPromise,
   PotentialObservable,
 } from '../core/potential-observable';
-import { createRenderScheduler } from '../core/render-scheduler';
+import { RenderScheduler } from '../core/render-scheduler';
 import { createRenderEventManager } from '../core/render-event/manager';
-import { TickScheduler } from '../core/tick-scheduler';
 
 type LetViewContextValue<PO> = PO extends ObservableOrPromise<infer V> ? V : PO;
 
@@ -103,7 +101,10 @@ export interface LetViewContext<PO> {
  *
  * @publicApi
  */
-@Directive({ selector: '[ngrxLet]' })
+@Directive({
+  selector: '[ngrxLet]',
+  providers: [RenderScheduler],
+})
 export class LetDirective<PO> implements OnInit, OnDestroy {
   private isMainViewCreated = false;
   private isSuspenseViewCreated = false;
@@ -114,10 +115,6 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
     $complete: false,
     $suspense: true,
   };
-  private readonly renderScheduler = createRenderScheduler({
-    cdRef: this.cdRef,
-    tickScheduler: this.tickScheduler,
-  });
   private readonly renderEventManager = createRenderEventManager<
     LetViewContextValue<PO>
   >({
@@ -182,11 +179,10 @@ export class LetDirective<PO> implements OnInit, OnDestroy {
   >;
 
   constructor(
-    private readonly cdRef: ChangeDetectorRef,
-    private readonly tickScheduler: TickScheduler,
     private readonly mainTemplateRef: TemplateRef<LetViewContext<PO>>,
     private readonly viewContainerRef: ViewContainerRef,
-    private readonly errorHandler: ErrorHandler
+    private readonly errorHandler: ErrorHandler,
+    private readonly renderScheduler: RenderScheduler
   ) {}
 
   static ngTemplateContextGuard<PO>(

--- a/modules/component/src/push/push.pipe.ts
+++ b/modules/component/src/push/push.pipe.ts
@@ -1,15 +1,8 @@
-import {
-  ChangeDetectorRef,
-  ErrorHandler,
-  OnDestroy,
-  Pipe,
-  PipeTransform,
-} from '@angular/core';
+import { ErrorHandler, OnDestroy, Pipe, PipeTransform } from '@angular/core';
 import { Unsubscribable } from 'rxjs';
 import { ObservableOrPromise } from '../core/potential-observable';
 import { createRenderScheduler } from '../core/render-scheduler';
 import { createRenderEventManager } from '../core/render-event/manager';
-import { TickScheduler } from '../core/tick-scheduler';
 
 type PushPipeResult<PO> = PO extends ObservableOrPromise<infer R>
   ? R | undefined
@@ -39,10 +32,7 @@ type PushPipeResult<PO> = PO extends ObservableOrPromise<infer R>
 @Pipe({ name: 'ngrxPush', pure: false })
 export class PushPipe implements PipeTransform, OnDestroy {
   private renderedValue: unknown;
-  private readonly renderScheduler = createRenderScheduler({
-    cdRef: this.cdRef,
-    tickScheduler: this.tickScheduler,
-  });
+  private readonly renderScheduler = createRenderScheduler();
   private readonly renderEventManager = createRenderEventManager({
     suspense: (event) => this.setRenderedValue(undefined, event.synchronous),
     next: (event) => this.setRenderedValue(event.value, event.synchronous),
@@ -60,11 +50,7 @@ export class PushPipe implements PipeTransform, OnDestroy {
   });
   private readonly subscription: Unsubscribable;
 
-  constructor(
-    private readonly cdRef: ChangeDetectorRef,
-    private readonly tickScheduler: TickScheduler,
-    private readonly errorHandler: ErrorHandler
-  ) {
+  constructor(private readonly errorHandler: ErrorHandler) {
     this.subscription = this.renderEventManager
       .handlePotentialObservableChanges()
       .subscribe();


### PR DESCRIPTION
This PR converts `RenderScheduler` to a service, so it could be also used in the following way:

```ts
import { RenderScheduler } from '@ngrx/component';

@Component({
  providers: [RenderScheduler],
})
export class TestComponent {
  constructor(private readonly renderScheduler: RenderScheduler) {}

  doSomething(): void {
    // ...
    this.renderScheduler.schedule();
  }
}
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This PR currently depends on #3488 