### PR TITLE
fix(store): support using `createActionGroup` with props typed as unions

### DIFF
--- a/modules/store/spec/types/action_group_creator.spec.ts
+++ b/modules/store/spec/types/action_group_creator.spec.ts
@@ -205,6 +205,38 @@ describe('createActionGroup', () => {
     });
 
     describe('props', () => {
+      it('should infer when props are typed as union', () => {
+        expectSnippet(`
+          const booksApiActions = createActionGroup({
+            source: 'Books API',
+            events: {
+              'Load Books Success': props<{ books: string[]; total: number } | { books: symbol[] }>(),
+            },
+          });
+
+          let loadBooksSuccess: typeof booksApiActions.loadBooksSuccess;
+        `).toInfer(
+          'loadBooksSuccess',
+          'ActionCreator<"[Books API] Load Books Success", (props: { books: string[]; total: number; } | { books: symbol[]; }) => ({ books: string[]; total: number; } | { books: symbol[]; }) & TypedAction<"[Books API] Load Books Success">>'
+        );
+      });
+
+      it('should infer when props are typed as intersection', () => {
+        expectSnippet(`
+          const booksApiActions = createActionGroup({
+            source: 'Books API',
+            events: {
+              'Load Books Success': props<{ books: string[] } & { total: number }>(),
+            },
+          });
+
+          let loadBooksSuccess: typeof booksApiActions.loadBooksSuccess;
+        `).toInfer(
+          'loadBooksSuccess',
+          'ActionCreator<"[Books API] Load Books Success", (props: { books: string[]; } & { total: number; }) => { books: string[]; } & { total: number; } & TypedAction<"[Books API] Load Books Success">>'
+        );
+      });
+
       it('should fail when props contain a type property', () => {
         expectSnippet(`
           const booksApiActions = createActionGroup({

--- a/modules/store/src/action_group_creator_models.ts
+++ b/modules/store/src/action_group_creator_models.ts
@@ -78,7 +78,7 @@ type EventCreator<
   PropsCreator extends ActionCreatorProps<unknown> | Creator,
   Type extends string
 > = PropsCreator extends ActionCreatorProps<infer Props>
-  ? Props extends void
+  ? void extends Props
     ? ActionCreator<Type, () => TypedAction<Type>>
     : ActionCreator<
         Type,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3712

## What is the new behavior?

We are able to use the `createActionGroup` function with props typed as unions:

```ts
const booksApiActions = createActionGroup({
  source: 'Books API',
  events: {
    'Load Books Success': props<{ books: string[]; status: 'success' } | { books: Book[] }>(),
  },
});

// works as intended
booksApiActions.loadBooksSuccess({ books: [''], status: 'success' });
booksApiActions.loadBooksSuccess({ books: [{ id: 1, title: '' }] });
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
