### PR TITLE
feat(effects): change the signature of provideEffect

### DIFF
--- a/modules/effects/spec/provide_effects.spec.ts
+++ b/modules/effects/spec/provide_effects.spec.ts
@@ -31,8 +31,8 @@ describe('provideEffects', () => {
         },
         provideStore({}).ɵproviders,
         // provide effects twice
-        provideEffects([]).ɵproviders,
-        provideEffects([]).ɵproviders,
+        provideEffects().ɵproviders,
+        provideEffects().ɵproviders,
       ],
     });
 
@@ -50,8 +50,8 @@ describe('provideEffects', () => {
         },
         provideStore().ɵproviders,
         // provide effects twice
-        provideEffects([]).ɵproviders,
-        provideEffects([]).ɵproviders,
+        provideEffects().ɵproviders,
+        provideEffects().ɵproviders,
       ],
     });
 
@@ -63,7 +63,7 @@ describe('provideEffects', () => {
   it('throws an error when store is not provided', () => {
     TestBed.configureTestingModule({
       // provide only effects
-      providers: [provideEffects([TestEffects]).ɵproviders],
+      providers: [provideEffects(TestEffects).ɵproviders],
     });
 
     expect(() => TestBed.inject(TestEffects)).toThrowError();
@@ -73,7 +73,7 @@ describe('provideEffects', () => {
     TestBed.configureTestingModule({
       providers: [
         provideStore().ɵproviders,
-        provideEffects([TestEffects]).ɵproviders,
+        provideEffects(TestEffects).ɵproviders,
       ],
     });
 
@@ -91,7 +91,7 @@ describe('provideEffects', () => {
   it('runs provided effects after root state registration', (done) => {
     TestBed.configureTestingModule({
       providers: [
-        provideEffects([TestEffects]).ɵproviders,
+        provideEffects(TestEffects).ɵproviders,
         // provide store after effects
         provideStore({ [rootSliceKey]: createReducer('ngrx') }).ɵproviders,
       ],
@@ -114,7 +114,7 @@ describe('provideEffects', () => {
     TestBed.configureTestingModule({
       providers: [
         provideStore().ɵproviders,
-        provideEffects([TestEffects]).ɵproviders,
+        provideEffects(TestEffects).ɵproviders,
         // provide feature state after effects
         provideState(featureSliceKey, createReducer('effects')).ɵproviders,
       ],

--- a/modules/effects/src/provide_effects.ts
+++ b/modules/effects/src/provide_effects.ts
@@ -24,7 +24,7 @@ import { rootEffectsInit as effectsInit } from './effects_actions';
  *
  * ```ts
  * bootstrapApplication(AppComponent, {
- *   providers: [provideEffects([RouterEffects])],
+ *   providers: [provideEffects(RouterEffects]],
  * });
  * ```
  *
@@ -34,7 +34,7 @@ import { rootEffectsInit as effectsInit } from './effects_actions';
  * const booksRoutes: Route[] = [
  *   {
  *     path: '',
- *     providers: [provideEffects([BooksApiEffects])],
+ *     providers: [provideEffects(BooksApiEffects)],
  *     children: [
  *       { path: '', component: BookListComponent },
  *       { path: ':id', component: BookDetailsComponent },
@@ -43,7 +43,9 @@ import { rootEffectsInit as effectsInit } from './effects_actions';
  * ];
  * ```
  */
-export function provideEffects(effects: Type<unknown>[]): EnvironmentProviders {
+export function provideEffects(
+  ...effects: Type<unknown>[]
+): EnvironmentProviders {
   return {
     ɵproviders: [
       effects,

--- a/projects/standalone-app/src/main.ts
+++ b/projects/standalone-app/src/main.ts
@@ -37,6 +37,6 @@ bootstrapApplication(AppComponent, {
       name: 'NgRx Standalone App',
     }),
     provideRouterStore(),
-    provideEffects([AppEffects]),
+    provideEffects(AppEffects),
   ],
 });


### PR DESCRIPTION


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

BREAKING CHANGE:

The signature of `provideEffects` is changed to expect a spreaded array of effects.

BEFORE:

`provideEffects` expecteded the effects to be passed as an array.

```ts
// single effect
provideEffects([MyEffect])

// multiple effects
provideEffects([MyEffect, MySecondEffect])
```

AFTER:

`provideEffects` expects the effects as a spreaded array as argument.

```ts
// single effect
provideEffects(MyEffect)

// multiple effects
provideEffects(MyEffect, MySecondEffect)
```