### PR TITLE
feat(effects): add ability to create functional effects

### DIFF
--- a/modules/effects/spec/effect_creator.spec.ts
+++ b/modules/effects/spec/effect_creator.spec.ts
@@ -12,7 +12,7 @@ describe('createEffect()', () => {
     const effect = createEffect(() => of({ type: 'a' }));
 
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ dispatch: true })
+      expect.objectContaining({ dispatch: true })
     );
   });
 
@@ -22,7 +22,7 @@ describe('createEffect()', () => {
     });
 
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ dispatch: true })
+      expect.objectContaining({ dispatch: true })
     );
   });
 
@@ -32,7 +32,7 @@ describe('createEffect()', () => {
     });
 
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ dispatch: false })
+      expect.objectContaining({ dispatch: false })
     );
   });
 
@@ -42,7 +42,7 @@ describe('createEffect()', () => {
     });
 
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ dispatch: false })
+      expect.objectContaining({ dispatch: false })
     );
   });
 
@@ -52,7 +52,7 @@ describe('createEffect()', () => {
 
     expect(effect).toBe(obs$);
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ functional: false })
+      expect.objectContaining({ functional: false })
     );
   });
 
@@ -62,7 +62,7 @@ describe('createEffect()', () => {
 
     expect(effect).toBe(obs$);
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ functional: false })
+      expect.objectContaining({ functional: false })
     );
   });
 
@@ -72,7 +72,7 @@ describe('createEffect()', () => {
 
     expect(effect).toBe(source);
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ functional: true })
+      expect.objectContaining({ functional: true })
     );
   });
 
@@ -93,7 +93,7 @@ describe('createEffect()', () => {
     const effect = createEffect(() => of({ type: 'a' }));
 
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ useEffectsErrorHandler: true })
+      expect.objectContaining({ useEffectsErrorHandler: true })
     );
   });
 
@@ -103,7 +103,7 @@ describe('createEffect()', () => {
     });
 
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ useEffectsErrorHandler: true })
+      expect.objectContaining({ useEffectsErrorHandler: true })
     );
   });
 
@@ -113,7 +113,7 @@ describe('createEffect()', () => {
     });
 
     expect(effect['__@ngrx/effects_create__']).toEqual(
-      jasmine.objectContaining({ useEffectsErrorHandler: false })
+      expect.objectContaining({ useEffectsErrorHandler: false })
     );
   });
 

--- a/modules/effects/spec/effect_sources.spec.ts
+++ b/modules/effects/spec/effect_sources.spec.ts
@@ -201,20 +201,60 @@ describe('EffectSources', () => {
         }
       }
 
