### PR TITLE
fix(eslint-plugin): Remove the md suffix from the docsUrl path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ The following is the list of supported scopes:
 - **schematics**
 - **store**
 - **store-devtools**
+- **eslint-plugin**
 
 ### Subject
 

--- a/modules/eslint-plugin/src/utils/helper-functions/docs.ts
+++ b/modules/eslint-plugin/src/utils/helper-functions/docs.ts
@@ -1,2 +1,2 @@
 export const docsUrl = (ruleName: string) =>
-  `https://ngrx.io/guide/eslint-plugin/rules/${ruleName}.md`;
+  `https://ngrx.io/guide/eslint-plugin/rules/${ruleName}`;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When I click on the docs url on VSCode, the user is navigated to a `PAGE NOT FOUND` page for all the rules.

https://user-images.githubusercontent.com/6942946/183309538-9e016d8a-de6a-4f92-8e53-b53c5a6157ca.mov



<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
