### PR TITLE
feat(store): use `createSelector` with selectors dictionary

### DIFF
--- a/modules/store/spec/selector.spec.ts
+++ b/modules/store/spec/selector.spec.ts
@@ -168,6 +168,37 @@ describe('Selectors', () => {
       expect(grandparent.release).toHaveBeenCalled();
       expect(parent.release).toHaveBeenCalled();
     });
+
+    it('should create a selector from selectors dictionary', () => {
+      interface State {
+        x: number;
+        y: string;
+      }
+
+      const selectX = (state: State) => state.x + 1;
+      const selectY = (state: State) => state.y;
+
+      const selectDictionary = createSelector({
+        s: selectX,
+        m: selectY,
+      });
+
+      expect(selectDictionary({ x: 1, y: 'ngrx' })).toEqual({
+        s: 2,
+        m: 'ngrx',
+      });
+      expect(selectDictionary({ x: 2, y: 'ngrx' })).toEqual({
+        s: 3,
+        m: 'ngrx',
+      });
+    });
+
+    it('should create a selector from empty dictionary', () => {
+      const selectDictionary = createSelector({});
+
+      expect(selectDictionary({ x: 1, y: 'ngrx' })).toEqual({});
+      expect(selectDictionary({ x: 2, y: 'store' })).toEqual({});
+    });
   });
 
   describe('createSelector with props', () => {

--- a/modules/store/spec/types/selector.spec.ts
+++ b/modules/store/spec/types/selector.spec.ts
@@ -4,7 +4,7 @@ import { compilerOptions } from './utils';
 describe('createSelector()', () => {
   const expectSnippet = expecter(
     (code) => `
-      import {createSelector} from '@ngrx/store';
+      import { createSelector } from '@ngrx/store';
       import { MemoizedSelector, DefaultProjectorFn } from '@ngrx/store';
 
       ${code}
@@ -38,12 +38,30 @@ describe('createSelector()', () => {
       `).toSucceed();
     });
   });
+
+  it('should create a selector from selectors dictionary', () => {
+    expectSnippet(`
+      const selectDictionary = createSelector({
+        s: (state: { x: string }) => state.x,
+        m: (state: { y: number }) => state.y,
+      });
+    `).toInfer(
+      'selectDictionary',
+      'MemoizedSelector<{ x: string; } & { y: number; }, { s: string; m: number; }, never>'
+    );
+  });
+
+  it('should create a selector from empty dictionary', () => {
+    expectSnippet(`
+      const selectDictionary = createSelector({});
+    `).toInfer('selectDictionary', 'MemoizedSelector<unknown, {}, never>');
+  });
 });
 
 describe('createSelector() with props', () => {
   const expectSnippet = expecter(
     (code) => `
-      import {createSelector} from '@ngrx/store';
+      import { createSelector } from '@ngrx/store';
       import { MemoizedSelectorWithProps, DefaultProjectorFn } from '@ngrx/store';
 
       ${code}

--- a/projects/ngrx.io/content/guide/store/selectors.md
+++ b/projects/ngrx.io/content/guide/store/selectors.md
@@ -80,6 +80,17 @@ export const selectVisibleBooks = createSelector(
 );
 </code-example>
 
+The `createSelector` function also provides the ability to pass a dictionary of selectors without a projector.
+In this case, `createSelector` will generate a projector function that maps the results of the input selectors to a dictionary.
+
+```ts
+// result type - { books: Book[]; query: string }
+const selectBooksPageViewModel = createSelector({
+  books: selectBooks, // result type - Book[]
+  query: selectQuery, // result type - string
+});
+```
+
 ### Using selectors with props
 
 <div class="alert is-critical">
@@ -135,8 +146,6 @@ ngOnInit() {
 ## Selecting Feature States
 
 The `createFeatureSelector` is a convenience method for returning a top level feature state. It returns a typed selector function for a feature slice of state.
-
-### Example
 
 <code-example header="index.ts">
 import { createSelector, createFeatureSelector } from '@ngrx/store';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3677 

## What is the new behavior?

We're able to use the `createSelector` function with a dictionary of selectors:

```ts
export const selectUsersPageViewModel = createSelector({
  users: selectUsers,
  activeUser: selectActiveUser,
  query: selectQuery,
  isLoading: selectIsLoading,
});
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
