### PR TITLE
docs(store): unify selector-naming in selectors-guide

### DIFF
--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -96,8 +96,8 @@ For example if we have a counter and we want to multiply its value, we can add t
 The last argument of a selector or a projector is the `props` argument, for our example it looks as follows:
 
 <code-example header="index.ts">
-export const getCount = createSelector(
-  getCounterValue,
+export const selectCount = createSelector(
+  selectCounterValue,
   (counter, props) => counter * props.multiply
 );
 </code-example>
@@ -106,7 +106,7 @@ Inside the component we can define the `props`:
 
 <code-example header="app.component.ts">
 ngOnInit() {
-  this.counter = this.store.select(fromRoot.getCount, { multiply: 2 })
+  this.counter = this.store.select(fromRoot.selectCount, { multiply: 2 })
 }
 </code-example>
 
@@ -115,7 +115,7 @@ Keep in mind that a selector only keeps the previous input arguments in its cach
 The following is an example of using multiple counters differentiated by `id`.
 
 <code-example header="index.ts">
-export const getCount = () =>
+export const selectCount = () =>
   createSelector(
     (state, props) => state.counter[props.id],
     (counter, props) => counter * props.multiply
@@ -126,9 +126,9 @@ The component's selectors are now calling the factory function to create differe
 
 <code-example header="app.component.ts">
 ngOnInit() {
-  this.counter2 = this.store.select(fromRoot.getCount(), { id: 'counter2', multiply: 2 });
-  this.counter4 = this.store.select(fromRoot.getCount(), { id: 'counter4', multiply: 4 });
-  this.counter6 = this.store.select(fromRoot.getCount(), { id: 'counter6', multiply: 6 });
+  this.counter2 = this.store.select(fromRoot.selectCount(), { id: 'counter2', multiply: 2 });
+  this.counter4 = this.store.select(fromRoot.selectCount(), { id: 'counter4', multiply: 4 });
+  this.counter6 = this.store.select(fromRoot.selectCount(), { id: 'counter6', multiply: 6 });
 }
 </code-example>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Documentation content changes
[ ] Other... Please describe:
```


Closes #

## What is the new behavior?
The stated examples are inconsistend. Sometimes selectors are prefixed with `select` and sometimes with `get`
## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Alternativly one could mention that there are two recommended ways how to name selectors. Right now it just looks inconsistent.