### PR TITLE
fix(router-store): set undefined for unserializable route title

### DIFF
--- a/modules/router-store/src/serializers/minimal_serializer.ts
+++ b/modules/router-store/src/serializers/minimal_serializer.ts
@@ -43,7 +43,10 @@ export class MinimalRouterStateSerializer
             pathMatch: route.routeConfig.pathMatch,
             redirectTo: route.routeConfig.redirectTo,
             outlet: route.routeConfig.outlet,
-            title: route.routeConfig.title,
+            title:
+              typeof route.routeConfig.title === 'string'
+                ? route.routeConfig.title
+                : undefined,
           }
         : null,
       queryParams: route.queryParams,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3495 

## What is the new behavior?

`MinimalRouterStateSerializer` sets `undefined` for unserializable route title.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is a temporary fix to avoid runtime errors when the `@ngrx/router-store` package is used with a custom title resolver in Angular 14. I'll create another PR that completely resolves this issue when we move to Angular 15 (that includes this fix https://github.com/angular/angular/issues/47459).
