### PR TITLE
fix: revert throwError usages with factory for RxJS 6 compatibility

### DIFF
--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -137,7 +137,7 @@ export class ComponentStore<T extends object> implements OnDestroy {
               return EMPTY;
             }
 
-            return throwError(() => error);
+            return throwError(error);
           }),
           takeUntil(this.destroy$)
         )

--- a/modules/data/src/dataservices/default-data.service.ts
+++ b/modules/data/src/dataservices/default-data.service.ts
@@ -168,7 +168,7 @@ export class DefaultDataService<T> implements EntityCollectionDataService<T> {
       }
       default: {
         const error = new Error('Unimplemented HTTP method, ' + method);
-        result$ = throwError(() => error);
+        result$ = throwError(error);
       }
     }
     if (this.timeout) {
@@ -184,7 +184,7 @@ export class DefaultDataService<T> implements EntityCollectionDataService<T> {
         return ok;
       }
       const error = new DataServiceError(err, reqData);
-      return throwError(() => error);
+      return throwError(error);
     };
   }
 

--- a/modules/data/src/dataservices/entity-cache-data.service.ts
+++ b/modules/data/src/dataservices/entity-cache-data.service.ts
@@ -79,7 +79,7 @@ export class EntityCacheDataService {
   protected handleError(reqData: RequestData) {
     return (err: any) => {
       const error = new DataServiceError(err, reqData);
-      return throwError(() => error);
+      return throwError(error);
     };
   }
 

--- a/modules/data/src/dispatchers/entity-cache-dispatcher.ts
+++ b/modules/data/src/dispatchers/entity-cache-dispatcher.ts
@@ -206,14 +206,13 @@ export class EntityCacheDispatcher {
       mergeMap((act) => {
         return act.type === EntityCacheAction.SAVE_ENTITIES_CANCEL
           ? throwError(
-              () =>
-                new PersistanceCanceled(
-                  (act as SaveEntitiesCancel).payload.reason
-                )
+              new PersistanceCanceled(
+                (act as SaveEntitiesCancel).payload.reason
+              )
             )
           : act.type === EntityCacheAction.SAVE_ENTITIES_SUCCESS
           ? of((act as SaveEntitiesSuccess).payload.changeSet)
-          : throwError(() => (act as SaveEntitiesError).payload);
+          : throwError((act as SaveEntitiesError).payload);
       })
     );
   }

--- a/modules/data/src/dispatchers/entity-dispatcher-base.ts
+++ b/modules/data/src/dispatchers/entity-dispatcher-base.ts
@@ -590,10 +590,10 @@ export class EntityDispatcherBase<T> implements EntityDispatcher<T> {
       mergeMap((act) => {
         const { entityOp } = act.payload;
         return entityOp === EntityOp.CANCEL_PERSIST
-          ? throwError(() => new PersistanceCanceled(act.payload.data))
+          ? throwError(new PersistanceCanceled(act.payload.data))
           : entityOp.endsWith(OP_SUCCESS)
           ? of(act.payload.data as D)
-          : throwError(() => act.payload.data.error);
+          : throwError(act.payload.data.error);
       })
     );
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3702 

## What is the new behavior?

`component-store` and `data` packages are compatible with RxJS 6.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