-      it('should resolve effects from instances', () => {
-        const sources$ = cold('--a--', { a: new SourceA() });
-        const expected = cold('--a--', { a });
+      const recordA = {
+        a: createEffect(() => alwaysOf(a), { functional: true }),
+      };
+      const recordB = {
+        b: createEffect(() => alwaysOf(b), { functional: true }),
+      };
+
+      it('should resolve effects from class instances', () => {
+        const sources$ = cold('--a--b--', {
+          a: new SourceA(),
+          b: new SourceB(),
+        });
+        const expected = cold('--a--b--', { a, b });
 
         const output = toActions(sources$);
 
         expect(output).toBeObservable(expected);
       });
 
-      it('should ignore duplicate sources', () => {
+      it('should resolve effects from records', () => {
+        const sources$ = cold('--a--b--', { a: recordA, b: recordB });
+        const expected = cold('--a--b--', { a, b });
+
+        const output = toActions(sources$);
+
+        expect(output).toBeObservable(expected);
+      });
+
+      it('should ignore duplicate class instances', () => {
         const sources$ = cold('--a--a--a--', {
           a: new SourceA(),
         });
         const expected = cold('--a--------', { a });
+
+        const output = toActions(sources$);
+
+        expect(output).toBeObservable(expected);
+      });
+
+      it('should ignore different instances of the same class', () => {
+        const sources$ = cold('--a--b--', {
+          a: new SourceA(),
+          b: new SourceA(),
+        });
+        const expected = cold('--a-----', { a });
+
+        const output = toActions(sources$);
+
+        expect(output).toBeObservable(expected);
+      });
+
+      it('should ignore duplicate records', () => {
+        const sources$ = cold('--a--b--', { a: recordA, b: recordA });
+        const expected = cold('--a-----', { a });
 
         const output = toActions(sources$);
 
@@ -264,7 +304,7 @@ describe('EffectSources', () => {
         expect(output).toBeObservable(expected);
       });
 
-      it('should start with an  action after being registered with OnInitEffects', () => {
+      it('should start with an action after being registered with OnInitEffects', () => {
         const sources$ = cold('--a--', {
           a: new SourceWithInitAction(new Subject()),
         });

--- a/modules/effects/spec/effects_feature_module.spec.ts
+++ b/modules/effects/spec/effects_feature_module.spec.ts
@@ -12,7 +12,7 @@ import { map, withLatestFrom } from 'rxjs/operators';
 import { Actions, EffectsModule, ofType, createEffect } from '../';
 import { EffectsFeatureModule } from '../src/effects_feature_module';
 import { EffectsRootModule } from '../src/effects_root_module';
-import { FEATURE_EFFECTS_INSTANCE_GROUPS } from '../src/tokens';
+import { _FEATURE_EFFECTS_INSTANCE_GROUPS } from '../src/tokens';
 
 describe('Effects Feature Module', () => {
   describe('when registered', () => {
@@ -33,7 +33,7 @@ describe('Effects Feature Module', () => {
             },
           },
           {
-            provide: FEATURE_EFFECTS_INSTANCE_GROUPS,
+            provide: _FEATURE_EFFECTS_INSTANCE_GROUPS,
             useValue: effectSourceGroups,
           },
           EffectsFeatureModule,

--- a/modules/effects/spec/effects_feature_module.spec.ts
+++ b/modules/effects/spec/effects_feature_module.spec.ts
@@ -12,7 +12,7 @@ import { map, withLatestFrom } from 'rxjs/operators';
 import { Actions, EffectsModule, ofType, createEffect } from '../';
 import { EffectsFeatureModule } from '../src/effects_feature_module';
 import { EffectsRootModule } from '../src/effects_root_module';
-import { FEATURE_EFFECTS } from '../src/tokens';
+import { FEATURE_EFFECTS_INSTANCE_GROUPS } from '../src/tokens';
 
 describe('Effects Feature Module', () => {
   describe('when registered', () => {
@@ -33,7 +33,7 @@ describe('Effects Feature Module', () => {
             },
           },
           {
-            provide: FEATURE_EFFECTS,
+            provide: FEATURE_EFFECTS_INSTANCE_GROUPS,
             useValue: effectSourceGroups,
           },
           EffectsFeatureModule,

--- a/modules/effects/spec/effects_metadata.spec.ts
+++ b/modules/effects/spec/effects_metadata.spec.ts
@@ -9,6 +9,7 @@ describe('Effects metadata', () => {
       class Fixture {
         effectSimple = createEffect(() => of({ type: 'a' }));
         effectNoDispatch = createEffect(() => of({ type: 'a' }), {
+          functional: true,
           dispatch: false,
         });
         noEffect: any;
@@ -27,21 +28,25 @@ describe('Effects metadata', () => {
         {
           propertyName: 'effectSimple',
           dispatch: true,
+          functional: false,
           useEffectsErrorHandler: true,
         },
         {
           propertyName: 'effectNoDispatch',
           dispatch: false,
+          functional: true,
           useEffectsErrorHandler: true,
         },
         {
           propertyName: 'effectWithMethod',
           dispatch: true,
+          functional: false,
           useEffectsErrorHandler: true,
         },
         {
           propertyName: 'effectWithUseEffectsErrorHandler',
           dispatch: true,
+          functional: false,
           useEffectsErrorHandler: false,
         },
       ];

--- a/modules/effects/spec/types/effect_creator.spec.ts
+++ b/modules/effects/spec/types/effect_creator.spec.ts
@@ -53,6 +53,30 @@ describe('createEffect()', () => {
         /Type 'Observable<{ foo: string; }>' is not assignable to type 'EffectResult<Action>'./
       );
     });
+
+    it('should create non-functional effect when functional is set to false', () => {
+      const snippet = expectSnippet(`
+        const effect1 = createEffect(
+          () => of({ type: 'a' }),
+          { functional: false }
+        );
+
+        const effect2 = createEffect(
+          () => of({ type: 'a' }),
+          // explicitly set dispatch: true
+          { functional: false, dispatch: true }
+        );
+      `);
+
+      snippet.toInfer(
+        'effect1',
+        'Observable<{ type: string; }> & CreateEffectMetadata'
+      );
+      snippet.toInfer(
+        'effect2',
+        'Observable<{ type: string; }> & CreateEffectMetadata'
+      );
+    });
   });
 
   describe('dispatch: false', () => {
@@ -74,6 +98,210 @@ describe('createEffect()', () => {
       const action = createAction('action without props');
       const effect = createEffect(() => of(action), { dispatch: false });
       `).toSucceed();
+    });
+
+    it('should create non-functional effect when functional is set to false', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          () => of('a'),
+          { functional: false, dispatch: false }
+        );
+      `).toInfer('effect', 'Observable<string> & CreateEffectMetadata');
+    });
+  });
+
+  describe('functional: true', () => {
+    it('should create dispatching effect without args', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          () => of({ type: 'a' }),
+          { functional: true }
+        );
+      `).toInfer(
+        'effect',
+        'FunctionalEffect<() => Observable<{ type: string; }>>'
+      );
+    });
+
+    it('should create dispatching effect with args', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          (type = 'a', x = 1, y = 2) => of({ type, x, y }),
+          { functional: true }
+        );
+      `).toInfer(
+        'effect',
+        'FunctionalEffect<(type?: string, x?: number, y?: number) => Observable<{ type: string; x: number; y: number; }>>'
+      );
+    });
+
+    it('should create dispatching effect when dispatch is set to true', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          ({ type = 'a' } = {}) => of({ type }),
+          { functional: true, dispatch: true }
+        );
+      `).toInfer(
+        'effect',
+        'FunctionalEffect<({ type }?: { type?: string; }) => Observable<{ type: string; }>>'
+      );
+    });
+
+    it('should create non-dispatching effect that returns action', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          (type = 'a') => of({ type }),
+          { functional: true, dispatch: false }
+        );
+      `).toInfer(
+        'effect',
+        'FunctionalEffect<(type?: string) => Observable<{ type: string; }>>'
+      );
+    });
+
+    it('should create non-dispatching effect that returns any observable', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          () => of('ngrx'),
+          { functional: true, dispatch: false }
+        );
+      `).toInfer('effect', 'FunctionalEffect<() => Observable<string>>');
+    });
+
+    it('should create non-dispatching effect that returns action creator', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          () => of(createAction('a')),
+          { functional: true, dispatch: false }
+        );
+      `).toInfer(
+        'effect',
+        'FunctionalEffect<() => Observable<ActionCreator<"a", () => TypedAction<"a">>>>'
+      );
+    });
+
+    it('should be possible to invoke dispatching effect without args as function', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          () => of({ type: 'a' }),
+          { functional: true }
+        );
+        effect();
+
+        let effectArgs: Parameters<typeof effect>;
+      `).toInfer('effectArgs', '[]');
+    });
+
+    it('should be possible to invoke dispatching effect with args as function', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          (type = 'a', payload = 'b') => of({ type, payload }),
+          { functional: true }
+        );
+        effect();
+        effect('m');
+        effect('m', 's');
+
+        let effectArgs: Parameters<typeof effect>;
+      `).toInfer('effectArgs', '[type?: string, payload?: string]');
+    });
+
+    it('should be possible to invoke non-dispatching effect without args as function', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          () => of('a'),
+          { functional: true, dispatch: false }
+        );
+        effect();
+
+        let effectArgs: Parameters<typeof effect>;
+      `).toInfer('effectArgs', '[]');
+    });
+
+    it('should be possible to invoke non-dispatching effect with args as function', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          ({ a = 1, b = 2 } = {}) => of([a, b]),
+          { functional: true, dispatch: false }
+        );
+        effect();
+        effect({});
+        effect({ a: 10 });
+        effect({ b: 20 });
+        effect({ a: 100, b: 200 });
+
+        let effectArgs: Parameters<typeof effect>;
+      `).toInfer('effectArgs', '[{ a?: number; b?: number; }?]');
+    });
+
+    it('should fail when dispatching effect arguments do not have default values', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          (type: string) => of({ type }),
+          { functional: true }
+        );
+      `).toFail();
+    });
+
+    it('should fail when non-dispatching effect arguments do not have default values', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          (x: number, y: number) => of([x, y]),
+          { functional: true, dispatch: false }
+        );
+      `).toFail();
+    });
+
+    it('should fail when additional properties are added to the effect config', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          () => of({ type: 'a' }),
+          { functional: true, x: 1, y: 2 }
+        );
+      `).toFail();
+    });
+
+    it('should fail when Observable<Action> is not returned as dispatching effect result', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          () => of({ type: 123 }),
+          { functional: true }
+        );
+      `).toFail();
+
+      expectSnippet(`
+        const effect = createEffect(
+          () => of(123),
+          { functional: true, dispatch: true }
+        );
+      `).toFail();
+
+      expectSnippet(`
+        const effect = createEffect(
+          () => 123,
+          { functional: true }
+        );
+      `).toFail();
+    });
+
+    it('should fail when action creator is returned as dispatching effect result', () => {
+      expectSnippet(`
+        const effect = createEffect(
+          () => of(createAction('a')),
+          { functional: true }
+        );
+      `).toFail(
+        /ActionCreator cannot be dispatched. Did you forget to call the action creator function/
+      );
+
+      expectSnippet(`
+        const effect = createEffect(
+          () => of(createAction('a')),
+          { functional: true, dispatch: true }
+        );
+      `).toFail(
+        /ActionCreator cannot be dispatched. Did you forget to call the action creator function/
+      );
     });
   });
 });

