### PR TITLE
feat(store): strict projectors

### DIFF
--- a/modules/router-store/spec/types/selectors.spec.ts
+++ b/modules/router-store/spec/types/selectors.spec.ts
@@ -38,10 +38,7 @@ describe('router selectors', () => {
         selectCurrentRoute,
         route => route
       );
-    `).toInfer(
-      'selector',
-      'MemoizedSelector<State, any, DefaultProjectorFn<any>>'
-    );
+    `).toInfer('selector', 'MemoizedSelector<State, any, (s1: any) => any>');
   });
 
   it('selectQueryParams should return Params', () => {
@@ -52,7 +49,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, Params, DefaultProjectorFn<Params>>'
+      'MemoizedSelector<State, Params, (s1: Params) => Params>'
     );
   });
 
@@ -65,7 +62,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, string, DefaultProjectorFn<string>>'
+      'MemoizedSelector<State, string, (s1: string) => string>'
     );
   });
 
@@ -77,7 +74,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, Params, DefaultProjectorFn<Params>>'
+      'MemoizedSelector<State, Params, (s1: Params) => Params>'
     );
   });
 
@@ -90,7 +87,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, string, DefaultProjectorFn<string>>'
+      'MemoizedSelector<State, string, (s1: string) => string>'
     );
   });
 
@@ -100,10 +97,7 @@ describe('router selectors', () => {
         selectRouteData,
         data => data
       );
-    `).toInfer(
-      'selector',
-      'MemoizedSelector<State, Data, DefaultProjectorFn<Data>>'
-    );
+    `).toInfer('selector', 'MemoizedSelector<State, Data, (s1: Data) => Data>');
   });
 
   it('selectUrl should return string', () => {
@@ -114,7 +108,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, string, DefaultProjectorFn<string>>'
+      'MemoizedSelector<State, string, (s1: string) => string>'
     );
   });
 
@@ -126,7 +120,7 @@ describe('router selectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, string, DefaultProjectorFn<string>>'
+      'MemoizedSelector<State, string, (s1: string) => string>'
     );
   });
 });

