### PR TITLE
feat(router-store): return resolved title via selectTitle

### DIFF
--- a/modules/router-store/spec/router_selectors.spec.ts
+++ b/modules/router-store/spec/router_selectors.spec.ts
@@ -41,7 +41,6 @@ const mockData = {
         outlet: 'primary',
         routeConfig: {
           path: 'login',
-          title: 'Login',
         },
         queryParams: {
           ref: 'ngrx.io',
@@ -234,10 +233,65 @@ describe('Router State Selectors', () => {
       expect(result).toEqual(state.router.state.url);
     });
 
-    it('should create a selector for getting the title', () => {
-      const result = selectors.selectTitle(state);
+    describe('selectTitle', () => {
+      it('should return undefined when route is not defined', () => {
+        const title = selectors.selectTitle({
+          router: { state: { root: null }, navigationId: 1 },
+        });
 
-      expect(result).toEqual(state.router.state.routeConfig?.title);
+        expect(title).toBe(undefined);
+      });
+
+      it('should return undefined when route config is not defined', () => {
+        const title = selectors.selectTitle({
+          router: {
+            state: { root: { routeConfig: null } },
+            navigationId: 1,
+          },
+        });
+
+        expect(title).toBe(undefined);
+      });
+
+      it('should return undefined when title is not defined', () => {
+        const title = selectors.selectTitle({
+          router: {
+            state: { root: { routeConfig: {} } },
+            navigationId: 1,
+          },
+        });
+
+        expect(title).toBe(undefined);
+      });
+
+      it('should return static title', () => {
+        const staticTitle = 'Static Title';
+        const title = selectors.selectTitle({
+          router: {
+            state: { root: { routeConfig: { title: staticTitle } } },
+            navigationId: 1,
+          },
+        });
+
+        expect(title).toBe(staticTitle);
+      });
+
+      it('should return resolved title', () => {
+        const resolvedTitle = 'Resolved Title';
+        const title = selectors.selectTitle({
+          router: {
+            state: {
+              root: {
+                routeConfig: { title: class TitleResolver {} },
+                title: resolvedTitle,
+              },
+            },
+            navigationId: 1,
+          },
+        });
+
+        expect(title).toBe(resolvedTitle);
+      });
     });
   });
 });

--- a/modules/router-store/src/router_selectors.ts
+++ b/modules/router-store/src/router_selectors.ts
@@ -58,10 +58,14 @@ export function getSelectors<V extends Record<string, any>>(
     selectRouterState,
     (routerState) => routerState && routerState.url
   );
-  const selectTitle = createSelector(
-    selectCurrentRoute,
-    (route) => route && route.routeConfig?.title
-  );
+  const selectTitle = createSelector(selectCurrentRoute, (route) => {
+    if (!route?.routeConfig) {
+      return undefined;
+    }
+    return typeof route.routeConfig.title === 'string'
+      ? route.routeConfig.title // static title
+      : route.title; // resolved title
+  });
 
   return {
     selectCurrentRoute,

--- a/modules/router-store/src/serializers/minimal_serializer.ts
+++ b/modules/router-store/src/serializers/minimal_serializer.ts
@@ -9,6 +9,7 @@ export interface MinimalActivatedRouteSnapshot {
   fragment: ActivatedRouteSnapshot['fragment'];
   data: ActivatedRouteSnapshot['data'];
   outlet: ActivatedRouteSnapshot['outlet'];
+  title: ActivatedRouteSnapshot['title'];
   firstChild?: MinimalActivatedRouteSnapshot;
   children: MinimalActivatedRouteSnapshot[];
 }
@@ -37,6 +38,7 @@ export class MinimalRouterStateSerializer
       data: route.data,
       url: route.url,
       outlet: route.outlet,
+      title: route.title,
       routeConfig: route.routeConfig
         ? {
             path: route.routeConfig.path,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `selectTitle` selector returns only a static title. When custom title resolver is used, the `selectTitle` result is `undefined`.

Closes #3622

## What is the new behavior?

The `selectTitle` selector returns resolved route title when a custom title resolver is used.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

```
BREAKING CHANGES:

Property `title: string | undefined` is added to the `MinimalActivatedRouteSnapshot` interface.

BEFORE:

The `MinimalActivatedRouteSnapshot` interface doesn't contain the `title` property.

AFTER:

The `MinimalActivatedRouteSnapshot` interface contains the required `title` property.
```