### PR TITLE
fix(eslint-plugin): avoid-mapping-selectors don't report on ThisExpression

### DIFF
--- a/modules/eslint-plugin/spec/rules/avoid-mapping-selectors.spec.ts
+++ b/modules/eslint-plugin/spec/rules/avoid-mapping-selectors.spec.ts
@@ -118,11 +118,16 @@ export class CollectionService {
 import { Store } from '@ngrx/store'
 
 class OkBecauseOfThis {
-  foo$ = this.store.select(selectIsAuthenticated).pipe(
+  storeSelect$ = this.store.select(selectIsAuthenticated).pipe(
       take(1),
       map((isAuthenticated: boolean) => (isAuthenticated ? true : this.router.parseUrl('/login'))),
   )
 
+  pipeSelect$ = this.store.pipe(
+      select(selectIsAuthenticated),
+      take(1),
+      map((isAuthenticated: boolean) => (isAuthenticated ? true : this.router.parseUrl('/login'))),
+  )
 
   constructor(private store: Store) {}
 }`,
@@ -130,15 +135,24 @@ class OkBecauseOfThis {
 import { Store } from '@ngrx/store'
 
 class OkBecauseOfEffect {
-foo$ = createEffect(() => {
-  return this.store.select(selectObj).pipe(
-    map((obj) => obj.prop),
-    distinctUntilChanged(),
-    map(() => anAction())
-  )
-})
-  
-constructor(private store: Store) {}
+  storeSelect$ = createEffect(() => {
+    return this.store.select(selectObj).pipe(
+      map((obj) => obj.prop),
+      distinctUntilChanged(),
+      map(() => anAction())
+    )
+  })
+
+  pipeSelect$ = createEffect(() => {
+    return this.store.pipe(
+      select(selectObj),
+      map((obj) => obj.prop),
+      distinctUntilChanged(),
+      map(() => anAction())
+    )
+  })
+
+  constructor(private store: Store) {}
 }`,
 ];
 

--- a/modules/eslint-plugin/spec/rules/avoid-mapping-selectors.spec.ts
+++ b/modules/eslint-plugin/spec/rules/avoid-mapping-selectors.spec.ts
@@ -154,6 +154,36 @@ class OkBecauseOfEffect {
 
   constructor(private store: Store) {}
 }`,
+  // https://github.com/ngrx/platform/issues/3511
+  `
+import { Store } from '@ngrx/store'
+
+class OkBecauseOfEffect {
+  storeSelect$ = createEffect(() => {
+    return this.store.select(selectObj).pipe(
+      switchMap(() => this.service.something()),
+      map((obj) => obj.prop),
+    )
+  })
+
+  pipeSelect$ = createEffect(() => {
+    return this.store.pipe(
+      select(selectObj),
+      exhaustMap(() => this.service.something()),
+      map((obj) => obj.prop),
+    )
+  })
+
+  somethingElse$ = createEffect(() => {
+    return this.store.pipe(
+      select(selectObj),
+      customOperator(() => this.prop),
+      map((obj) => obj.prop),
+    )
+  })
+
+  constructor(private store: Store, private service: Service) {}
+}`,
 ];
 
 const invalid: () => RunTests['invalid'] = () => [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3511

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This scans if `this` is used in an operator.
If it finds a `this`, then the `avoid-mapping-selectors` rule is disabled.
The reasoning behind this, is that the selector is used in combination with something from the component (which can't be moved into the selector) to do something.  
