### PR TITLE
feat(component): handle observable dictionaries

### DIFF
--- a/modules/component/spec/core/potential-observable.spec.ts
+++ b/modules/component/spec/core/potential-observable.spec.ts
@@ -32,7 +32,17 @@ describe('fromPotentialObservable', () => {
 
   testNonObservableInput(true, 'boolean');
 
-  testNonObservableInput({ ngrx: 'component' }, 'object');
+  testNonObservableInput({}, 'empty object');
+
+  testNonObservableInput(
+    { ngrx: 'component' },
+    'object with non-observable values'
+  );
+
+  testNonObservableInput(
+    { x: of(1), y: 2 },
+    'object with at least one non-observable value'
+  );
 
   testNonObservableInput([1, 2, 3], 'array');
 
@@ -51,5 +61,21 @@ describe('fromPotentialObservable', () => {
     const obs1$ = of('ngrx');
     const obs2$ = fromPotentialObservable(obs1$);
     expect(obs1$).toBe(obs2$);
+  });
+
+  it('should combine observables and distinct same values from observable dictionary', () => {
+    const { testScheduler } = setup();
+
+    testScheduler.run(({ cold, expectObservable }) => {
+      const o1$ = cold('o--p-q', { o: 1, p: 2, q: 2 });
+      const o2$ = cold('-xy-z-', { x: 3, y: 3, z: 4 });
+
+      const result$ = fromPotentialObservable({ o1: o1$, o2: o2$ });
+      expectObservable(result$).toBe('-k-lm-', {
+        k: { o1: 1, o2: 3 },
+        l: { o1: 2, o2: 3 },
+        m: { o1: 2, o2: 4 },
+      });
+    });
   });
 });

