### PR TITLE
feat(entity): disallow adding ids and entities to additionalState

### DIFF
--- a/modules/entity/src/entity_state.ts
+++ b/modules/entity/src/entity_state.ts
@@ -9,7 +9,7 @@ export function getInitialEntityState<V>(): EntityState<V> {
 
 export function createInitialStateFactory<V>() {
   function getInitialState(): EntityState<V>;
-  function getInitialState<S extends object>(
+  function getInitialState<S extends object & { ids: never; entities: never }>(
     additionalState: S
   ): EntityState<V> & S;
   function getInitialState(additionalState: any = {}): any {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:
```

## What is the current behavior?

Typescript does allow adding an object with ids and entities to the getInitialState method

Closes #

## What is the new behavior?

The new signature disallows adding ids or entities props to the getInitialState

## Does this PR introduce a breaking change?

Not sure, probably because if used wrong the compiler will fail

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
