### PR TITLE
feat(component-store): handle errors in next callback

### DIFF
--- a/modules/component-store/spec/tap-response.spec.ts
+++ b/modules/component-store/spec/tap-response.spec.ts
@@ -22,6 +22,19 @@ describe('tapResponse', () => {
     expect(errorCallback).toHaveBeenCalledWith(error);
   });
 
+  it('should invoke error callback on the exception thrown in next', () => {
+    const errorCallback = jest.fn<void, [{ message: string }]>();
+    const error = { message: 'error' };
+
+    function producesError() {
+      throw error;
+    }
+
+    of(1).pipe(tapResponse(producesError, errorCallback)).subscribe();
+
+    expect(errorCallback).toHaveBeenCalledWith(error);
+  });
+
   it('should invoke complete callback on complete', () => {
     const completeCallback = jest.fn<void, []>();
 

--- a/modules/component-store/src/tap-response.ts
+++ b/modules/component-store/src/tap-response.ts
@@ -31,9 +31,11 @@ export function tapResponse<T, E = unknown>(
     source.pipe(
       tap({
         next: nextFn,
-        error: errorFn,
         complete: completeFn,
       }),
-      catchError(() => EMPTY)
+      catchError((e) => {
+        errorFn(e);
+        return EMPTY;
+      })
     );
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When anything is thrown from the first argument of `tapResponse` fn( aka `next` callback) it is not handled.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes # https://github.com/ngrx/platform/issues/3431

## What is the new behavior?

When anything is thrown from the first argument of `tapResponse` fn( aka `next` callback) is now handled by the same error handler as the second argument (aka `error` callback).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
