### PR TITLE
docs(store): fix typo for createSelectorFactory docs

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -608,7 +608,7 @@ export function createSelectorFactory<T = any, Props = any, V = any>(
  *   return a.reduce(reduceToDetermineIfArraysContainSameContents, true);
  * }
  *
- * export const creactOrderDoesNotMatterSelector = createSelectorFactory(
+ * export const createOrderDoesNotMatterSelector = createSelectorFactory(
  *   (projectionFun) => defaultMemoize(
  *     projectionFun,
  *     orderDoesNotMatterComparer,


### PR DESCRIPTION
The documentation comments for createSelectorFactory had a minor typo.

closes #3705 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3705 

## What is the new behavior?
Addresses a typo in the createSelectorFactory comments


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