--- a/modules/store/spec/selector.spec.ts
+++ b/modules/store/spec/selector.spec.ts
@@ -56,7 +56,7 @@ describe('Selectors', () => {
 
       const selector = createSelector(incrementOne, incrementTwo, projectFn);
 
-      expect(selector.projector()).toBe(2);
+      expect(selector.projector<any>()).toBe(2);
 
       selector.setResult(5);
 

--- a/modules/store/spec/selector.spec.ts
+++ b/modules/store/spec/selector.spec.ts
@@ -56,7 +56,7 @@ describe('Selectors', () => {
 
       const selector = createSelector(incrementOne, incrementTwo, projectFn);
 
-      expect(selector.projector<any>()).toBe(2);
+      expect((selector.projector as any)()).toBe(2);
 
       selector.setResult(5);
 

--- a/modules/store/spec/types/selector.spec.ts
+++ b/modules/store/spec/types/selector.spec.ts
@@ -23,16 +23,6 @@ describe('createSelector()', () => {
         selectTest.projector();
       `).toFail(/Expected 2 arguments, but got 0./);
     });
-    it('should not require correct parameters when strictness bypassed with `any` generic argument', () => {
-      expectSnippet(`
-        const selectTest = createSelector(
-            () => 'one',
-            () => 2,
-            (one, two) => 3
-        );
-        selectTest.projector<any>();
-      `).toSucceed();
-    });
     it('should not require parameters for existing explicitly loosely typed selectors', () => {
       expectSnippet(`
         const selectTest: MemoizedSelector<

--- a/modules/store/spec/types/selector.spec.ts
+++ b/modules/store/spec/types/selector.spec.ts
@@ -1,0 +1,51 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('createSelector()', () => {
+  const expectSnippet = expecter(
+    (code) => `
+      import {createSelector} from '@ngrx/store';
+      import { MemoizedSelector, DefaultProjectorFn } from '@ngrx/store';
+
+      ${code}
+    `,
+    compilerOptions()
+  );
+
+  describe('projector', () => {
+    it('should require correct arguments by default', () => {
+      expectSnippet(`
+        const selectTest = createSelector(
+            () => 'one',
+            () => 2,
+            (one, two) => 3
+        );
+        selectTest.projector();
+      `).toFail(/Expected 2 arguments, but got 0./);
+    });
+    it('should not require correct parameters when strictness bypassed with `any` generic argument', () => {
+      expectSnippet(`
+        const selectTest = createSelector(
+            () => 'one',
+            () => 2,
+            (one, two) => 3
+        );
+        selectTest.projector<any>();
+      `).toSucceed();
+    });
+    it('should not require parameters for existing explicitly loosely typed selectors', () => {
+      expectSnippet(`
+        const selectTest: MemoizedSelector<
+          unknown,
+          number,
+          DefaultProjectorFn<number>
+        > = createSelector(
+          () => 'one',
+          () => 2,
+          (one, two) => 3
+        );
+        selectTest.projector();
+      `).toSucceed();
+    });
+  });
+});

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -17,13 +17,32 @@ export type ComparatorFn = (a: any, b: any) => boolean;
 
 export type DefaultProjectorFn<T> = (...args: any[]) => T;
 
+type ProjectorStrictness = 'strict';
+
+type SelectorProjectorArgs<
+  StrictnessConfig extends ProjectorStrictness,
+  ProjectorArgs
+> = StrictnessConfig extends 'strict'
+  ? ProjectorArgs extends unknown[]
+    ? ProjectorArgs
+    : any[]
+  : any[];
+
+type SelectorProjectorFn<ProjectorFn> = ProjectorFn extends (
+  ...args: infer ProjectorArgs
+) => infer ProjectorResult
+  ? <Strictness extends ProjectorStrictness = 'strict'>(
+      ...args: SelectorProjectorArgs<Strictness, ProjectorArgs>
+    ) => ProjectorResult
+  : ProjectorFn;
+
 export interface MemoizedSelector<
   State,
   Result,
   ProjectorFn = DefaultProjectorFn<Result>
 > extends Selector<State, Result> {
   release(): void;
-  projector: ProjectorFn;
+  projector: SelectorProjectorFn<ProjectorFn>;
   setResult: (result?: Result) => void;
   clearResult: () => void;
 }
@@ -125,25 +144,25 @@ export function defaultMemoize(
 export function createSelector<State, S1, Result>(
   s1: Selector<State, S1>,
   projector: (s1: S1) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (s1: S1) => Result>;
 export function createSelector<State, S1, S2, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
   projector: (s1: S1, s2: S2) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (s1: S1, s2: S2) => Result>;
 export function createSelector<State, S1, S2, S3, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
   s3: Selector<State, S3>,
   projector: (s1: S1, s2: S2, s3: S3) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (s1: S1, s2: S2, s3: S3) => Result>;
 export function createSelector<State, S1, S2, S3, S4, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
   s3: Selector<State, S3>,
   s4: Selector<State, S4>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (s1: S1, s2: S2, s3: S3, s4: S4) => Result>;
 export function createSelector<State, S1, S2, S3, S4, S5, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -151,7 +170,11 @@ export function createSelector<State, S1, S2, S3, S4, S5, Result>(
   s4: Selector<State, S4>,
   s5: Selector<State, S5>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<
+  State,
+  Result,
+  (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5) => Result
+>;
 export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -160,7 +183,11 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, Result>(
   s5: Selector<State, S5>,
   s6: Selector<State, S6>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<
+  State,
+  Result,
+  (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6) => Result
+>;
 export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -170,7 +197,11 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, Result>(
   s6: Selector<State, S6>,
   s7: Selector<State, S7>,
   projector: (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<
+  State,
+  Result,
+  (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7) => Result
+>;
 export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
   s1: Selector<State, S1>,
   s2: Selector<State, S2>,
@@ -190,7 +221,11 @@ export function createSelector<State, S1, S2, S3, S4, S5, S6, S7, S8, Result>(
     s7: S7,
     s8: S8
   ) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<
+  State,
+  Result,
+  (s1: S1, s2: S2, s3: S3, s4: S4, s5: S5, s6: S6, s7: S7, s8: S8) => Result
+>;
 
 export function createSelector<State, Slices extends unknown[], Result>(
   ...args: [...slices: Selector<State, unknown>[], projector: unknown] &
@@ -198,7 +233,7 @@ export function createSelector<State, Slices extends unknown[], Result>(
       ...slices: { [i in keyof Slices]: Selector<State, Slices[i]> },
       projector: (...s: Slices) => Result
     ]
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (...s: Slices) => Result>;
 
 /**
  * @deprecated Selectors with props are deprecated, for more info see {@link https://github.com/ngrx/platform/issues/2980 Github Issue}
@@ -346,7 +381,7 @@ export function createSelector<State, Slices extends unknown[], Result>(
   selectors: Selector<State, unknown>[] &
     [...{ [i in keyof Slices]: Selector<State, Slices[i]> }],
   projector: (...s: Slices) => Result
-): MemoizedSelector<State, Result>;
+): MemoizedSelector<State, Result, (...s: Slices) => Result>;
 
 /**
  * @deprecated Selectors with props are deprecated, for more info see {@link https://github.com/ngrx/platform/issues/2980 Github Issue}

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -17,12 +17,6 @@ export type ComparatorFn = (a: any, b: any) => boolean;
 
 export type DefaultProjectorFn<T> = (...args: any[]) => T;
 
-type SelectorProjectorFn<ProjectorFn> = ProjectorFn extends (
-  ...args: infer ProjectorArgs
-) => infer ProjectorResult
-  ? (...args: ProjectorArgs) => ProjectorResult
-  : ProjectorFn;
-
 export interface MemoizedSelector<
   State,
   Result,

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -17,23 +17,10 @@ export type ComparatorFn = (a: any, b: any) => boolean;
 
 export type DefaultProjectorFn<T> = (...args: any[]) => T;
 
-type ProjectorStrictness = 'strict';
-
-type SelectorProjectorArgs<
-  StrictnessConfig extends ProjectorStrictness,
-  ProjectorArgs
-> = StrictnessConfig extends 'strict'
-  ? ProjectorArgs extends unknown[]
-    ? ProjectorArgs
-    : any[]
-  : any[];
-
 type SelectorProjectorFn<ProjectorFn> = ProjectorFn extends (
   ...args: infer ProjectorArgs
 ) => infer ProjectorResult
-  ? <Strictness extends ProjectorStrictness = 'strict'>(
-      ...args: SelectorProjectorArgs<Strictness, ProjectorArgs>
-    ) => ProjectorResult
+  ? (...args: ProjectorArgs) => ProjectorResult
   : ProjectorFn;
 
 export interface MemoizedSelector<

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -23,7 +23,7 @@ export interface MemoizedSelector<
   ProjectorFn = DefaultProjectorFn<Result>
 > extends Selector<State, Result> {
   release(): void;
-  projector: SelectorProjectorFn<ProjectorFn>;
+  projector: ProjectorFn;
   setResult: (result?: Result) => void;
   clearResult: () => void;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3571 

## What is the new behavior?

The `projector` is strict by default, but can be bypassed with an `any` generic parameter.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

A migration will be included to include `<any>` for every existing projector.

## Other information
