### PR TITLE
refactor(store): optimize `freeze` helper function

### DIFF
--- a/modules/store/spec/meta-reducers/immutability_reducer.spec.ts
+++ b/modules/store/spec/meta-reducers/immutability_reducer.spec.ts
@@ -1,4 +1,4 @@
-import { immutabilityCheckMetaReducer } from '../../src/meta-reducers';
+import { immutabilityCheckMetaReducer, freeze } from '../../src/meta-reducers';
 
 describe('immutabilityCheckMetaReducer:', () => {
   describe('actions:', () => {
@@ -126,5 +126,19 @@ describe('immutabilityCheckMetaReducer:', () => {
       const state = reducer({ numbers: [1, 2, 3] }, { type: 'init' });
       return reducer(state, { type: 'invoke' });
     }
+  });
+});
+
+describe('freeze', () => {
+  it('should not freeze the same object twice', () => {
+    const childObj = { bar: 'baz' };
+    const parentObj = { foo: childObj };
+    const spy = spyOn(Object, 'freeze').and.callThrough();
+    freeze(parentObj);
+    expect(spy).toHaveBeenCalledWith(parentObj);
+    expect(spy).toHaveBeenCalledWith(childObj);
+    spy.calls.reset();
+    freeze(parentObj);
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/modules/store/src/meta-reducers/immutability_reducer.ts
+++ b/modules/store/src/meta-reducers/immutability_reducer.ts
@@ -14,7 +14,11 @@ export function immutabilityCheckMetaReducer(
   };
 }
 
-function freeze(target: any) {
+export function freeze(target: any) {
+  if (Object.isFrozen(target)) {
+    return target;
+  }
+
   Object.freeze(target);
 
   const targetIsFunction = isFunction(target);

--- a/modules/store/src/meta-reducers/index.ts
+++ b/modules/store/src/meta-reducers/index.ts
@@ -1,3 +1,3 @@
-export { immutabilityCheckMetaReducer } from './immutability_reducer';
+export { immutabilityCheckMetaReducer, freeze } from './immutability_reducer';
 export { serializationCheckMetaReducer } from './serialization_reducer';
 export { inNgZoneAssertMetaReducer } from './inNgZoneAssert_reducer';


### PR DESCRIPTION
Change implementation of `freeze` helper function so that it does not call `Object.freeze(...)` on an object that is already frozen

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `freeze` helper function can end up calling `Object.freeze(...)` on the same object even if the object is already frozen.

## What is the new behavior?

An object is frozen only once.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

