### PR TITLE
feat(store): introduced actionGroupCreator variant that keeps casing

### DIFF
--- a/modules/store/spec/action_group_creator.spec.ts
+++ b/modules/store/spec/action_group_creator.spec.ts
@@ -1,4 +1,5 @@
 import { createActionGroup, emptyProps, props } from '@ngrx/store';
+import { createActionGroupKeepCasing } from '../src/action_group_creator';
 
 describe('createActionGroup', () => {
   const authApiActions = createActionGroup({
@@ -17,6 +18,16 @@ describe('createActionGroup', () => {
     },
   });
 
+  const authorApiActions = createActionGroupKeepCasing({
+    source: 'Author API keep casing',
+    events: {
+      loadAuthors: emptyProps(),
+      loadAuthorsSUCceS: emptyProps(),
+      loadAuthorsFailed: emptyProps(),
+      'reload authors': emptyProps(),
+    },
+  });
+
   it('should create action name by camel casing the event name', () => {
     expect(booksApiActions.loadBooksSuccess).toBeDefined();
   });
@@ -24,6 +35,19 @@ describe('createActionGroup', () => {
   it('should create action type using the "[Source] Event" pattern', () => {
     expect(booksApiActions.loadBooksSuccess().type).toBe(
       '[Books API]  Load BOOKS  suCCess  '
+    );
+  });
+
+  it('should create action name by camel casing the event name', () => {
+    expect(authorApiActions.loadAuthors).toBeDefined();
+    expect(authorApiActions.loadAuthorsSUCceS).toBeDefined();
+    expect(authorApiActions.loadAuthorsFailed).toBeDefined();
+    expect(authorApiActions.reloadauthors).toBeDefined();
+  });
+
+  it('should create action type using the "[Source] Event" pattern', () => {
+    expect(authorApiActions.loadAuthors().type).toBe(
+      '[Author API keep casing] loadAuthors'
     );
   });
 

--- a/modules/store/src/action_group_creator_models.ts
+++ b/modules/store/src/action_group_creator_models.ts
@@ -98,6 +98,10 @@ export type ActionName<EventName extends string> = Uncapitalize<
   Join<TitleCase<Lowercase<Trim<EventName>>>>
 >;
 
+export type ActionNameKeepCasing<EventName extends string> = Uncapitalize<
+  Join<Trim<EventName>>
+>;
+
 export interface ActionGroupConfig<
   Source extends string,
   Events extends Record<string, ActionCreatorProps<unknown> | Creator>
@@ -121,4 +125,13 @@ export type ActionGroup<
     Events[EventName],
     `[${Source}] ${EventName & string}`
   >;
+};
+
+export type ActionGroupKeepCasing<
+  Source extends string,
+  Events extends Record<string, ActionCreatorProps<unknown> | Creator>
+> = {
+  [EventName in keyof Events as ActionNameKeepCasing<
+    EventName & string
+  >]: EventCreator<Events[EventName], `[${Source}] ${EventName & string}`>;
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x]  The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #
Closes https://github.com/ngrx/platform/issues/3693

## What is the new behavior?
Introduces a new variant of ActionGroup (ActionGroupKeepCasing) where the casing is unchanged.
This allows eventNames to be defined as property keys instead of strings, which is more intuitive.

This also allows usage of actions to be found easier (in: dispatch, effect, reducer)


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
