### PR TITLE
feat(store): add ability to create extra selectors with createFeature

### DIFF
--- a/modules/store/spec/feature_creator.spec.ts
+++ b/modules/store/spec/feature_creator.spec.ts
@@ -104,13 +104,13 @@ describe('createFeature()', () => {
     });
   });
 
-  describe('derived selectors', () => {
+  describe('extra selectors', () => {
     it('should create a feature', () => {
       const initialState = { count1: 9, count2: 10 };
       const counterFeature = createFeature({
         name: 'counter',
         reducer: createReducer(initialState),
-        derivedSelectors: ({
+        extraSelectors: ({
           selectCounterState,
           selectCount1,
           selectCount2,
@@ -153,12 +153,12 @@ describe('createFeature()', () => {
       ]);
     });
 
-    it('should override base selectors if derived selectors have the same names', () => {
+    it('should override base selectors if extra selectors have the same names', () => {
       const initialState = { count1: 10, count2: 100 };
       const counterFeature = createFeature({
         name: 'counter',
         reducer: createReducer(initialState),
-        derivedSelectors: ({
+        extraSelectors: ({
           selectCounterState,
           selectCount1,
           selectCount2,

--- a/modules/store/spec/feature_creator.spec.ts
+++ b/modules/store/spec/feature_creator.spec.ts
@@ -1,4 +1,10 @@
-import { createFeature, createReducer, Store, StoreModule } from '@ngrx/store';
+import {
+  createFeature,
+  createReducer,
+  createSelector,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
 import { TestBed } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 
@@ -94,6 +100,104 @@ describe('createFeature()', () => {
         'name',
         'reducer',
         'selectFooState',
+      ]);
+    });
+  });
+
+  describe('derived selectors', () => {
+    it('should create a feature', () => {
+      const initialState = { count1: 9, count2: 10 };
+      const counterFeature = createFeature({
+        name: 'counter',
+        reducer: createReducer(initialState),
+        derivedSelectors: ({
+          selectCounterState,
+          selectCount1,
+          selectCount2,
+        }) => ({
+          selectSquaredCount2: createSelector(
+            selectCounterState,
+            ({ count2 }) => count2 * count2
+          ),
+          selectTotalCount: createSelector(
+            selectCount1,
+            selectCount2,
+            (count1, count2) => count1 + count2
+          ),
+        }),
+      });
+
+      expect(counterFeature.selectCounterState({ counter: initialState })).toBe(
+        initialState
+      );
+      expect(counterFeature.selectCount1({ counter: initialState })).toBe(
+        initialState.count1
+      );
+      expect(counterFeature.selectCount2({ counter: initialState })).toBe(
+        initialState.count2
+      );
+      expect(
+        counterFeature.selectSquaredCount2({ counter: initialState })
+      ).toBe(initialState.count2 * initialState.count2);
+      expect(counterFeature.selectTotalCount({ counter: initialState })).toBe(
+        initialState.count1 + initialState.count2
+      );
+      expect(Object.keys(counterFeature)).toEqual([
+        'name',
+        'reducer',
+        'selectCounterState',
+        'selectCount1',
+        'selectCount2',
+        'selectSquaredCount2',
+        'selectTotalCount',
+      ]);
+    });
+
+    it('should override base selectors if derived selectors have the same names', () => {
+      const initialState = { count1: 10, count2: 100 };
+      const counterFeature = createFeature({
+        name: 'counter',
+        reducer: createReducer(initialState),
+        derivedSelectors: ({
+          selectCounterState,
+          selectCount1,
+          selectCount2,
+        }) => ({
+          selectCounterState: createSelector(
+            selectCounterState,
+            ({ count1, count2 }) => `ngrx-${count1}-${count2}`
+          ),
+          selectCount2: createSelector(
+            selectCount2,
+            (count2) => `ngrx-${count2}`
+          ),
+          selectTotalCount: createSelector(
+            selectCount1,
+            selectCount2,
+            (count1, count2) => count1 + count2
+          ),
+        }),
+      });
+
+      expect(counterFeature.selectCounterState({ counter: initialState })).toBe(
+        `ngrx-${initialState.count1}-${initialState.count2}`
+      );
+      expect(counterFeature.selectCount1({ counter: initialState })).toBe(
+        initialState.count1
+      );
+      expect(counterFeature.selectCount2({ counter: initialState })).toBe(
+        `ngrx-${initialState.count2}`
+      );
+      expect(counterFeature.selectTotalCount({ counter: initialState })).toBe(
+        initialState.count1 + initialState.count2
+      );
+      expect(Object.keys(counterFeature)).toEqual([
+        'name',
+        'reducer',
+        'selectCounterState',
+        'selectCount1',
+        'selectCount2',
+        'selectTotalCount',
       ]);
     });
   });

--- a/modules/store/spec/feature_creator.spec.ts
+++ b/modules/store/spec/feature_creator.spec.ts
@@ -105,7 +105,7 @@ describe('createFeature()', () => {
   });
 
   describe('extra selectors', () => {
-    it('should create a feature', () => {
+    it('should create extra selectors', () => {
       const initialState = { count1: 9, count2: 10 };
       const counterFeature = createFeature({
         name: 'counter',

--- a/modules/store/spec/types/feature_creator.spec.ts
+++ b/modules/store/spec/types/feature_creator.spec.ts
@@ -399,7 +399,7 @@ describe('createFeature()', () => {
   });
 
   describe('extra selectors', () => {
-    it('should create a feature', () => {
+    it('should create extra selectors', () => {
       const snippet = expectSnippet(`
         const increment = createAction('increment');
 
@@ -463,7 +463,7 @@ describe('createFeature()', () => {
       );
     });
 
-    it('should create a feature when reducer is created outside', () => {
+    it('should create extra selectors when reducer is created outside', () => {
       const snippet = expectSnippet(`
         const counterReducer = createReducer({ count: 0 });
 

--- a/modules/store/spec/types/feature_creator.spec.ts
+++ b/modules/store/spec/types/feature_creator.spec.ts
@@ -398,7 +398,7 @@ describe('createFeature()', () => {
     });
   });
 
-  describe('derived selectors', () => {
+  describe('extra selectors', () => {
     it('should create a feature', () => {
       const snippet = expectSnippet(`
         const increment = createAction('increment');
@@ -416,7 +416,7 @@ describe('createFeature()', () => {
             initialState,
             on(increment, (state) => ({ count: state.count + 1 }))
           ),
-          derivedSelectors: ({ selectCounterState, selectCount }) => ({
+          extraSelectors: ({ selectCounterState, selectCount }) => ({
             selectCounterState2: createSelector(
               selectCounterState,
               (state) => state
@@ -470,7 +470,7 @@ describe('createFeature()', () => {
         const counterFeature = createFeature({
           name: 'counter',
           reducer: counterReducer,
-          derivedSelectors: ({ selectCounterState, selectCount }) => ({
+          extraSelectors: ({ selectCounterState, selectCount }) => ({
             selectSquaredCount: createSelector(
               selectCounterState,
               selectCount,
@@ -509,12 +509,12 @@ describe('createFeature()', () => {
       );
     });
 
-    it('should override base selectors if derived selectors have the same names', () => {
+    it('should override base selectors if extra selectors have the same names', () => {
       const snippet = expectSnippet(`
         const counterFeature = createFeature({
           name: 'counter',
           reducer: createReducer({ count1: 0, count2: 0 }),
-          derivedSelectors: ({ selectCounterState, selectCount1, selectCount2 }) => ({
+          extraSelectors: ({ selectCounterState, selectCount1, selectCount2 }) => ({
             selectCounterState: createSelector(
               selectCount1,
               selectCount2,
@@ -556,14 +556,14 @@ describe('createFeature()', () => {
       );
     });
 
-    it('should not break the feature object when derived selector names are not string literals', () => {
+    it('should not break the feature object when extra selector names are not string literals', () => {
       const snippet = expectSnippet(`
         const untypedSelectors: Record<string, Selector<Record<string, any>, unknown>> = {};
 
         const counterFeature1 = createFeature({
           name: 'counter1',
           reducer: createReducer(0),
-          derivedSelectors: ({ selectCounter1State }) => ({
+          extraSelectors: ({ selectCounter1State }) => ({
             ['selectInvalid' as string]: createSelector(
               selectCounter1State,
               (count) => count
@@ -579,7 +579,7 @@ describe('createFeature()', () => {
         const counterFeature2 = createFeature({
           name: 'counter2',
           reducer: createReducer(0),
-          derivedSelectors: () => untypedSelectors,
+          extraSelectors: () => untypedSelectors,
         });
 
         const { selectCounter1State } = counterFeature1;
@@ -607,12 +607,12 @@ describe('createFeature()', () => {
       );
     });
 
-    it('should not break the feature object when derived selectors are an empty object', () => {
+    it('should not break the feature object when extra selectors are an empty object', () => {
       const snippet = expectSnippet(`
         const counterFeature = createFeature({
           name: 'counter',
           reducer: createReducer(0),
-          derivedSelectors: () => ({}),
+          extraSelectors: () => ({}),
         });
 
         const { selectCounterState } = counterFeature;
@@ -629,15 +629,15 @@ describe('createFeature()', () => {
       );
     });
 
-    it('should create a feature when derived selectors dictionary is typed as a type', () => {
+    it('should create a feature when extra selectors dictionary is typed as a type', () => {
       const snippet = expectSnippet(`
-        type DerivedSelectors = {
+        type ExtraSelectors = {
           selectCountStr: Selector<Record<string, any>, string>;
         }
 
-        function getDerivedSelectors(
+        function getExtraSelectors(
           selectCount: Selector<Record<string, any>, number>
-        ): DerivedSelectors {
+        ): ExtraSelectors {
           return {
             selectCountStr: createSelector(
               selectCount,
@@ -649,8 +649,8 @@ describe('createFeature()', () => {
         const counterFeature = createFeature({
           name: 'counter',
           reducer: createReducer(0),
-          derivedSelectors: ({ selectCounterState }) =>
-            getDerivedSelectors(selectCounterState),
+          extraSelectors: ({ selectCounterState }) =>
+            getExtraSelectors(selectCounterState),
         });
 
         const { selectCountStr } = counterFeature;
@@ -669,15 +669,15 @@ describe('createFeature()', () => {
 
     // This is known behavior.
     // Record<string, Selector> is not compatible with interface of selectors.
-    it('should fail when derived selectors dictionary is typed as an interface', () => {
+    it('should fail when extra selectors dictionary is typed as an interface', () => {
       expectSnippet(`
-        interface DerivedSelectors {
+        interface ExtraSelectors {
           selectSquaredCount: Selector<Record<string, any>, number>;
         }
 
-        function getDerivedSelectors(
+        function getExtraSelectors(
           selectCount: Selector<Record<string, any>, number>
-        ): DerivedSelectors {
+        ): ExtraSelectors {
           return {
             selectSquaredCount: createSelector(
               selectCount,
@@ -689,20 +689,20 @@ describe('createFeature()', () => {
         const counterFeature = createFeature({
           name: 'counter',
           reducer: createReducer(0),
-          derivedSelectors: ({ selectCounterState }) =>
-            getDerivedSelectors(selectCounterState),
+          extraSelectors: ({ selectCounterState }) =>
+            getExtraSelectors(selectCounterState),
         });
       `).toFail(
-        /Index signature for type 'string' is missing in type 'DerivedSelectors'./
+        /Index signature for type 'string' is missing in type 'ExtraSelectors'./
       );
     });
 
-    it('should fail when derived selectors result is not a dictionary of selectors', () => {
+    it('should fail when extra selectors result is not a dictionary of selectors', () => {
       expectSnippet(`
         const counterFeature = createFeature({
           name: 'counter',
           reducer: createReducer(0),
-          derivedSelectors: ({ selectCounterState }) => ({
+          extraSelectors: ({ selectCounterState }) => ({
             selectSquaredCount: createSelector(
               selectCounterState,
               (count) => count * count
@@ -716,7 +716,7 @@ describe('createFeature()', () => {
         const counterFeature = createFeature({
           name: 'counter',
           reducer: createReducer(0),
-          derivedSelectors: () => 'ngrx',
+          extraSelectors: () => 'ngrx',
         });
       `).toFail();
     });
@@ -726,7 +726,7 @@ describe('createFeature()', () => {
         const counterFeature = createFeature({
           name: 'counter',
           reducer: createReducer({} as { count?: number; }),
-          derivedSelectors: () => ({}),
+          extraSelectors: () => ({}),
         });
       `).toFail();
 
@@ -739,7 +739,7 @@ describe('createFeature()', () => {
         const counterFeature = createFeature({
           name: 'counter',
           reducer: createReducer(initialState),
-          derivedSelectors: () => ({}),
+          extraSelectors: () => ({}),
         });
       `).toFail();
     });

--- a/modules/store/spec/types/feature_creator.spec.ts
+++ b/modules/store/spec/types/feature_creator.spec.ts
@@ -9,8 +9,10 @@ describe('createFeature()', () => {
         createAction,
         createFeature,
         createReducer,
+        createSelector,
         on,
         props,
+        Selector,
         Store,
         StoreModule,
       } from '@ngrx/store';
@@ -82,6 +84,34 @@ describe('createFeature()', () => {
       snippet.toInfer(
         'productsFeatureKeys',
         '"selectProductsState" | "selectQuery" | "selectProducts" | keyof FeatureConfig<"products", State>'
+      );
+    });
+
+    it('should create a feature when reducer is created outside', () => {
+      const snippet = expectSnippet(`
+        const counterReducer = createReducer({ count: 0 });
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: counterReducer,
+        });
+
+        const {
+          name,
+          reducer,
+          selectCounterState,
+          selectCount,
+        } = counterFeature;
+      `);
+
+      snippet.toInfer('name', '"counter"');
+      snippet.toInfer('reducer', 'ActionReducer<{ count: number; }, Action>');
+      snippet.toInfer(
+        'selectCounterState',
+        'MemoizedSelector<Record<string, any>, { count: number; }, DefaultProjectorFn<{ count: number; }>>'
+      );
+      snippet.toInfer(
+        'selectCount',
+        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
       );
     });
 
@@ -217,6 +247,39 @@ describe('createFeature()', () => {
       );
     });
 
+    it('should create a feature when reducer is created outside', () => {
+      const snippet = expectSnippet(`
+        interface State {
+          bar: string;
+        }
+        const initialState: State = { bar: 'ngrx' };
+
+        const fooReducer = createReducer(initialState);
+        const fooFeature = createFeature<{ foo: State }>({
+          name: 'foo',
+          reducer: fooReducer,
+        });
+
+        const {
+          name,
+          reducer,
+          selectFooState,
+          selectBar,
+        } = fooFeature;
+      `);
+
+      snippet.toInfer('name', '"foo"');
+      snippet.toInfer('reducer', 'ActionReducer<State, Action>');
+      snippet.toInfer(
+        'selectFooState',
+        'MemoizedSelector<{ foo: State; }, State, DefaultProjectorFn<State>>'
+      );
+      snippet.toInfer(
+        'selectBar',
+        'MemoizedSelector<{ foo: State; }, string, DefaultProjectorFn<string>>'
+      );
+    });
+
     it('should fail when name is not key of app state', () => {
       expectSnippet(`
         interface AppState {
@@ -332,6 +395,353 @@ describe('createFeature()', () => {
         'featureKeys',
         '"selectDateState" | keyof FeatureConfig<"date", Date>'
       );
+    });
+  });
+
+  describe('derived selectors', () => {
+    it('should create a feature', () => {
+      const snippet = expectSnippet(`
+        const increment = createAction('increment');
+
+        interface State {
+          count: number;
+        }
+        const initialState: State = {
+          count: 0,
+        };
+
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: createReducer(
+            initialState,
+            on(increment, (state) => ({ count: state.count + 1 }))
+          ),
+          derivedSelectors: ({ selectCounterState, selectCount }) => ({
+            selectCounterState2: createSelector(
+              selectCounterState,
+              (state) => state
+            ),
+            selectCountPlus1: createSelector(
+              selectCount,
+              (count) => count + 1
+            ),
+          }),
+        });
+
+        const {
+          name,
+          reducer,
+          selectCounterState,
+          selectCount,
+          selectCounterState2,
+          selectCountPlus1,
+        } = counterFeature;
+        let counterFeatureKeys: keyof typeof counterFeature;
+      `);
+
+      snippet.toInfer('name', '"counter"');
+      snippet.toInfer('reducer', 'ActionReducer<State, Action>');
+      snippet.toInfer(
+        'selectCounterState',
+        'MemoizedSelector<Record<string, any>, State, DefaultProjectorFn<State>>'
+      );
+      snippet.toInfer(
+        'selectCount',
+        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+      );
+      snippet.toInfer(
+        'selectCounterState2',
+        'MemoizedSelector<Record<string, any>, State, (s1: State) => State>'
+      );
+      snippet.toInfer(
+        'selectCountPlus1',
+        'MemoizedSelector<Record<string, any>, number, (s1: number) => number>'
+      );
+      snippet.toInfer(
+        'counterFeatureKeys',
+        '"name" | "reducer" | "selectCounterState" | "selectCount" | "selectCounterState2" | "selectCountPlus1"'
+      );
+    });
+
+    it('should create a feature when reducer is created outside', () => {
+      const snippet = expectSnippet(`
+        const counterReducer = createReducer({ count: 0 });
+
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: counterReducer,
+          derivedSelectors: ({ selectCounterState, selectCount }) => ({
+            selectSquaredCount: createSelector(
+              selectCounterState,
+              selectCount,
+              ({ count }, c) => count * c
+            ),
+          }),
+        });
+
+        const {
+          name,
+          reducer,
+          selectCounterState,
+          selectCount,
+          selectSquaredCount,
+        } = counterFeature;
+        let counterFeatureKeys: keyof typeof counterFeature;
+      `);
+
+      snippet.toInfer('name', '"counter"');
+      snippet.toInfer('reducer', 'ActionReducer<{ count: number; }, Action>');
+      snippet.toInfer(
+        'selectCounterState',
+        'MemoizedSelector<Record<string, any>, { count: number; }, DefaultProjectorFn<{ count: number; }>>'
+      );
+      snippet.toInfer(
+        'selectCount',
+        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+      );
+      snippet.toInfer(
+        'selectSquaredCount',
+        'MemoizedSelector<Record<string, any>, number, (s1: { count: number; }, s2: number) => number>'
+      );
+      snippet.toInfer(
+        'counterFeatureKeys',
+        '"name" | "reducer" | "selectCounterState" | "selectCount" | "selectSquaredCount"'
+      );
+    });
+
+    it('should override base selectors if derived selectors have the same names', () => {
+      const snippet = expectSnippet(`
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: createReducer({ count1: 0, count2: 0 }),
+          derivedSelectors: ({ selectCounterState, selectCount1, selectCount2 }) => ({
+            selectCounterState: createSelector(
+              selectCount1,
+              selectCount2,
+              (count3, count4) => ({ count3, count4 })
+            ),
+            selectCount1: createSelector(selectCount1, (count) => count + ''),
+            selectCount10: createSelector(selectCount2, (count) => count + 1),
+          }),
+        });
+
+        const {
+          selectCounterState,
+          selectCount1,
+          selectCount2,
+          selectCount10,
+        } = counterFeature;
+        let counterFeatureKeys: keyof typeof counterFeature;
+      `);
+
+      snippet.toInfer(
+        'selectCounterState',
+        'MemoizedSelector<Record<string, any>, { count3: number; count4: number; }, (s1: number, s2: number) => { count3: number; count4: number; }>'
+      );
+      snippet.toInfer(
+        'selectCount1',
+        'MemoizedSelector<Record<string, any>, string, (s1: number) => string>'
+      );
+      snippet.toInfer(
+        'selectCount2',
+        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+      );
+      snippet.toInfer(
+        'selectCount10',
+        'MemoizedSelector<Record<string, any>, number, (s1: number) => number>'
+      );
+      snippet.toInfer(
+        'counterFeatureKeys',
+        '"name" | "reducer" | "selectCounterState" | "selectCount1" | "selectCount2" | "selectCount10"'
+      );
+    });
+
+    it('should not break the feature object when derived selector names are not string literals', () => {
+      const snippet = expectSnippet(`
+        const untypedSelectors: Record<string, Selector<Record<string, any>, unknown>> = {};
+
+        const counterFeature1 = createFeature({
+          name: 'counter1',
+          reducer: createReducer(0),
+          derivedSelectors: ({ selectCounter1State }) => ({
+            ['selectInvalid' as string]: createSelector(
+              selectCounter1State,
+              (count) => count
+            ),
+            selectSquaredCount: createSelector(
+              selectCounter1State,
+              (count) => count * count
+            ),
+            ...untypedSelectors,
+          }),
+        });
+
+        const counterFeature2 = createFeature({
+          name: 'counter2',
+          reducer: createReducer(0),
+          derivedSelectors: () => untypedSelectors,
+        });
+
+        const { selectCounter1State } = counterFeature1;
+        const { selectCounter2State } = counterFeature2;
+
+        let counterFeature1Keys: keyof typeof counterFeature1;
+        let counterFeature2Keys: keyof typeof counterFeature2;
+      `);
+
+      snippet.toInfer(
+        'selectCounter1State',
+        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+      );
+      snippet.toInfer(
+        'selectCounter2State',
+        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+      );
+      snippet.toInfer(
+        'counterFeature1Keys',
+        '"selectCounter1State" | keyof FeatureConfig<"counter1", number>'
+      );
+      snippet.toInfer(
+        'counterFeature2Keys',
+        '"selectCounter2State" | keyof FeatureConfig<"counter2", number>'
+      );
+    });
+
+    it('should not break the feature object when derived selectors are an empty object', () => {
+      const snippet = expectSnippet(`
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: createReducer(0),
+          derivedSelectors: () => ({}),
+        });
+
+        const { selectCounterState } = counterFeature;
+        let counterFeatureKeys: keyof typeof counterFeature;
+      `);
+
+      snippet.toInfer(
+        'selectCounterState',
+        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+      );
+      snippet.toInfer(
+        'counterFeatureKeys',
+        '"name" | "reducer" | "selectCounterState"'
+      );
+    });
+
+    it('should create a feature when derived selectors dictionary is typed as a type', () => {
+      const snippet = expectSnippet(`
+        type DerivedSelectors = {
+          selectCountStr: Selector<Record<string, any>, string>;
+        }
+
+        function getDerivedSelectors(
+          selectCount: Selector<Record<string, any>, number>
+        ): DerivedSelectors {
+          return {
+            selectCountStr: createSelector(
+              selectCount,
+              (count) => count + ''
+            ),
+          };
+        }
+
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: createReducer(0),
+          derivedSelectors: ({ selectCounterState }) =>
+            getDerivedSelectors(selectCounterState),
+        });
+
+        const { selectCountStr } = counterFeature;
+        let counterFeatureKeys: keyof typeof counterFeature;
+      `);
+
+      snippet.toInfer(
+        'selectCountStr',
+        'Selector<Record<string, any>, string>'
+      );
+      snippet.toInfer(
+        'counterFeatureKeys',
+        '"name" | "reducer" | "selectCounterState" | "selectCountStr"'
+      );
+    });
+
+    // This is known behavior.
+    // Record<string, Selector> is not compatible with interface of selectors.
+    it('should fail when derived selectors dictionary is typed as an interface', () => {
+      expectSnippet(`
+        interface DerivedSelectors {
+          selectSquaredCount: Selector<Record<string, any>, number>;
+        }
+
+        function getDerivedSelectors(
+          selectCount: Selector<Record<string, any>, number>
+        ): DerivedSelectors {
+          return {
+            selectSquaredCount: createSelector(
+              selectCount,
+              (count) => count * count
+            ),
+          };
+        }
+
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: createReducer(0),
+          derivedSelectors: ({ selectCounterState }) =>
+            getDerivedSelectors(selectCounterState),
+        });
+      `).toFail(
+        /Index signature for type 'string' is missing in type 'DerivedSelectors'./
+      );
+    });
+
+    it('should fail when derived selectors result is not a dictionary of selectors', () => {
+      expectSnippet(`
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: createReducer(0),
+          derivedSelectors: ({ selectCounterState }) => ({
+            selectSquaredCount: createSelector(
+              selectCounterState,
+              (count) => count * count
+            ),
+            x: 1,
+          }),
+        });
+      `).toFail();
+
+      expectSnippet(`
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: createReducer(0),
+          derivedSelectors: () => 'ngrx',
+        });
+      `).toFail();
+    });
+
+    it('should fail when feature state contains optional properties', () => {
+      expectSnippet(`
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: createReducer({} as { count?: number; }),
+          derivedSelectors: () => ({}),
+        });
+      `).toFail();
+
+      expectSnippet(`
+        interface State {
+          count?: number;
+        }
+        const initialState: State = {};
+
+        const counterFeature = createFeature({
+          name: 'counter',
+          reducer: createReducer(initialState),
+          derivedSelectors: () => ({}),
+        });
+      `).toFail();
     });
   });
 });

--- a/modules/store/src/feature_creator.ts
+++ b/modules/store/src/feature_creator.ts
@@ -1,5 +1,5 @@
 import { capitalize } from './helpers';
-import { ActionReducer } from './models';
+import { ActionReducer, Selector } from './models';
 import { isPlainObject } from './meta-reducers/utils';
 import {
   createFeatureSelector,
@@ -8,18 +8,49 @@ import {
 } from './selector';
 import { FeatureSelector, NestedSelectors } from './feature_creator_models';
 
-export type Feature<
-  AppState extends Record<string, any>,
-  FeatureName extends keyof AppState & string,
-  FeatureState extends AppState[FeatureName]
-> = FeatureConfig<FeatureName, FeatureState> &
-  FeatureSelector<AppState, FeatureName, FeatureState> &
-  NestedSelectors<AppState, FeatureState>;
-
 export interface FeatureConfig<FeatureName extends string, FeatureState> {
   name: FeatureName;
   reducer: ActionReducer<FeatureState>;
 }
+
+type Feature<
+  AppState extends Record<string, any>,
+  FeatureName extends keyof AppState & string,
+  FeatureState extends AppState[FeatureName]
+> = FeatureConfig<FeatureName, FeatureState> &
+  BaseSelectors<AppState, FeatureName, FeatureState>;
+
+type FeatureWithDerivedSelectors<
+  FeatureName extends string,
+  FeatureState,
+  DerivedSelectors extends DerivedSelectorsDictionary
+> = string extends keyof DerivedSelectors
+  ? Feature<Record<string, any>, FeatureName, FeatureState>
+  : Omit<
+      Feature<Record<string, any>, FeatureName, FeatureState>,
+      keyof DerivedSelectors
+    > &
+      DerivedSelectors;
+
+type BaseSelectors<
+  AppState extends Record<string, any>,
+  FeatureName extends keyof AppState & string,
+  FeatureState extends AppState[FeatureName]
+> = FeatureSelector<AppState, FeatureName, FeatureState> &
+  NestedSelectors<AppState, FeatureState>;
+
+type DerivedSelectorsDictionary = Record<
+  string,
+  Selector<Record<string, any>, unknown>
+>;
+
+type DerivedSelectorsFactory<
+  FeatureName extends string,
+  FeatureState,
+  DerivedSelectors extends DerivedSelectorsDictionary
+> = (
+  baseSelectors: BaseSelectors<Record<string, any>, FeatureName, FeatureState>
+) => DerivedSelectors;
 
 type NotAllowedFeatureStateCheck<FeatureState> =
   FeatureState extends Required<FeatureState>
@@ -27,13 +58,55 @@ type NotAllowedFeatureStateCheck<FeatureState> =
     : 'optional properties are not allowed in the feature state';
 
 /**
+ * Creates a feature object with derived selectors.
+ *
+ * @param featureConfig An object that contains a feature name, a feature
+ * reducer, and derived selectors factory.
+ * @returns An object that contains a feature name, a feature reducer,
+ * a feature selector, a selector for each feature state property, and
+ * derived selectors.
+ */
+export function createFeature<
+  FeatureName extends string,
+  FeatureState,
+  DerivedSelectors extends DerivedSelectorsDictionary
+>(
+  featureConfig: FeatureConfig<FeatureName, FeatureState> & {
+    derivedSelectors: DerivedSelectorsFactory<
+      FeatureName,
+      FeatureState,
+      DerivedSelectors
+    >;
+  } & NotAllowedFeatureStateCheck<FeatureState>
+): FeatureWithDerivedSelectors<FeatureName, FeatureState, DerivedSelectors>;
+/**
+ * Creates a feature object.
+ *
+ * @param featureConfig An object that contains a feature name and a feature
+ * reducer.
+ * @returns An object that contains a feature name, a feature reducer,
+ * a feature selector, and a selector for each feature state property.
+ */
+export function createFeature<
+  AppState extends Record<string, any>,
+  FeatureName extends keyof AppState & string = keyof AppState & string,
+  FeatureState extends AppState[FeatureName] = AppState[FeatureName]
+>(
+  featureConfig: FeatureConfig<FeatureName, FeatureState> &
+    NotAllowedFeatureStateCheck<FeatureState>
+): Feature<AppState, FeatureName, FeatureState>;
+/**
  * @description
  * A function that accepts a feature name and a feature reducer, and creates
  * a feature selector and a selector for each feature state property.
+ * This function also provides the ability to add derived selectors to
+ * the feature object.
  *
- * @param featureConfig An object that contains a feature name and a feature reducer.
+ * @param featureConfig An object that contains a feature name and a feature
+ * reducer as required, and derived selectors factory as an optional argument.
  * @returns An object that contains a feature name, a feature reducer,
- * a feature selector, and a selector for each feature state property.
+ * a feature selector, a selector for each feature state property, and derived
+ * selectors.
  *
  * @usageNotes
  *
@@ -87,25 +160,88 @@ type NotAllowedFeatureStateCheck<FeatureState> =
  *   selectSelectedId, // type: MemoizedSelector<Record<string, any, string | null>
  * } = productsFeature;
  * ```
+ *
+ * **Creating Feature with Derived Selectors**
+ *
+ * ```ts
+ * type CallState = 'init' | 'loading' | 'loaded' | { error: string };
+ *
+ * interface State extends EntityState<Product> {
+ *   callState: CallState;
+ * }
+ *
+ * const adapter = createEntityAdapter<Product>();
+ * const initialState: State = adapter.getInitialState({
+ *   callState: 'init',
+ * });
+ *
+ * export const productsFeature = createFeature({
+ *   name: 'products',
+ *   reducer: createReducer(initialState),
+ *   derivedSelectors: ({ selectProductsState, selectCallState }) => ({
+ *     ...adapter.getSelectors(selectBooksState),
+ *     ...getCallStateSelectors(selectCallState)
+ *   }),
+ * });
+ *
+ * const {
+ *   name,
+ *   reducer,
+ *   // feature selector
+ *   selectProductsState,
+ *   // feature state properties selectors
+ *   selectIds,
+ *   selectEntities,
+ *   selectCallState,
+ *   // derived selectors returned by `adapter.getSelectors`
+ *   selectAll,
+ *   selectTotal,
+ *   // derived selectors returned by `getCallStateSelectors`
+ *   selectIsLoading,
+ *   selectIsLoaded,
+ *   selectError,
+ * } = productsFeature;
+ * ```
  */
 export function createFeature<
   AppState extends Record<string, any>,
-  FeatureName extends keyof AppState & string = keyof AppState & string,
-  FeatureState extends AppState[FeatureName] = AppState[FeatureName]
+  FeatureName extends keyof AppState & string,
+  FeatureState extends AppState[FeatureName],
+  DerivedSelectors extends Record<
+    string,
+    Selector<Record<string, any>, unknown>
+  >
 >(
-  featureConfig: FeatureConfig<FeatureName, FeatureState> &
-    NotAllowedFeatureStateCheck<FeatureState>
-): Feature<AppState, FeatureName, FeatureState> {
-  const { name, reducer } = featureConfig;
+  featureConfig: FeatureConfig<FeatureName, FeatureState> & {
+    derivedSelectors?: DerivedSelectorsFactory<
+      FeatureName,
+      FeatureState,
+      DerivedSelectors
+    >;
+  }
+): Feature<AppState, FeatureName, FeatureState> & DerivedSelectors {
+  const {
+    name,
+    reducer,
+    derivedSelectors: derivedSelectorsFactory,
+  } = featureConfig;
+
   const featureSelector = createFeatureSelector<FeatureState>(name);
   const nestedSelectors = createNestedSelectors(featureSelector, reducer);
+  const baseSelectors = {
+    [`select${capitalize(name)}State`]: featureSelector,
+    ...nestedSelectors,
+  } as BaseSelectors<Record<string, any>, FeatureName, FeatureState>;
+  const derivedSelectors = derivedSelectorsFactory
+    ? derivedSelectorsFactory(baseSelectors)
+    : {};
 
   return {
     name,
     reducer,
-    [`select${capitalize(name)}State`]: featureSelector,
-    ...nestedSelectors,
-  } as unknown as Feature<AppState, FeatureName, FeatureState>;
+    ...baseSelectors,
+    ...derivedSelectors,
+  } as Feature<AppState, FeatureName, FeatureState> & DerivedSelectors;
 }
 
 function createNestedSelectors<

--- a/modules/store/src/reducer_creator.ts
+++ b/modules/store/src/reducer_creator.ts
@@ -111,10 +111,14 @@ export function on<
  * );
  * ```
  */
-export function createReducer<S, A extends Action = Action>(
-  initialState: S,
-  ...ons: ReducerTypes<S, readonly ActionCreator[]>[]
-): ActionReducer<S, A> {
+export function createReducer<
+  S,
+  A extends Action = Action,
+  // Additional generic for the return type is introduced to enable correct
+  // type inference when `createReducer` is used within `createFeature`.
+  // For more info see: https://github.com/microsoft/TypeScript/issues/52114
+  R extends ActionReducer<S, A> = ActionReducer<S, A>
+>(initialState: S, ...ons: ReducerTypes<S, readonly ActionCreator[]>[]): R {
   const map = new Map<string, OnReducer<S, ActionCreator[]>>();
   for (const on of ons) {
     for (const type of on.types) {
@@ -132,5 +136,5 @@ export function createReducer<S, A extends Action = Action>(
   return function (state: S = initialState, action: A): S {
     const reducer = map.get(action.type);
     return reducer ? reducer(state, action) : state;
-  };
+  } as R;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3719 

## What is the new behavior?

We can add extra selectors to the feature object by using the extra selectors factory:

```ts
interface State extends EntityState<Book> {
  callState: CallState;
}

export const booksFeature = createFeature({
  name: 'books',
  reducer: createReducer(initialState, /* case reducers */),
  extraSelectors: ({ selectBooksState, selectCallState }) => ({
    ...adapter.getSelectors(selectBooksState),
    ...getCallStateSelectors(selectCallState),
  }),
});
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
