### PR TITLE
feat(store): make reducers arg of StoreModule.forRoot optional

### DIFF
--- a/modules/store/src/provide_store.ts
+++ b/modules/store/src/provide_store.ts
@@ -114,8 +114,11 @@ export function provideState<T, V extends Action = Action>(
 }
 
 export function _provideStore<T, V extends Action = Action>(
-  reducers: ActionReducerMap<T, V> | InjectionToken<ActionReducerMap<T, V>>,
-  config: RootStoreConfig<T, V>
+  reducers:
+    | ActionReducerMap<T, V>
+    | InjectionToken<ActionReducerMap<T, V>>
+    | Record<string, never> = {},
+  config: RootStoreConfig<T, V> = {}
 ): Provider[] {
   return [
     {
@@ -211,7 +214,7 @@ export function provideStore<T, V extends Action = Action>(
   config?: RootStoreConfig<T, V>
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
-    ..._provideStore(reducers ?? ({} as ActionReducerMap<T, V>), config ?? {}),
+    ..._provideStore(reducers, config),
     ENVIRONMENT_STORE_PROVIDER,
   ]);
 }

--- a/modules/store/src/store_module.ts
+++ b/modules/store/src/store_module.ts
@@ -81,12 +81,12 @@ export class StoreFeatureModule implements OnDestroy {
 @NgModule({})
 export class StoreModule {
   static forRoot<T, V extends Action = Action>(
-    reducers: ActionReducerMap<T, V> | InjectionToken<ActionReducerMap<T, V>>,
+    reducers?: ActionReducerMap<T, V> | InjectionToken<ActionReducerMap<T, V>>,
     config?: RootStoreConfig<T, V>
   ): ModuleWithProviders<StoreRootModule> {
     return {
       ngModule: StoreRootModule,
-      providers: [..._provideStore(reducers, config ?? {})],
+      providers: [..._provideStore(reducers, config)],
     };
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Importing `StoreModule.forRoot` without initial reducers is done in the following way:

```ts
imports: [
  StoreModule.forRoot({}),
]
```

## What is the new behavior?

Importing `StoreModule.forRoot` without initial reducers can be also done as follows:

```ts
imports: [
  StoreModule.forRoot(),
]
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
