### PR TITLE
fix(schematics): disable package json peer dep updates during build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -728,6 +728,7 @@
             "tsConfig": "modules/schematics/tsconfig.build.json",
             "packageJson": "modules/schematics/package.json",
             "main": "modules/schematics/src/index.ts",
+            "updateBuildableProjectDepsInPackageJson": false,
             "sourceMap": false,
             "assets": [
               "collection.json",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3691

## What is the new behavior?

The `package.json` for `@ngrx/schematics` is not updated

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
