### PR TITLE
fix(component-store): use asapScheduler to schedule lifecycle hooks check

### DIFF
--- a/modules/component-store/spec/component-store.spec.ts
+++ b/modules/component-store/spec/component-store.spec.ts
@@ -37,7 +37,7 @@ import {
   Injector,
   Provider,
 } from '@angular/core';
-import { fakeAsync, tick } from '@angular/core/testing';
+import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
 
 describe('Component Store', () => {
   describe('initialization', () => {
@@ -1651,7 +1651,7 @@ describe('Component Store', () => {
 
       const store = state.injector.get(LifecycleStore);
 
-      tick(0);
+      flushMicrotasks();
       expect(store.ngrxOnStoreInit).toBeDefined();
       expect(store['ɵhasProvider']).toBeTruthy();
       expect(console.warn).not.toHaveBeenCalled();
@@ -1666,7 +1666,7 @@ describe('Component Store', () => {
 
       const store = state.injector.get(NonProviderStore);
 
-      tick(0);
+      flushMicrotasks();
       expect(store.ngrxOnStoreInit).toBeDefined();
       expect(store['ɵhasProvider']).toBeFalsy();
       expect(console.warn).toHaveBeenCalled();

--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -9,7 +9,7 @@ import {
   Subject,
   queueScheduler,
   scheduled,
-  asyncScheduler,
+  asapScheduler,
   EMPTY,
 } from 'rxjs';
 import {
@@ -322,7 +322,7 @@ export class ComponentStore<T extends object> implements OnDestroy {
    * but not used with provideComponentStore()
    */
   private checkProviderForHooks() {
-    asyncScheduler.schedule(() => {
+    asapScheduler.schedule(() => {
       if (
         isDevMode() &&
         (isOnStoreInitDefined(this) || isOnStateInitDefined(this)) &&


### PR DESCRIPTION
Switch from asyncScheduler to asapScheduler to prevent the "1 periodic timer(s) still in the queue" error.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
  there are existing tests for this that still pass
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3573

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