--- a/modules/effects/spec/types/effects_module.spec.ts
+++ b/modules/effects/spec/types/effects_module.spec.ts
@@ -4,9 +4,20 @@ import { compilerOptions } from './utils';
 describe('EffectsModule()', () => {
   const expectSnippet = expecter(
     (code) => `
-      import { EffectsModule } from '@ngrx/effects';
+      import {
+        CreateEffectMetadata,
+        EffectsModule,
+        FunctionalEffect,
+      } from '@ngrx/effects';
+      import { Observable } from 'rxjs';
 
-      class EffectFixture {}
+      class ClassEffects {}
+      const fnEffectsRecord: Record<string, FunctionalEffect> = {};
+      const nonFnEffectsRecord: Record<
+        string,
+        // it should fail if at least one effect in the record is not functional
+        FunctionalEffect | (Observable<unknown> & CreateEffectMetadata)
+      > = {};
 
       ${code}`,
     compilerOptions()
@@ -19,22 +30,70 @@ describe('EffectsModule()', () => {
       `).toSucceed();
     });
 
-    it('should compile with a single param', () => {
+    it('should compile with a single effects class', () => {
       expectSnippet(`
-        EffectsModule.forRoot(EffectFixture);
+        EffectsModule.forRoot(ClassEffects);
       `).toSucceed();
     });
 
-    it('should compile with an array param', () => {
+    it('should compile with an array of effects classes', () => {
       expectSnippet(`
-        EffectsModule.forRoot([EffectFixture]);
+        EffectsModule.forRoot([ClassEffects]);
       `).toSucceed();
     });
 
-    it('should compile with a spreaded array param', () => {
+    it('should compile with a sequence of effects classes', () => {
       expectSnippet(`
-        EffectsModule.forRoot(EffectFixture, EffectFixture);
+        EffectsModule.forRoot(ClassEffects, ClassEffects);
       `).toSucceed();
+    });
+
+    it('should compile with a single functional effects record', () => {
+      expectSnippet(`
+        EffectsModule.forRoot(fnEffectsRecord);
+      `).toSucceed();
+    });
+
+    it('should compile with an array of functional effects records', () => {
+      expectSnippet(`
+        EffectsModule.forRoot([fnEffectsRecord, fnEffectsRecord]);
+      `).toSucceed();
+    });
+
+    it('should compile with a sequence of functional effects records', () => {
+      expectSnippet(`
+        EffectsModule.forRoot(fnEffectsRecord, fnEffectsRecord, fnEffectsRecord);
+      `).toSucceed();
+    });
+
+    it('should compile with an array of functional effects records and classes', () => {
+      expectSnippet(`
+        EffectsModule.forRoot([fnEffectsRecord, ClassEffects, fnEffectsRecord]);
+      `).toSucceed();
+    });
+
+    it('should compile with a sequence of functional effects records and classes', () => {
+      expectSnippet(`
+        EffectsModule.forRoot(ClassEffects, fnEffectsRecord, ClassEffects);
+      `).toSucceed();
+    });
+
+    it('should fail with a single non-functional effects record', () => {
+      expectSnippet(`
+        EffectsModule.forRoot(nonFnEffectsRecord);
+      `).toFail();
+    });
+
+    it('should fail with an array of classes, functional, and non-functional effects records', () => {
+      expectSnippet(`
+        EffectsModule.forRoot([fnEffectsRecord, ClassEffects, nonFnEffectsRecord]);
+      `).toFail();
+    });
+
+    it('should fail with a sequence of classes, functional, and non-functional effects records', () => {
+      expectSnippet(`
+        EffectsModule.forRoot(nonFnEffectsRecord, fnEffectsRecord, ClassEffects);
+      `).toFail();
     });
   });
 
@@ -45,22 +104,70 @@ describe('EffectsModule()', () => {
       `).toSucceed();
     });
 
-    it('should compile with a single param', () => {
+    it('should compile with a single effects class', () => {
       expectSnippet(`
-        EffectsModule.forFeature(EffectFixture);
+        EffectsModule.forFeature(ClassEffects);
       `).toSucceed();
     });
 
-    it('should compile with an array param', () => {
+    it('should compile with an array of effects classes', () => {
       expectSnippet(`
-        EffectsModule.forFeature([EffectFixture]);
+        EffectsModule.forFeature([ClassEffects]);
       `).toSucceed();
     });
 
-    it('should compile with a spreaded array param', () => {
+    it('should compile with a sequence of effects classes', () => {
       expectSnippet(`
-        EffectsModule.forFeature(EffectFixture, EffectFixture);
+        EffectsModule.forFeature(ClassEffects, ClassEffects);
       `).toSucceed();
+    });
+
+    it('should compile with a single functional effects record', () => {
+      expectSnippet(`
+        EffectsModule.forFeature(fnEffectsRecord);
+      `).toSucceed();
+    });
+
+    it('should compile with an array of functional effects records', () => {
+      expectSnippet(`
+        EffectsModule.forFeature([fnEffectsRecord, fnEffectsRecord]);
+      `).toSucceed();
+    });
+
+    it('should compile with a sequence of functional effects records', () => {
+      expectSnippet(`
+        EffectsModule.forFeature(fnEffectsRecord, fnEffectsRecord, fnEffectsRecord);
+      `).toSucceed();
+    });
+
+    it('should compile with an array of functional effects records and classes', () => {
+      expectSnippet(`
+        EffectsModule.forFeature([fnEffectsRecord, ClassEffects, fnEffectsRecord]);
+      `).toSucceed();
+    });
+
+    it('should compile with a sequence of functional effects records and classes', () => {
+      expectSnippet(`
+        EffectsModule.forFeature(ClassEffects, fnEffectsRecord, ClassEffects);
+      `).toSucceed();
+    });
+
+    it('should fail with a single non-functional effects record', () => {
+      expectSnippet(`
+        EffectsModule.forFeature(nonFnEffectsRecord);
+      `).toFail();
+    });
+
+    it('should fail with an array of classes, functional, and non-functional effects records', () => {
+      expectSnippet(`
+        EffectsModule.forFeature([fnEffectsRecord, ClassEffects, nonFnEffectsRecord]);
+      `).toFail();
+    });
+
+    it('should fail with a sequence of classes, functional, and non-functional effects records', () => {
+      expectSnippet(`
+        EffectsModule.forFeature(nonFnEffectsRecord, fnEffectsRecord, ClassEffects);
+      `).toFail();
     });
   });
 });

--- a/modules/effects/spec/types/provide_effects.spec.ts
+++ b/modules/effects/spec/types/provide_effects.spec.ts
@@ -4,9 +4,20 @@ import { compilerOptions } from './utils';
 describe('provideEffects()', () => {
   const expectSnippet = expecter(
     (code) => `
-      import { provideEffects } from '@ngrx/effects';
+      import {
+        CreateEffectMetadata,
+        FunctionalEffect,
+        provideEffects,
+      } from '@ngrx/effects';
+      import { Observable } from 'rxjs';
 
-      class EffectFixture {}
+      class ClassEffects {}
+      const fnEffectsRecord: Record<string, FunctionalEffect> = {};
+      const nonFnEffectsRecord: Record<
+        string,
+        // it should fail if at least one effect in the record is not functional
+        FunctionalEffect | (Observable<unknown> & CreateEffectMetadata)
+      > = {};
 
       ${code}`,
     compilerOptions()
@@ -14,25 +25,73 @@ describe('provideEffects()', () => {
 
   it('should compile without params', () => {
     expectSnippet(`
-        provideEffects();
-      `).toSucceed();
+      provideEffects();
+    `).toSucceed();
   });
 
-  it('should compile with a single param', () => {
+  it('should compile with a single effects class', () => {
     expectSnippet(`
-        provideEffects(EffectFixture);
-      `).toSucceed();
+      provideEffects(ClassEffects);
+    `).toSucceed();
   });
 
-  it('should compile with an array param', () => {
+  it('should compile with an array of effects classes', () => {
     expectSnippet(`
-        provideEffects([EffectFixture]);
-      `).toSucceed();
+      provideEffects([ClassEffects]);
+    `).toSucceed();
   });
 
-  it('should compile with a spreaded array param', () => {
+  it('should compile with a sequence of effects classes', () => {
     expectSnippet(`
-        provideEffects(EffectFixture, EffectFixture);
-      `).toSucceed();
+      provideEffects(ClassEffects, ClassEffects);
+    `).toSucceed();
+  });
+
+  it('should compile with a single functional effects record', () => {
+    expectSnippet(`
+      provideEffects(fnEffectsRecord);
+    `).toSucceed();
+  });
+
+  it('should compile with an array of functional effects records', () => {
+    expectSnippet(`
+      provideEffects([fnEffectsRecord, fnEffectsRecord]);
+    `).toSucceed();
+  });
+
+  it('should compile with a sequence of functional effects records', () => {
+    expectSnippet(`
+      provideEffects(fnEffectsRecord, fnEffectsRecord, fnEffectsRecord);
+    `).toSucceed();
+  });
+
+  it('should compile with an array of functional effects records and classes', () => {
+    expectSnippet(`
+      provideEffects([fnEffectsRecord, ClassEffects, fnEffectsRecord]);
+    `).toSucceed();
+  });
+
+  it('should compile with a sequence of functional effects records and classes', () => {
+    expectSnippet(`
+      provideEffects(ClassEffects, fnEffectsRecord, ClassEffects);
+    `).toSucceed();
+  });
+
+  it('should fail with a single non-functional effects record', () => {
+    expectSnippet(`
+      provideEffects(nonFnEffectsRecord);
+    `).toFail();
+  });
+
+  it('should fail with an array of classes, functional, and non-functional effects records', () => {
+    expectSnippet(`
+      provideEffects([fnEffectsRecord, ClassEffects, nonFnEffectsRecord]);
+    `).toFail();
+  });
+
+  it('should fail with a sequence of classes, functional, and non-functional effects records', () => {
+    expectSnippet(`
+      provideEffects(nonFnEffectsRecord, fnEffectsRecord, ClassEffects);
+    `).toFail();
   });
 });

--- a/modules/effects/spec/utils.spec.ts
+++ b/modules/effects/spec/utils.spec.ts
@@ -1,12 +1,57 @@
-import { getSourceForInstance } from '../src/utils';
+import {
+  getClasses,
+  getSourceForInstance,
+  isClass,
+  isClassInstance,
+} from '../src/utils';
 
-describe('getSourceProto', () => {
-  it('should get the prototype for an instance of a source', () => {
+describe('getSourceForInstance', () => {
+  it('gets the prototype for an instance of a source', () => {
     class Fixture {}
     const instance = new Fixture();
 
     const proto = getSourceForInstance(instance);
 
     expect(proto).toBe(Fixture.prototype);
+  });
+});
+
+describe('isClassInstance', () => {
+  it('returns true for a class instance', () => {
+    class C {}
+    expect(isClassInstance(new C())).toBe(true);
+  });
+
+  it('returns false for a class', () => {
+    expect(isClassInstance(class C {})).toBe(false);
+  });
+
+  it('returns false for a record', () => {
+    expect(isClassInstance({ foo: 'bar' })).toBe(false);
+  });
+
+  it('returns false for a function', () => {
+    expect(isClassInstance(() => {})).toBe(false);
+  });
+});
+
+describe('isClass', () => {
+  it('returns true for a class', () => {
+    expect(isClass(class C {})).toBe(true);
+  });
+
+  it('returns false for a record', () => {
+    expect(isClass({ foo: 'bar' })).toBe(false);
+  });
+});
+
+describe('getClasses', () => {
+  it('gets classes from an array with classes and records', () => {
+    class C1 {}
+    class C2 {}
+    class C3 {}
+
+    const classes = getClasses([C1, {}, C2, C3, { foo: 'bar' }]);
+    expect(classes).toEqual([C1, C2, C3]);
   });
 });

--- a/modules/effects/src/effect_creator.ts
+++ b/modules/effects/src/effect_creator.ts
@@ -33,10 +33,7 @@ export function createEffect<Source extends () => Observable<unknown>>(
   source: Source,
   config: EffectConfig & { functional: true; dispatch: false }
 ): FunctionalEffect<Source>;
-export function createEffect<
-  Result extends Observable<Action>,
-  Source extends () => Result
->(
+export function createEffect<Source extends () => Observable<Action>>(
   source: Source & ConditionallyDisallowActionCreator<true, ReturnType<Source>>,
   config: EffectConfig & { functional: true; dispatch?: true }
 ): FunctionalEffect<Source>;
@@ -110,12 +107,12 @@ export function createEffect<
  * ```
  */
 export function createEffect<
-  C extends EffectConfig,
-  DT extends DispatchType<C>,
-  OT extends ObservableType<DT, OT>,
-  R extends EffectResult<OT>,
-  S extends () => R
->(source: S, config = {} as C): (S | R) & CreateEffectMetadata {
+  Result extends EffectResult<unknown>,
+  Source extends () => Result
+>(
+  source: Source,
+  config: EffectConfig = {}
+): (Source | Result) & CreateEffectMetadata {
   const effect = config.functional ? source : source();
   const value: EffectConfig = {
     ...DEFAULT_EFFECT_CONFIG,

--- a/modules/effects/src/effect_creator.ts
+++ b/modules/effects/src/effect_creator.ts
@@ -1,11 +1,12 @@
 import { Observable } from 'rxjs';
 import { Action, ActionCreator } from '@ngrx/store';
 import {
-  EffectMetadata,
-  EffectConfig,
-  DEFAULT_EFFECT_CONFIG,
-  CreateEffectMetadata,
   CREATE_EFFECT_METADATA_KEY,
+  CreateEffectMetadata,
+  DEFAULT_EFFECT_CONFIG,
+  EffectConfig,
+  EffectMetadata,
+  FunctionalEffect,
 } from './models';
 
 type DispatchType<T> = T extends { dispatch: infer U } ? U : true;
@@ -19,35 +20,92 @@ type ConditionallyDisallowActionCreator<DT, Result> = DT extends false
     : unknown
   : unknown;
 
+export function createEffect<
+  C extends EffectConfig & { functional?: false },
+  DT extends DispatchType<C>,
+  OT extends ObservableType<DT, OT>,
+  R extends EffectResult<OT>
+>(
+  source: () => R & ConditionallyDisallowActionCreator<DT, R>,
+  config?: C
+): R & CreateEffectMetadata;
+export function createEffect<Source extends () => Observable<unknown>>(
+  source: Source,
+  config: EffectConfig & { functional: true; dispatch: false }
+): FunctionalEffect<Source>;
+export function createEffect<
+  Result extends Observable<Action>,
+  Source extends () => Result
+>(
+  source: Source & ConditionallyDisallowActionCreator<true, ReturnType<Source>>,
+  config: EffectConfig & { functional: true; dispatch?: true }
+): FunctionalEffect<Source>;
 /**
  * @description
- * Creates an effect from an `Observable` and an `EffectConfig`.
  *
- * @param source A function which returns an `Observable`.
- * @param config A `Partial<EffectConfig>` to configure the effect.  By default, `dispatch` is true and `useEffectsErrorHandler` is true.
- * @returns If `EffectConfig`#`dispatch` is true, returns `Observable<Action>`.  Else, returns `Observable<unknown>`.
+ * Creates an effect from a source and an `EffectConfig`.
+ *
+ * @param source A function which returns an observable or observable factory.
+ * @param config A `EffectConfig` to configure the effect. By default,
+ * `dispatch` is true, `functional` is false, and `useEffectsErrorHandler` is
+ * true.
+ * @returns If `EffectConfig`#`functional` is true, returns the source function.
+ * Else, returns the source function result. When `EffectConfig`#`dispatch` is
+ * true, the source function result needs to be `Observable<Action>`.
  *
  * @usageNotes
  *
- * ** Mapping to a different action **
+ * ### Class Effects
+ *
  * ```ts
- * effectName$ = createEffect(
- *   () => this.actions$.pipe(
- *     ofType(FeatureActions.actionOne),
- *     map(() => FeatureActions.actionTwo())
- *   )
- * );
+ * @Injectable()
+ * export class FeatureEffects {
+ *   // mapping to a different action
+ *   readonly effect1$ = createEffect(
+ *     () => this.actions$.pipe(
+ *       ofType(FeatureActions.actionOne),
+ *       map(() => FeatureActions.actionTwo())
+ *     )
+ *   );
+ *
+ *   // non-dispatching effect
+ *   readonly effect2$ = createEffect(
+ *     () => this.actions$.pipe(
+ *       ofType(FeatureActions.actionTwo),
+ *       tap(() => console.log('Action Two Dispatched'))
+ *     ),
+ *     { dispatch: false } // FeatureActions.actionTwo is not dispatched
+ *   );
+ *
+ *   constructor(private readonly actions$: Actions) {}
+ * }
  * ```
  *
- *  ** Non-dispatching effects **
+ * ### Functional Effects
+ *
  * ```ts
- * effectName$ = createEffect(
- *   () => this.actions$.pipe(
- *     ofType(FeatureActions.actionOne),
- *     tap(() => console.log('Action One Dispatched'))
- *   ),
- *   { dispatch: false }
- *   // FeatureActions.actionOne is not dispatched
+ * // mapping to a different action
+ * export const loadUsers = createEffect(
+ *   (actions$ = inject(Actions), usersService = inject(UsersService)) => {
+ *     return actions$.pipe(
+ *       ofType(UsersPageActions.opened),
+ *       exhaustMap(() => {
+ *         return usersService.getAll().pipe(
+ *           map((users) => UsersApiActions.usersLoadedSuccess({ users })),
+ *           catchError((error) =>
+ *             of(UsersApiActions.usersLoadedFailure({ error }))
+ *           )
+ *         );
+ *       })
+ *     );
+ *   },
+ *   { functional: true }
+ * );
+ *
+ * // non-dispatching functional effect
+ * export const logDispatchedActions = createEffect(
+ *   () => inject(Actions).pipe(tap(console.log)),
+ *   { functional: true, dispatch: false }
  * );
  * ```
  */
@@ -55,12 +113,10 @@ export function createEffect<
   C extends EffectConfig,
   DT extends DispatchType<C>,
   OT extends ObservableType<DT, OT>,
-  R extends EffectResult<OT>
->(
-  source: () => R & ConditionallyDisallowActionCreator<DT, R>,
-  config?: Partial<C>
-): R & CreateEffectMetadata {
-  const effect = source();
+  R extends EffectResult<OT>,
+  S extends () => R
+>(source: S, config = {} as C): (S | R) & CreateEffectMetadata {
+  const effect = config.functional ? source : source();
   const value: EffectConfig = {
     ...DEFAULT_EFFECT_CONFIG,
     ...config, // Overrides any defaults if values are provided

--- a/modules/effects/src/effect_sources.ts
+++ b/modules/effects/src/effect_sources.ts
@@ -18,16 +18,16 @@ import {
 import { EffectsErrorHandler } from './effects_error_handler';
 import { mergeEffects } from './effects_resolver';
 import {
-  onIdentifyEffectsKey,
-  onRunEffectsKey,
-  OnRunEffects,
-  onInitEffects,
   isOnIdentifyEffects,
   isOnRunEffects,
   isOnInitEffects,
 } from './lifecycle_hooks';
 import { EFFECTS_ERROR_HANDLER } from './tokens';
-import { getSourceForInstance, ObservableNotification } from './utils';
+import {
+  getSourceForInstance,
+  isClassInstance,
+  ObservableNotification,
+} from './utils';
 
 @Injectable({ providedIn: 'root' })
 export class EffectSources extends Subject<any> {
@@ -48,7 +48,11 @@ export class EffectSources extends Subject<any> {
    */
   toActions(): Observable<Action> {
     return this.pipe(
-      groupBy(getSourceForInstance),
+      groupBy((effectsInstance) =>
+        isClassInstance(effectsInstance)
+          ? getSourceForInstance(effectsInstance)
+          : effectsInstance
+      ),
       mergeMap((source$) => {
         return source$.pipe(groupBy(effectsInstance));
       }),

--- a/modules/effects/src/effects_feature_module.ts
+++ b/modules/effects/src/effects_feature_module.ts
@@ -1,20 +1,19 @@
 import { NgModule, Inject, Optional } from '@angular/core';
 import { StoreRootModule, StoreFeatureModule } from '@ngrx/store';
 import { EffectsRootModule } from './effects_root_module';
-import { FEATURE_EFFECTS } from './tokens';
+import { FEATURE_EFFECTS_INSTANCE_GROUPS } from './tokens';
 
 @NgModule({})
 export class EffectsFeatureModule {
   constructor(
-    root: EffectsRootModule,
-    @Inject(FEATURE_EFFECTS) effectSourceGroups: any[][],
+    effectsRootModule: EffectsRootModule,
+    @Inject(FEATURE_EFFECTS_INSTANCE_GROUPS) effectsInstanceGroups: unknown[][],
     @Optional() storeRootModule: StoreRootModule,
     @Optional() storeFeatureModule: StoreFeatureModule
   ) {
-    effectSourceGroups.forEach((group) =>
-      group.forEach((effectSourceInstance) =>
-        root.addEffects(effectSourceInstance)
-      )
-    );
+    const effectsInstances = effectsInstanceGroups.flat();
+    for (const effectsInstance of effectsInstances) {
+      effectsRootModule.addEffects(effectsInstance);
+    }
   }
 }

--- a/modules/effects/src/effects_feature_module.ts
+++ b/modules/effects/src/effects_feature_module.ts
@@ -1,13 +1,14 @@
 import { NgModule, Inject, Optional } from '@angular/core';
 import { StoreRootModule, StoreFeatureModule } from '@ngrx/store';
 import { EffectsRootModule } from './effects_root_module';
-import { FEATURE_EFFECTS_INSTANCE_GROUPS } from './tokens';
+import { _FEATURE_EFFECTS_INSTANCE_GROUPS } from './tokens';
 
 @NgModule({})
 export class EffectsFeatureModule {
   constructor(
     effectsRootModule: EffectsRootModule,
-    @Inject(FEATURE_EFFECTS_INSTANCE_GROUPS) effectsInstanceGroups: unknown[][],
+    @Inject(_FEATURE_EFFECTS_INSTANCE_GROUPS)
+    effectsInstanceGroups: unknown[][],
     @Optional() storeRootModule: StoreRootModule,
     @Optional() storeFeatureModule: StoreFeatureModule
   ) {

--- a/modules/effects/src/effects_module.ts
+++ b/modules/effects/src/effects_module.ts
@@ -6,27 +6,32 @@ import {
   _FEATURE_EFFECTS,
   _ROOT_EFFECTS,
   _ROOT_EFFECTS_GUARD,
-  FEATURE_EFFECTS,
-  ROOT_EFFECTS,
+  FEATURE_EFFECTS_INSTANCE_GROUPS,
+  ROOT_EFFECTS_INSTANCES,
   USER_PROVIDED_EFFECTS,
 } from './tokens';
+import { FunctionalEffect } from './models';
+import { getClasses, isClass } from './utils';
 
 @NgModule({})
 export class EffectsModule {
   static forFeature(
-    featureEffects: Type<unknown>[]
+    featureEffects: Array<Type<unknown> | Record<string, FunctionalEffect>>
   ): ModuleWithProviders<EffectsFeatureModule>;
   static forFeature(
-    ...featureEffects: Type<unknown>[]
+    ...featureEffects: Array<Type<unknown> | Record<string, FunctionalEffect>>
   ): ModuleWithProviders<EffectsFeatureModule>;
   static forFeature(
-    ...featureEffects: Type<unknown>[] | Type<unknown>[][]
+    ...featureEffects:
+      | Array<Type<unknown> | Record<string, FunctionalEffect>>
+      | [Array<Type<unknown> | Record<string, FunctionalEffect>>]
   ): ModuleWithProviders<EffectsFeatureModule> {
     const effects = featureEffects.flat();
+    const effectsClasses = getClasses(effects);
     return {
       ngModule: EffectsFeatureModule,
       providers: [
-        effects,
+        effectsClasses,
         {
           provide: _FEATURE_EFFECTS,
           multi: true,
@@ -38,9 +43,9 @@ export class EffectsModule {
           useValue: [],
         },
         {
-          provide: FEATURE_EFFECTS,
+          provide: FEATURE_EFFECTS_INSTANCE_GROUPS,
           multi: true,
-          useFactory: createEffects,
+          useFactory: createEffectsInstances,
           deps: [_FEATURE_EFFECTS, USER_PROVIDED_EFFECTS],
         },
       ],
@@ -48,19 +53,22 @@ export class EffectsModule {
   }
 
   static forRoot(
-    rootEffects: Type<unknown>[]
+    rootEffects: Array<Type<unknown> | Record<string, FunctionalEffect>>
   ): ModuleWithProviders<EffectsRootModule>;
   static forRoot(
-    ...rootEffects: Type<unknown>[]
+    ...rootEffects: Array<Type<unknown> | Record<string, FunctionalEffect>>
   ): ModuleWithProviders<EffectsRootModule>;
   static forRoot(
-    ...rootEffects: Type<unknown>[] | Type<unknown>[][]
+    ...rootEffects:
+      | Array<Type<unknown> | Record<string, FunctionalEffect>>
+      | [Array<Type<unknown> | Record<string, FunctionalEffect>>]
   ): ModuleWithProviders<EffectsRootModule> {
     const effects = rootEffects.flat();
+    const effectsClasses = getClasses(effects);
     return {
       ngModule: EffectsRootModule,
       providers: [
-        effects,
+        effectsClasses,
         {
           provide: _ROOT_EFFECTS,
           useValue: [effects],
@@ -75,8 +83,8 @@ export class EffectsModule {
           useValue: [],
         },
         {
-          provide: ROOT_EFFECTS,
-          useFactory: createEffects,
+          provide: ROOT_EFFECTS_INSTANCES,
+          useFactory: createEffectsInstances,
           deps: [_ROOT_EFFECTS, USER_PROVIDED_EFFECTS],
         },
       ],
@@ -84,25 +92,25 @@ export class EffectsModule {
   }
 }
 
-function createEffects(
-  effectGroups: Type<unknown>[][],
-  userProvidedEffectGroups: Type<unknown>[][]
+function createEffectsInstances(
+  effectsGroups: Array<Type<unknown> | Record<string, FunctionalEffect>>[],
+  userProvidedEffectsGroups: Type<unknown>[][]
 ): unknown[] {
-  const mergedEffects: Type<unknown>[] = [];
+  const effects: Array<Type<unknown> | Record<string, FunctionalEffect>> = [];
 
-  for (const effectGroup of effectGroups) {
-    mergedEffects.push(...effectGroup);
+  for (const effectsGroup of effectsGroups) {
+    effects.push(...effectsGroup);
   }
 
-  for (const userProvidedEffectGroup of userProvidedEffectGroups) {
-    mergedEffects.push(...userProvidedEffectGroup);
+  for (const userProvidedEffectsGroup of userProvidedEffectsGroups) {
+    effects.push(...userProvidedEffectsGroup);
   }
 
-  return createEffectInstances(mergedEffects);
-}
-
-function createEffectInstances(effects: Type<unknown>[]): unknown[] {
-  return effects.map((effect) => inject(effect));
+  return effects.map((effectsClassOrRecord) =>
+    isClass(effectsClassOrRecord)
+      ? inject(effectsClassOrRecord)
+      : effectsClassOrRecord
+  );
 }
 
 function _provideForRootGuard(): unknown {

--- a/modules/effects/src/effects_module.ts
+++ b/modules/effects/src/effects_module.ts
@@ -6,8 +6,8 @@ import {
   _FEATURE_EFFECTS,
   _ROOT_EFFECTS,
   _ROOT_EFFECTS_GUARD,
-  FEATURE_EFFECTS_INSTANCE_GROUPS,
-  ROOT_EFFECTS_INSTANCES,
+  _FEATURE_EFFECTS_INSTANCE_GROUPS,
+  _ROOT_EFFECTS_INSTANCES,
   USER_PROVIDED_EFFECTS,
 } from './tokens';
 import { FunctionalEffect } from './models';
@@ -43,7 +43,7 @@ export class EffectsModule {
           useValue: [],
         },
         {
-          provide: FEATURE_EFFECTS_INSTANCE_GROUPS,
+          provide: _FEATURE_EFFECTS_INSTANCE_GROUPS,
           multi: true,
           useFactory: createEffectsInstances,
           deps: [_FEATURE_EFFECTS, USER_PROVIDED_EFFECTS],
@@ -83,7 +83,7 @@ export class EffectsModule {
           useValue: [],
         },
         {
-          provide: ROOT_EFFECTS_INSTANCES,
+          provide: _ROOT_EFFECTS_INSTANCES,
           useFactory: createEffectsInstances,
           deps: [_ROOT_EFFECTS, USER_PROVIDED_EFFECTS],
         },

--- a/modules/effects/src/effects_root_module.ts
+++ b/modules/effects/src/effects_root_module.ts
@@ -2,7 +2,7 @@ import { NgModule, Inject, Optional } from '@angular/core';
 import { Store, StoreRootModule, StoreFeatureModule } from '@ngrx/store';
 import { EffectsRunner } from './effects_runner';
 import { EffectSources } from './effect_sources';
-import { ROOT_EFFECTS, _ROOT_EFFECTS_GUARD } from './tokens';
+import { _ROOT_EFFECTS_GUARD, ROOT_EFFECTS_INSTANCES } from './tokens';
 import { ROOT_EFFECTS_INIT } from './effects_actions';
 
 @NgModule({})
@@ -10,24 +10,24 @@ export class EffectsRootModule {
   constructor(
     private sources: EffectSources,
     runner: EffectsRunner,
-    store: Store<any>,
-    @Inject(ROOT_EFFECTS) rootEffects: any[],
+    store: Store,
+    @Inject(ROOT_EFFECTS_INSTANCES) rootEffectsInstances: unknown[],
     @Optional() storeRootModule: StoreRootModule,
     @Optional() storeFeatureModule: StoreFeatureModule,
     @Optional()
     @Inject(_ROOT_EFFECTS_GUARD)
-    guard: any
+    guard: unknown
   ) {
     runner.start();
 
-    rootEffects.forEach((effectSourceInstance) =>
-      sources.addEffects(effectSourceInstance)
-    );
+    for (const effectsInstance of rootEffectsInstances) {
+      sources.addEffects(effectsInstance);
+    }
 
     store.dispatch({ type: ROOT_EFFECTS_INIT });
   }
 
-  addEffects(effectSourceInstance: any) {
-    this.sources.addEffects(effectSourceInstance);
+  addEffects(effectsInstance: unknown): void {
+    this.sources.addEffects(effectsInstance);
   }
 }

--- a/modules/effects/src/effects_root_module.ts
+++ b/modules/effects/src/effects_root_module.ts
@@ -2,7 +2,7 @@ import { NgModule, Inject, Optional } from '@angular/core';
 import { Store, StoreRootModule, StoreFeatureModule } from '@ngrx/store';
 import { EffectsRunner } from './effects_runner';
 import { EffectSources } from './effect_sources';
-import { _ROOT_EFFECTS_GUARD, ROOT_EFFECTS_INSTANCES } from './tokens';
+import { _ROOT_EFFECTS_GUARD, _ROOT_EFFECTS_INSTANCES } from './tokens';
 import { ROOT_EFFECTS_INIT } from './effects_actions';
 
 @NgModule({})
@@ -11,7 +11,7 @@ export class EffectsRootModule {
     private sources: EffectSources,
     runner: EffectsRunner,
     store: Store,
-    @Inject(ROOT_EFFECTS_INSTANCES) rootEffectsInstances: unknown[],
+    @Inject(_ROOT_EFFECTS_INSTANCES) rootEffectsInstances: unknown[],
     @Optional() storeRootModule: StoreRootModule,
     @Optional() storeFeatureModule: StoreFeatureModule,
     @Optional()

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -6,7 +6,11 @@ export {
   EffectsErrorHandler,
   defaultEffectsErrorHandler,
 } from './effects_error_handler';
-export { EffectsMetadata, CreateEffectMetadata } from './models';
+export {
+  EffectsMetadata,
+  CreateEffectMetadata,
+  FunctionalEffect,
+} from './models';
 export { Actions, ofType } from './actions';
 export { EffectsModule } from './effects_module';
 export { EffectSources } from './effect_sources';

--- a/modules/effects/src/models.ts
+++ b/modules/effects/src/models.ts
@@ -1,3 +1,5 @@
+import { Observable } from 'rxjs';
+
 /**
  * Configures an effect created by `createEffect`.
  */
@@ -8,6 +10,11 @@ export interface EffectConfig {
    */
   dispatch?: boolean;
   /**
+   * Determines whether the functional effect will be created.
+   * If true, the effect can be created outside the effects class.
+   */
+  functional?: boolean;
+  /**
    * Determines if the effect will be resubscribed to if an error occurs in the main actions stream.
    */
   useEffectsErrorHandler?: boolean;
@@ -15,6 +22,7 @@ export interface EffectConfig {
 
 export const DEFAULT_EFFECT_CONFIG: Readonly<Required<EffectConfig>> = {
   dispatch: true,
+  functional: false,
   useEffectsErrorHandler: true,
 };
 
@@ -23,6 +31,14 @@ export const CREATE_EFFECT_METADATA_KEY = '__@ngrx/effects_create__';
 export interface CreateEffectMetadata {
   [CREATE_EFFECT_METADATA_KEY]: EffectConfig;
 }
+
+export interface FunctionalCreateEffectMetadata extends CreateEffectMetadata {
+  [CREATE_EFFECT_METADATA_KEY]: EffectConfig & { functional: true };
+}
+
+export type FunctionalEffect<
+  Source extends () => Observable<unknown> = () => Observable<unknown>
+> = Source & FunctionalCreateEffectMetadata;
 
 export type EffectPropertyKey<T extends Record<keyof T, Object>> = Exclude<
   keyof T,

--- a/modules/effects/src/tokens.ts
+++ b/modules/effects/src/tokens.ts
@@ -3,24 +3,25 @@ import {
   defaultEffectsErrorHandler,
   EffectsErrorHandler,
 } from './effects_error_handler';
+import { FunctionalEffect } from './models';
 
 export const _ROOT_EFFECTS_GUARD = new InjectionToken<void>(
   '@ngrx/effects Internal Root Guard'
 );
-export const USER_PROVIDED_EFFECTS = new InjectionToken<Type<any>[][]>(
+export const USER_PROVIDED_EFFECTS = new InjectionToken<Type<unknown>[][]>(
   '@ngrx/effects User Provided Effects'
 );
-export const _ROOT_EFFECTS = new InjectionToken<Type<any>[]>(
-  '@ngrx/effects Internal Root Effects'
+export const _ROOT_EFFECTS = new InjectionToken<
+  [Array<Type<unknown> | Record<string, FunctionalEffect>>]
+>('@ngrx/effects Internal Root Effects');
+export const ROOT_EFFECTS_INSTANCES = new InjectionToken<unknown[]>(
+  '@ngrx/effects Root Effects Instances'
 );
-export const ROOT_EFFECTS = new InjectionToken<Type<any>[]>(
-  '@ngrx/effects Root Effects'
-);
-export const _FEATURE_EFFECTS = new InjectionToken<Type<any>[]>(
-  '@ngrx/effects Internal Feature Effects'
-);
-export const FEATURE_EFFECTS = new InjectionToken<any[][]>(
-  '@ngrx/effects Feature Effects'
+export const _FEATURE_EFFECTS = new InjectionToken<
+  Array<Type<unknown> | Record<string, FunctionalEffect>>[]
+>('@ngrx/effects Internal Feature Effects');
+export const FEATURE_EFFECTS_INSTANCE_GROUPS = new InjectionToken<unknown[][]>(
+  '@ngrx/effects Feature Effects Instance Groups'
 );
 export const EFFECTS_ERROR_HANDLER = new InjectionToken<EffectsErrorHandler>(
   '@ngrx/effects Effects Error Handler',

--- a/modules/effects/src/tokens.ts
+++ b/modules/effects/src/tokens.ts
@@ -14,14 +14,14 @@ export const USER_PROVIDED_EFFECTS = new InjectionToken<Type<unknown>[][]>(
 export const _ROOT_EFFECTS = new InjectionToken<
   [Array<Type<unknown> | Record<string, FunctionalEffect>>]
 >('@ngrx/effects Internal Root Effects');
-export const ROOT_EFFECTS_INSTANCES = new InjectionToken<unknown[]>(
-  '@ngrx/effects Root Effects Instances'
+export const _ROOT_EFFECTS_INSTANCES = new InjectionToken<unknown[]>(
+  '@ngrx/effects Internal Root Effects Instances'
 );
 export const _FEATURE_EFFECTS = new InjectionToken<
   Array<Type<unknown> | Record<string, FunctionalEffect>>[]
 >('@ngrx/effects Internal Feature Effects');
-export const FEATURE_EFFECTS_INSTANCE_GROUPS = new InjectionToken<unknown[][]>(
-  '@ngrx/effects Feature Effects Instance Groups'
+export const _FEATURE_EFFECTS_INSTANCE_GROUPS = new InjectionToken<unknown[][]>(
+  '@ngrx/effects Internal Feature Effects Instance Groups'
 );
 export const EFFECTS_ERROR_HANDLER = new InjectionToken<EffectsErrorHandler>(
   '@ngrx/effects Effects Error Handler',

--- a/modules/effects/src/utils.ts
+++ b/modules/effects/src/utils.ts
@@ -1,5 +1,25 @@
+import { Type } from '@angular/core';
+
 export function getSourceForInstance<T>(instance: T): T {
   return Object.getPrototypeOf(instance);
+}
+
+export function isClassInstance(obj: object): boolean {
+  return (
+    obj.constructor.name !== 'Object' && obj.constructor.name !== 'Function'
+  );
+}
+
+export function isClass(
+  classOrRecord: Type<unknown> | Record<string, unknown>
+): classOrRecord is Type<unknown> {
+  return typeof classOrRecord === 'function';
+}
+
+export function getClasses(
+  classesAndRecords: Array<Type<unknown> | Record<string, unknown>>
+): Type<unknown>[] {
+  return classesAndRecords.filter(isClass);
 }
 
 // TODO: replace with RxJS interfaces when possible


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We are not able to create effects outside the effects classes.

Closes #3668 

## What is the new behavior?

We are able to create effects outside the effects class by adding `functional: true` flag within the effect config.

Examples:

```ts
// (file: users.effects.ts)

// mapping to a different action
export const loadUsers = createEffect(
  (actions$ = inject(Actions), usersService = inject(UsersService)) => {
    return actions$.pipe(
      ofType(UsersPageActions.opened),
      exhaustMap(() => {
        return usersService.getAll().pipe(
          map((users) => UsersApiActions.usersLoadedSuccess({ users })),
          catchError((error) =>
            of(UsersApiActions.usersLoadedFailure({ error }))
          )
        );
      })
    );
  },
  { functional: true }
);

// non-dispatching functional effect
export const logDispatchedActions = createEffect(
  () => inject(Actions).pipe(tap(console.log)),
  { functional: true, dispatch: false }
);
```

Functional effects can be registered by using the `provideEffects` function as follows:

```ts
import * as usersEffects from './users.effects';

bootstrapApplication(AppComponent, {
  providers: [provideEffects(usersEffects)],
});
```

Functional effects can be easily tested without `TestBed`:

```ts
// marble test
const result$ = usersEffects.loadUsers(actionsMock, usersServiceMock);
expect(result$).toBeObservable(/* ... */);
expect(usersServiceMock, 'getAll').toHaveBeenCalled();

// imperative test
usersEffects.loadUsers(actionsMock, usersServiceMock).subscribe((action) => {
  expect(action).toEqual(/* ... */);
  expect(usersServiceMock, 'getAll').toHaveBeenCalled();
  done();
});
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
