### PR TITLE
fix(eslint-plugin): remove @angular-devkit/schematics dependency

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -479,6 +479,7 @@
             "tsConfig": "modules/eslint-plugin/tsconfig.build.json",
             "packageJson": "modules/eslint-plugin/package.json",
             "main": "modules/eslint-plugin/src/index.ts",
+            "updateBuildableProjectDepsInPackageJson": false,
             "sourceMap": false,
             "assets": [
               "collection.json",

--- a/modules/eslint-plugin/package.json
+++ b/modules/eslint-plugin/package.json
@@ -36,7 +36,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@angular-devkit/schematics": "^14.0.0-rc.0",
+    "@angular-devkit/schematics": "^15.0.0",
     "@typescript-eslint/experimental-utils": "^5.4.0",
     "eslint-etc": "^5.1.0",
     "semver": "^7.3.5",

--- a/modules/eslint-plugin/package.json
+++ b/modules/eslint-plugin/package.json
@@ -36,7 +36,6 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@angular-devkit/schematics": "^15.0.0",
     "@typescript-eslint/experimental-utils": "^5.4.0",
     "eslint-etc": "^5.1.0",
     "semver": "^7.3.5",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When isntallint the eslint-plugin the old v14 version of `@angular-devkit/schematics` will be installed

Closes #3709

## What is the new behavior?
With this fix the latest v15 version of `@angular-devkit/schematics` will be installed

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
