### PR TITLE
feat(data): add withEffects feature for provideEntityData

### DIFF
--- a/modules/data/src/entity-data-without-effects.module.ts
+++ b/modules/data/src/entity-data-without-effects.module.ts
@@ -1,9 +1,8 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { EntityDataModuleConfig } from './entity-data-config';
 import {
-  provideRootEntityDataWithoutEffects,
-  ENTITY_DATA_WITHOUT_EFFECTS_PROVIDERS,
-  initializeEntityDataWithoutEffects,
+  BASE_ENTITY_DATA_PROVIDERS,
+  provideEntityDataConfig,
 } from './provide-entity-data';
 
 /**
@@ -13,7 +12,7 @@ import {
  * therefore opt-out of @ngrx/effects for entities
  */
 @NgModule({
-  providers: [ENTITY_DATA_WITHOUT_EFFECTS_PROVIDERS],
+  providers: [BASE_ENTITY_DATA_PROVIDERS],
 })
 export class EntityDataModuleWithoutEffects {
   static forRoot(
@@ -21,11 +20,7 @@ export class EntityDataModuleWithoutEffects {
   ): ModuleWithProviders<EntityDataModuleWithoutEffects> {
     return {
       ngModule: EntityDataModuleWithoutEffects,
-      providers: [provideRootEntityDataWithoutEffects(config)],
+      providers: [provideEntityDataConfig(config)],
     };
-  }
-
-  constructor() {
-    initializeEntityDataWithoutEffects();
   }
 }

--- a/modules/data/src/entity-data.module.ts
+++ b/modules/data/src/entity-data.module.ts
@@ -1,12 +1,9 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-
 import { EntityDataModuleConfig } from './entity-data-config';
 import { EntityDataModuleWithoutEffects } from './entity-data-without-effects.module';
 import {
-  ENTITY_DATA_PROVIDERS,
-  initializeEntityData,
-  provideRootEntityData,
-  provideRootEntityDataWithoutEffects,
+  ENTITY_DATA_EFFECTS_PROVIDERS,
+  provideEntityDataConfig,
 } from './provide-entity-data';
 
 /**
@@ -16,7 +13,7 @@ import {
  */
 @NgModule({
   imports: [EntityDataModuleWithoutEffects],
-  providers: [ENTITY_DATA_PROVIDERS],
+  providers: [ENTITY_DATA_EFFECTS_PROVIDERS],
 })
 export class EntityDataModule {
   static forRoot(
@@ -24,14 +21,7 @@ export class EntityDataModule {
   ): ModuleWithProviders<EntityDataModule> {
     return {
       ngModule: EntityDataModule,
-      providers: [
-        provideRootEntityDataWithoutEffects(config),
-        provideRootEntityData(config),
-      ],
+      providers: [provideEntityDataConfig(config)],
     };
-  }
-
-  constructor() {
-    initializeEntityData();
   }
 }

--- a/modules/data/src/index.ts
+++ b/modules/data/src/index.ts
@@ -198,7 +198,4 @@ export { EntityDataModuleWithoutEffects } from './entity-data-without-effects.mo
 export { EntityDataModule } from './entity-data.module';
 
 // // Standalone APIs
-export {
-  provideEntityData,
-  provideEntityDataWithoutEffects,
-} from './provide-entity-data';
+export { provideEntityData, withEffects } from './provide-entity-data';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There are two standalone functions for `@ngrx/data` package: `provideEntityData` and `provideEntityDataWithoutEffects`.

## What is the new behavior?

There is only one standalone function for `@ngrx/data` package - `provideEntityData`.

When it's used in the following way:

```ts
provideEntityData({ entityMetadata });
```

It provides entity data with entity configuration without effects.

When it's used with `withEffects` feature as follows:

```ts
provideEntityData({ entityMetadata }, withEffects());
```

It also registers entity effects and provides HTTP data services.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

There are no breaking changes because standalone `@ngrx/data` APIs are not released yet.
