### PR TITLE
fix(eslint-plugin): avoid-combining-selectors with arrays should warn

### DIFF
--- a/modules/eslint-plugin/spec/rules/avoid-combining-selectors.spec.ts
+++ b/modules/eslint-plugin/spec/rules/avoid-combining-selectors.spec.ts
@@ -80,12 +80,44 @@ class NotOk {
     `
 import { Store } from '@ngrx/store'
 
+class NotOkWithArrays {
+  readonly vm$: Observable<unknown>
+
+  constructor(store: Store, private store2: Store) {
+    this.vm$ = combineLatest([
+      store.select(selectItems),
+      store.select(selectOtherItems),
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [${messageId}]
+      this.store2.select(selectOtherItems),
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [${messageId}]
+    ])
+  }
+}`
+  ),
+  fromFixture(
+    `
+import { Store } from '@ngrx/store'
+
 class NotOk1 {
   vm$ = combineLatest(
     this.store.pipe(select(selectItems)),
     this.store.pipe(select(selectOtherItems)),
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [${messageId}]
   )
+
+  constructor(private store: Store) {}
+}`
+  ),
+  fromFixture(
+    `
+import { Store } from '@ngrx/store'
+
+class NotOkWithArray {
+  vm$ = combineLatest([
+    this.store.pipe(select(selectItems)),
+    this.store.pipe(select(selectOtherItems)),
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [${messageId}]
+  ])
 
   constructor(private store: Store) {}
 }`

--- a/modules/eslint-plugin/src/rules/store/avoid-combining-selectors.ts
+++ b/modules/eslint-plugin/src/rules/store/avoid-combining-selectors.ts
@@ -42,14 +42,21 @@ export default createRule<Options, MessageIds>({
       storeNames
     )})` as const;
 
+    const selectsInArray: TSESTree.CallExpression[] = [];
     return {
-      [`CallExpression[callee.name='combineLatest'][arguments.length>1] ${pipeableOrStoreSelect} ~ ${pipeableOrStoreSelect}`](
+      [`CallExpression[callee.name='combineLatest'] ${pipeableOrStoreSelect} ~ ${pipeableOrStoreSelect}`](
         node: TSESTree.CallExpression
       ) {
-        context.report({
-          node,
-          messageId,
-        });
+        selectsInArray.push(node);
+      },
+      [`CallExpression[callee.name='combineLatest']:exit`]() {
+        for (const node of selectsInArray) {
+          context.report({
+            node,
+            messageId,
+          });
+        }
+        selectsInArray.length = 0;
       },
     };
   },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3565

The problem was that only `combineLatest(foo$, bar$, baz$)` was analyzed, and not the overload that takes the selectors as an array `combineLatest([foo$, bar$, baz$])`.

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
