### PR TITLE
docs(store): fix link to component-store

### DIFF
--- a/projects/ngrx.io/content/guide/store/why.md
+++ b/projects/ngrx.io/content/guide/store/why.md
@@ -1,6 +1,6 @@
 # Why use NgRx Store for State Management?
 
-NgRx Store provides state management for creating maintainable, explicit applications through the use of single state and actions in order to express state changes. In cases where you don't need a global, application-wide solution to manage state, consider using [NgRx ComponentStore](guide/component) which provides a solution for local state management.
+NgRx Store provides state management for creating maintainable, explicit applications through the use of single state and actions in order to express state changes. In cases where you don't need a global, application-wide solution to manage state, consider using [NgRx ComponentStore](guide/component-store) which provides a solution for local state management.
 
 ## When Should I Use NgRx Store for State Management?
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There's a link in the doc for component-store that actually points to component

## What is the new behavior?

The link correctly points to component-store

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```