--- a/modules/component/spec/core/render-event/manager.spec.ts
+++ b/modules/component/spec/core/render-event/manager.spec.ts
@@ -19,7 +19,7 @@ describe('createRenderEventManager', () => {
     const nextHandler = jest.fn();
     const errorHandler = jest.fn();
     const completeHandler = jest.fn();
-    const renderEventManager = createRenderEventManager<T>({
+    const renderEventManager = createRenderEventManager<Observable<T>>({
       suspense: suspenseHandler,
       next: nextHandler,
       error: errorHandler,

--- a/modules/component/spec/types/let.directive.types.spec.ts
+++ b/modules/component/spec/types/let.directive.types.spec.ts
@@ -19,9 +19,14 @@ describe('LetDirective', () => {
     expectPotentialObservable('number').toBeInferredAs('number');
     expectPotentialObservable('null').toBeInferredAs('null');
     expectPotentialObservable('string[]').toBeInferredAs('string[]');
+    expectPotentialObservable('{}').toBeInferredAs('{}');
     expectPotentialObservable('{ ngrx: boolean; }').toBeInferredAs(
       '{ ngrx: boolean; }'
     );
+    expectPotentialObservable(
+      'User',
+      'interface User { name: string; }'
+    ).toBeInferredAs('User');
   });
 
   it('should infer the value when potential observable is a union of non-observables', () => {
@@ -76,5 +81,70 @@ describe('LetDirective', () => {
     expectPotentialObservable(
       'Observable<number> | Promise<{ ngrx: string; }> | boolean | null'
     ).toBeInferredAs('number | boolean | { ngrx: string; } | null');
+  });
+
+  it('should infer the value when potential observable is an observable dictionary', () => {
+    expectPotentialObservable(
+      '{ o1: Observable<number>; o2: Observable<{ ngrx: string }> }'
+    ).toBeInferredAs('{ o1: number; o2: { ngrx: string; }; }');
+  });
+
+  it('should infer the value when potential observable is an observable dictionary typed as interface', () => {
+    expectPotentialObservable(
+      'Dictionary',
+      'interface Dictionary { x: Observable<string>; y: Observable<boolean | undefined> }'
+    ).toBeInferredAs('{ x: string; y: boolean | undefined; }');
+  });
+
+  it('should infer the value as static when potential observable is a dictionary with at least one non-observable property', () => {
+    expectPotentialObservable(
+      '{ o: Observable<bigint>; n: number }'
+    ).toBeInferredAs('{ o: Observable<bigint>; n: number; }');
+    expectPotentialObservable(
+      'Dictionary',
+      'interface Dictionary { o: Observable<number>; p: Promise<string> }'
+    ).toBeInferredAs('Dictionary');
+  });
+
+  it('should infer the value as static when potential observable is an observable dictionary with optional properties', () => {
+    expectPotentialObservable(
+      '{ o1: Observable<boolean>; o2?: Observable<string> }'
+    ).toBeInferredAs(
+      '{ o1: Observable<boolean>; o2?: Observable<string> | undefined; }'
+    );
+    expectPotentialObservable(
+      'Dictionary',
+      'interface Dictionary { o1: Observable<number>; o2?: Observable<bigint> }'
+    ).toBeInferredAs('Dictionary');
+  });
+
+  it('should infer the value when potential observable is a union of observable dictionary and non-observable', () => {
+    expectPotentialObservable(
+      '{ o: Observable<string> } | { ngrx: string }'
+    ).toBeInferredAs('{ ngrx: string; } | { o: string; }');
+    expectPotentialObservable(
+      'Dictionary | number',
+      'interface Dictionary { o: Observable<number> }'
+    ).toBeInferredAs('number | { o: number; }');
+  });
+
+  it('should infer the value when potential observable is a union of observable dictionary and promise', () => {
+    expectPotentialObservable(
+      '{ o: Observable<symbol> } | Promise<{ ngrx: string }>'
+    ).toBeInferredAs('{ ngrx: string; } | { o: symbol; }');
+    expectPotentialObservable(
+      'Dictionary | Promise<number>',
+      'interface Dictionary { o: Observable<number> }'
+    ).toBeInferredAs('number | { o: number; }');
+  });
+
+  it('should infer the value when potential observable is a union of observable dictionary and observable', () => {
+    expectPotentialObservable(
+      '{ o: Observable<number> } | Observable<{ ngrx: string }>'
+    ).toBeInferredAs('{ ngrx: string; } | { o: number; }');
+    expectPotentialObservable(
+      'Dictionary | Observable<boolean>',
+      'interface Dictionary { o: Observable<boolean> }'
+    ).toBeInferredAs('boolean | { o: boolean; }');
   });
 });

--- a/modules/component/spec/types/push.pipe.types.spec.ts
+++ b/modules/component/spec/types/push.pipe.types.spec.ts
@@ -16,9 +16,14 @@ describe('PushPipe', () => {
     expectPotentialObservable('string').toBeInferredAs('string');
     expectPotentialObservable('undefined').toBeInferredAs('undefined');
     expectPotentialObservable('boolean[]').toBeInferredAs('boolean[]');
+    expectPotentialObservable('{}').toBeInferredAs('{}');
     expectPotentialObservable(
       '{ x: number; y: string; z: symbol; }'
     ).toBeInferredAs('{ x: number; y: string; z: symbol; }');
+    expectPotentialObservable(
+      'Book',
+      'interface Book { title: string; }'
+    ).toBeInferredAs('Book');
   });
 
   it('should infer the result when potential observable is a union of non-observables', () => {
@@ -66,12 +71,79 @@ describe('PushPipe', () => {
   it('should infer the result when potential observable is a union of observable and non-observable', () => {
     expectPotentialObservable(
       'Observable<number[]> | Record<string, unknown>'
-    ).toBeInferredAs('number[] | Record<string, unknown> | undefined');
+    ).toBeInferredAs('Record<string, unknown> | number[] | undefined');
   });
 
   it('should infer the result when potential observable is a union of observable, promise, and non-observable', () => {
     expectPotentialObservable(
       'Observable<{ z: symbol; }> | Promise<number[]> | boolean | null'
     ).toBeInferredAs('boolean | { z: symbol; } | number[] | null | undefined');
+  });
+
+  it('should infer the result when potential observable is an observable dictionary', () => {
+    expectPotentialObservable(
+      '{ o1: Observable<number | boolean>; o2: Observable<{ ngrx: string }> }'
+    ).toBeInferredAs(
+      '{ o1: number | boolean; o2: { ngrx: string; }; } | undefined'
+    );
+  });
+
+  it('should infer the result when potential observable is an observable dictionary typed as interface', () => {
+    expectPotentialObservable(
+      'Dictionary',
+      'interface Dictionary { o1: Observable<bigint>; o2: Observable<string | symbol> }'
+    ).toBeInferredAs('{ o1: bigint; o2: string | symbol; } | undefined');
+  });
+
+  it('should infer the result as static when potential observable is a dictionary with at least one non-observable property', () => {
+    expectPotentialObservable(
+      '{ o: Observable<string>; b: boolean }'
+    ).toBeInferredAs('{ o: Observable<string>; b: boolean; }');
+    expectPotentialObservable(
+      'Dictionary',
+      'interface Dictionary { o: Observable<string>; p: Promise<null> }'
+    ).toBeInferredAs('Dictionary');
+  });
+
+  it('should infer the result as static when potential observable is an observable dictionary with optional properties', () => {
+    expectPotentialObservable(
+      '{ x: Observable<number>; y?: Observable<bigint> }'
+    ).toBeInferredAs(
+      '{ x: Observable<number>; y?: Observable<bigint> | undefined; }'
+    );
+    expectPotentialObservable(
+      'Dictionary',
+      'interface Dictionary { o1: Observable<number>; o2?: Observable<bigint> }'
+    ).toBeInferredAs('Dictionary');
+  });
+
+  it('should infer the result when potential observable is a union of observable dictionary and non-observable', () => {
+    expectPotentialObservable(
+      '{ x: Observable<string> } | { y: number; z: bigint; }'
+    ).toBeInferredAs('{ y: number; z: bigint; } | { x: string; } | undefined');
+    expectPotentialObservable(
+      'Dictionary | number',
+      'interface Dictionary { x: Observable<string> }'
+    ).toBeInferredAs('number | { x: string; } | undefined');
+  });
+
+  it('should infer the result when potential observable is a union of observable dictionary and promise', () => {
+    expectPotentialObservable(
+      '{ ngrx: Observable<string> } | Promise<string>'
+    ).toBeInferredAs('string | { ngrx: string; } | undefined');
+    expectPotentialObservable(
+      'Dictionary | Promise<symbol>',
+      'interface Dictionary { o: Observable<symbol> }'
+    ).toBeInferredAs('symbol | { o: symbol; } | undefined');
+  });
+
+  it('should infer the value when potential observable is a union of observable dictionary and observable', () => {
+    expectPotentialObservable(
+      '{ o: Observable<number> } | Observable<number>'
+    ).toBeInferredAs('number | { o: number; } | undefined');
+    expectPotentialObservable(
+      'Dictionary | Observable<bigint>',
+      'interface Dictionary { o: Observable<bigint> }'
+    ).toBeInferredAs('bigint | { o: bigint; } | undefined');
   });
 });

--- a/modules/component/spec/types/utils.ts
+++ b/modules/component/spec/types/utils.ts
@@ -18,8 +18,11 @@ export function potentialObservableExpecter(
     throw new Error('Snippet must include a constant named `value`!');
   }
 
-  return (potentialObservableType: string) => {
-    const expectSnippet = expecter(snippetFactory, compilerOptions());
+  return (potentialObservableType: string, typeDefinition = '') => {
+    const expectSnippet = expecter(
+      () => `${typeDefinition} ${snippetFactory(potentialObservableType)}`,
+      compilerOptions()
+    );
 
     return {
       toBeInferredAs(valueType: string): void {

--- a/modules/component/src/core/potential-observable.ts
+++ b/modules/component/src/core/potential-observable.ts
@@ -1,25 +1,83 @@
-import { from, isObservable, Observable } from 'rxjs';
+import { combineLatest, from, isObservable, Observable } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
 
-export type ObservableOrPromise<T> = Observable<T> | PromiseLike<T>;
+type Primitive = string | number | bigint | boolean | symbol | null | undefined;
 
-export type PotentialObservable<T> = T | ObservableOrPromise<T>;
+type ObservableOrPromise<T> = Observable<T> | PromiseLike<T>;
 
-export function fromPotentialObservable<T>(
-  potentialObservable: PotentialObservable<T>
-): Observable<T> {
+type ObservableDictionary<PO> = Required<{
+  [Key in keyof PO]: Observable<unknown>;
+}>;
+
+export type PotentialObservableResult<
+  PO,
+  ExtendedResult = never
+> = PO extends ObservableOrPromise<infer Result>
+  ? Result | ExtendedResult
+  : PO extends Primitive
+  ? PO
+  : keyof PO extends never
+  ? PO
+  : PO extends ObservableDictionary<PO>
+  ?
+      | {
+          [Key in keyof PO]: PO[Key] extends Observable<infer Value>
+            ? Value
+            : never;
+        }
+      | ExtendedResult
+  : PO;
+
+export function fromPotentialObservable<PO>(
+  potentialObservable: PO
+): Observable<PotentialObservableResult<PO>> {
+  type Result = ReturnType<typeof fromPotentialObservable<PO>>;
+
   if (isObservable(potentialObservable)) {
-    return potentialObservable;
+    return potentialObservable as Result;
+  }
+
+  if (isObservableDictionary(potentialObservable)) {
+    return combineLatest(
+      toDistinctObsDictionary(potentialObservable)
+    ) as Result;
   }
 
   if (isPromiseLike(potentialObservable)) {
-    return from(potentialObservable);
+    return from(potentialObservable) as Result;
   }
 
-  return new Observable((subscriber) => {
+  return new Observable<PO>((subscriber) => {
     subscriber.next(potentialObservable);
-  });
+  }) as Result;
 }
 
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return typeof (value as PromiseLike<unknown>)?.then === 'function';
+}
+
+function isObservableDictionary(
+  value: unknown
+): value is Record<string, Observable<unknown>> {
+  return (
+    isDictionary(value) &&
+    Object.keys(value).length > 0 &&
+    Object.values(value).every(isObservable)
+  );
+}
+
+function isDictionary(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toDistinctObsDictionary<
+  OD extends Record<string, Observable<unknown>>
+>(obsDictionary: OD): OD {
+  return Object.keys(obsDictionary).reduce(
+    (acc, key) => ({
+      ...acc,
+      [key]: obsDictionary[key].pipe(distinctUntilChanged()),
+    }),
+    {} as OD
+  );
 }

--- a/modules/component/src/core/render-event/manager.ts
+++ b/modules/component/src/core/render-event/manager.ts
@@ -4,19 +4,21 @@ import { ErrorRenderEvent, NextRenderEvent, RenderEvent } from './models';
 import { combineRenderEventHandlers, RenderEventHandlers } from './handlers';
 import {
   fromPotentialObservable,
-  PotentialObservable,
+  PotentialObservableResult,
 } from '../potential-observable';
 
-export interface RenderEventManager<T> {
-  nextPotentialObservable(potentialObservable: PotentialObservable<T>): void;
-  handlePotentialObservableChanges(): Observable<RenderEvent<T>>;
+export interface RenderEventManager<PO> {
+  nextPotentialObservable(potentialObservable: PO): void;
+  handlePotentialObservableChanges(): Observable<
+    RenderEvent<PotentialObservableResult<PO>>
+  >;
 }
 
-export function createRenderEventManager<T>(
-  handlers: RenderEventHandlers<T>
-): RenderEventManager<T> {
+export function createRenderEventManager<PO>(
+  handlers: RenderEventHandlers<PotentialObservableResult<PO>>
+): RenderEventManager<PO> {
   const handleRenderEvent = combineRenderEventHandlers(handlers);
-  const potentialObservable$ = new ReplaySubject<PotentialObservable<T>>(1);
+  const potentialObservable$ = new ReplaySubject<PO>(1);
 
   return {
     nextPotentialObservable(potentialObservable) {
@@ -33,39 +35,41 @@ export function createRenderEventManager<T>(
   };
 }
 
-function switchMapToRenderEvent<T>(): (
-  source: Observable<PotentialObservable<T>>
-) => Observable<RenderEvent<T>> {
+function switchMapToRenderEvent<PO>(): (
+  source: Observable<PO>
+) => Observable<RenderEvent<PotentialObservableResult<PO>>> {
   return pipe(
     switchMap((potentialObservable) => {
       const observable$ = fromPotentialObservable(potentialObservable);
       let reset = true;
       let synchronous = true;
 
-      return new Observable<RenderEvent<T>>((subscriber) => {
-        const subscription = observable$.subscribe({
-          next(value) {
-            subscriber.next({ type: 'next', value, reset, synchronous });
-            reset = false;
-          },
-          error(error) {
-            subscriber.next({ type: 'error', error, reset, synchronous });
-            reset = false;
-          },
-          complete() {
-            subscriber.next({ type: 'complete', reset, synchronous });
-            reset = false;
-          },
-        });
+      return new Observable<RenderEvent<PotentialObservableResult<PO>>>(
+        (subscriber) => {
+          const subscription = observable$.subscribe({
+            next(value) {
+              subscriber.next({ type: 'next', value, reset, synchronous });
+              reset = false;
+            },
+            error(error) {
+              subscriber.next({ type: 'error', error, reset, synchronous });
+              reset = false;
+            },
+            complete() {
+              subscriber.next({ type: 'complete', reset, synchronous });
+              reset = false;
+            },
+          });
 
-        if (reset) {
-          subscriber.next({ type: 'suspense', reset, synchronous: true });
-          reset = false;
+          if (reset) {
+            subscriber.next({ type: 'suspense', reset, synchronous: true });
+            reset = false;
+          }
+          synchronous = false;
+
+          return subscription;
         }
-        synchronous = false;
-
-        return subscription;
-      });
+      );
     })
   );
 }

--- a/modules/component/src/push/push.pipe.ts
+++ b/modules/component/src/push/push.pipe.ts
@@ -1,12 +1,10 @@
 import { ErrorHandler, OnDestroy, Pipe, PipeTransform } from '@angular/core';
 import { Unsubscribable } from 'rxjs';
-import { ObservableOrPromise } from '../core/potential-observable';
+import { PotentialObservableResult } from '../core/potential-observable';
 import { createRenderScheduler } from '../core/render-scheduler';
 import { createRenderEventManager } from '../core/render-event/manager';
 
-type PushPipeResult<PO> = PO extends ObservableOrPromise<infer R>
-  ? R | undefined
-  : PO;
+type PushPipeResult<PO> = PotentialObservableResult<PO, undefined>;
 
 /**
  * @ngModule PushModule
@@ -19,12 +17,22 @@ type PushPipeResult<PO> = PO extends ObservableOrPromise<infer R>
  *
  * @usageNotes
  *
+ * ### Displaying Observable Values
+ *
  * ```html
  * <p>{{ number$ | ngrxPush }}</p>
  *
  * <ng-container *ngIf="number$ | ngrxPush as n">{{ n }}</ng-container>
  *
  * <app-number [number]="number$ | ngrxPush"></app-number>
+ * ```
+ *
+ * ### Combining Multiple Observables
+ *
+ * ```html
+ * <code>
+ *   {{ { users: users$, query: query$ } | ngrxPush | json }}
+ * </code>
  * ```
  *
  * @publicApi

--- a/projects/ngrx.io/content/guide/component/index.md
+++ b/projects/ngrx.io/content/guide/component/index.md
@@ -14,6 +14,7 @@ This package is still experimental and may change during development.
 
 - Rendering observable events in a performant way.
 - Displaying different content based on the current state of an observable.
+- Combining multiple observables in the template.
 - Creating readable templates by using aliases for nested properties.
 - Building fully reactive Angular applications regardless of whether `zone.js` is present or not.
 

--- a/projects/ngrx.io/content/guide/component/let.md
+++ b/projects/ngrx.io/content/guide/component/let.md
@@ -88,6 +88,18 @@ We can track next, error, and complete events:
 </ng-container>
 ```
 
+## Combining Multiple Observables
+
+The `*ngrxLet` directive can be also used with a dictionary of observables.
+This feature provides the ability to create a view model object in the template:
+
+```html
+<ng-container *ngrxLet="{ users: users$, query: query$ } as vm">
+  <app-search-bar [query]="vm.query"></app-search-bar>
+  <app-user-list [users]="vm.users"></app-user-list>
+</ng-container>
+```
+
 ## Using Suspense Template
 
 There is an option to pass the suspense template that will be displayed
@@ -134,6 +146,7 @@ This feature provides the ability to create readable templates by using aliases 
   (See ["Comparison with `*ngIf` and `async`"](#comparison-with-ngif-and-async) section)
 - Takes away the multiple usages of the `async` or `ngrxPush` pipe.
 - Allows displaying different content based on the current state of an observable.
+- Allows combining multiple observables in the template.
 - Provides a unified/structured way of handling `null` and `undefined`.
 - Provides the ability to create readable templates by using aliases for nested properties.
 - Triggers change detection using the `RenderScheduler` that behaves differently in

--- a/projects/ngrx.io/content/guide/component/push.md
+++ b/projects/ngrx.io/content/guide/component/push.md
@@ -74,9 +74,21 @@ an observable emits a new value. It can be used as follows:
 <app-number [number]="number$ | ngrxPush"></app-number>
 ```
 
+## Combining Multiple Observables
+
+The `ngrxPush` pipe can be also used with a dictionary of observables in the
+following way:
+
+```html
+<code>
+  {{ { users: users$, query: query$ } | ngrxPush | json }}
+</code>
+```
+
 ## Included Features
 
 - Takes observables or promises, retrieves their values, and passes the value to the template.
+- Allows combining multiple observables in the template.
 - Handles `null` and `undefined` values in a clean unified/structured way.
 - Triggers change detection using the `RenderScheduler` that behaves differently in
   zone-full and zone-less mode.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`*ngrxLet` directive and `ngrxPush` pipe treat observable dictionaries as static values.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3545 

## What is the new behavior?

`*ngrxLet` directive and `ngrxPush` pipe are able to handle observable dictionaries.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
