### PR TITLE
feat(router-store): rename getSelectors to getRouterSelectors

### DIFF
--- a/modules/router-store/spec/router_selectors.spec.ts
+++ b/modules/router-store/spec/router_selectors.spec.ts
@@ -1,5 +1,5 @@
 import {
-  getSelectors,
+  getRouterSelectors,
   RouterReducerState,
   DEFAULT_ROUTER_FEATURENAME,
   createRouterSelector,
@@ -135,7 +135,7 @@ describe('Router State Selectors', () => {
         router: mockData,
       };
 
-      selectors = getSelectors();
+      selectors = getRouterSelectors();
     });
 
     it('should create selectCurrentRoute selector for selecting the current route', () => {
@@ -148,7 +148,7 @@ describe('Router State Selectors', () => {
       const stateOverwrite = {
         anotherRouterKey: mockData,
       };
-      const selectorOverwrite = getSelectors(
+      const selectorOverwrite = getRouterSelectors(
         (state: typeof stateOverwrite) => state.anotherRouterKey
       );
 
@@ -162,7 +162,7 @@ describe('Router State Selectors', () => {
       const stateOverwrite = {
         [DEFAULT_ROUTER_FEATURENAME]: mockData,
       };
-      const selectorOverwrite = getSelectors(createRouterSelector());
+      const selectorOverwrite = getRouterSelectors(createRouterSelector());
 
       const result = selectorOverwrite.selectCurrentRoute(stateOverwrite);
       expect(result).toEqual(
@@ -178,7 +178,7 @@ describe('Router State Selectors', () => {
       const state: State = {
         router: undefined,
       };
-      selectors = getSelectors((state: State) => state.router);
+      selectors = getRouterSelectors((state: State) => state.router);
 
       const result = selectors.selectCurrentRoute(state);
 

--- a/modules/router-store/spec/types/selectors.spec.ts
+++ b/modules/router-store/spec/types/selectors.spec.ts
@@ -4,16 +4,16 @@ import { compilerOptions } from './utils';
 describe('router selectors', () => {
   const expectSnippet = expecter(
     (code) => `
-      import * as fromRouter from '@ngrx/router-store';
+      import { getRouterSelectors, RouterReducerState } from '@ngrx/router-store';
       import { createSelector, createFeatureSelector } from '@ngrx/store';
 
       export interface State {
-        router: fromRouter.RouterReducerState<any>;
+        router: RouterReducerState<any>;
       }
 
       export const selectRouter = createFeatureSelector<
         State,
-        fromRouter.RouterReducerState<any>
+        RouterReducerState<any>
       >('router');
 
       export const {
@@ -25,7 +25,7 @@ describe('router selectors', () => {
         selectRouteData,
         selectUrl,
         selectTitle,
-      } = fromRouter.getSelectors(selectRouter);
+      } = getRouterSelectors(selectRouter);
 
       ${code}
     `,

--- a/modules/router-store/src/index.ts
+++ b/modules/router-store/src/index.ts
@@ -44,5 +44,9 @@ export {
   MinimalRouterStateSnapshot,
   MinimalRouterStateSerializer,
 } from './serializers/minimal_serializer';
-export { getSelectors, createRouterSelector } from './router_selectors';
+export {
+  getRouterSelectors,
+  getSelectors,
+  createRouterSelector,
+} from './router_selectors';
 export { provideRouterStore } from './provide_router_store';

--- a/modules/router-store/src/router_selectors.ts
+++ b/modules/router-store/src/router_selectors.ts
@@ -13,7 +13,13 @@ export function createRouterSelector<
   return createFeatureSelector(DEFAULT_ROUTER_FEATURENAME);
 }
 
-export function getSelectors<V extends Record<string, any>>(
+/**
+ * @deprecated This function is deprecated in favor of `getRouterSelectors`.
+ * For more info see: https://github.com/ngrx/platform/issues/3738
+ */
+export const getSelectors = getRouterSelectors;
+
+export function getRouterSelectors<V extends Record<string, any>>(
   selectState: (state: V) => RouterReducerState<any> = createRouterSelector<V>()
 ): RouterStateSelectors<V> {
   const selectRouterState = createSelector(

--- a/projects/example-app/src/app/reducers/index.ts
+++ b/projects/example-app/src/app/reducers/index.ts
@@ -6,7 +6,11 @@ import {
   ActionReducerMap,
   MetaReducer,
 } from '@ngrx/store';
-import * as fromRouter from '@ngrx/router-store';
+import {
+  getRouterSelectors,
+  routerReducer,
+  RouterReducerState,
+} from '@ngrx/router-store';
 
 /**
  * Every reducer module's default export is the reducer function itself. In
@@ -24,7 +28,7 @@ import { InjectionToken, isDevMode } from '@angular/core';
  */
 export interface State {
   [fromLayout.layoutFeatureKey]: fromLayout.State;
-  router: fromRouter.RouterReducerState<any>;
+  router: RouterReducerState<any>;
 }
 
 /**
@@ -37,7 +41,7 @@ export const ROOT_REDUCERS = new InjectionToken<
 >('Root reducers token', {
   factory: () => ({
     [fromLayout.layoutFeatureKey]: fromLayout.reducer,
-    router: fromRouter.routerReducer,
+    router: routerReducer,
   }),
 });
 
@@ -60,7 +64,6 @@ export function logger(reducer: ActionReducer<State>): ActionReducer<State> {
  * the root meta-reducer. To add more meta-reducers, provide an array of meta-reducers
  * that will be composed to form the root meta-reducer.
  */
-
 export const metaReducers: MetaReducer<State>[] = isDevMode() ? [logger] : [];
 
 /**
@@ -78,4 +81,4 @@ export const selectShowSidenav = createSelector(
 /**
  * Router Selectors
  */
-export const { selectRouteData } = fromRouter.getSelectors();
+export const { selectRouteData } = getRouterSelectors();

--- a/projects/ngrx.io/content/examples/router-store-selectors/src/app/router.selectors.ts
+++ b/projects/ngrx.io/content/examples/router-store-selectors/src/app/router.selectors.ts
@@ -1,8 +1,8 @@
 // #docregion routerSelectors
-import { getSelectors, RouterReducerState } from '@ngrx/router-store';
+import { getRouterSelectors, RouterReducerState } from '@ngrx/router-store';
 
 // `router` is used as the default feature name. You can use the feature name
-// of your choice by creating a feature selector and pass it to the `getSelectors` function
+// of your choice by creating a feature selector and pass it to the `getRouterSelectors` function
 // export const selectRouter = createFeatureSelector<RouterReducerState>('yourFeatureName');
 
 export const {
@@ -16,5 +16,5 @@ export const {
     selectRouteDataParam, // factory function to select a route data param
     selectUrl, // select the current url
     selectTitle, // select the title if available
-} = getSelectors();
+} = getRouterSelectors();
 // #enddocregion routerSelectors

--- a/projects/ngrx.io/content/guide/migration/v15.md
+++ b/projects/ngrx.io/content/guide/migration/v15.md
@@ -221,3 +221,26 @@ export class TestComponent {
 }
 ```
 
+## Deprecations
+
+### @ngrx/router-store
+
+#### Renamed `getSelectors` Function
+
+The `getSelectors` function is deprecated in favor of `getRouterSelectors`.
+
+BEFORE:
+
+```ts
+import { getSelectors } from '@ngrx/router-store';
+
+const routerSelectors = getSelectors();
+```
+
+AFTER:
+
+```ts
+import { getRouterSelectors } from '@ngrx/router-store';
+
+const routerSelectors = getRouterSelectors();
+```

--- a/projects/ngrx.io/content/guide/migration/v15.md
+++ b/projects/ngrx.io/content/guide/migration/v15.md
@@ -225,7 +225,7 @@ export class TestComponent {
 
 ### @ngrx/router-store
 
-#### Renamed `getSelectors` Function
+#### Renamed `getSelectors` Function (Introduced in v15.2)
 
 The `getSelectors` function is deprecated in favor of `getRouterSelectors`.
 

--- a/projects/ngrx.io/content/guide/router-store/selectors.md
+++ b/projects/ngrx.io/content/guide/router-store/selectors.md
@@ -1,12 +1,12 @@
 # Router selectors
 
-The `getSelectors` method supplied within `@ngrx/router-store` provides functions for selecting common information from the router state.
+The `getRouterSelectors` method supplied within `@ngrx/router-store` provides functions for selecting common information from the router state.
 
-The default behavior of `getSelectors` selects the router state for the `router` state key.
-If the default router state config is overwritten with a different router state key, the `getSelectors` method takes a selector function to select the piece of state where the router state is being stored.
+The default behavior of `getRouterSelectors` selects the router state for the `router` state key.
+If the default router state config is overwritten with a different router state key, the `getRouterSelectors` method takes a selector function to select the piece of state where the router state is being stored.
 The example below shows how to provide a selector for the top level `router` key in your state object.
 
-**Note:** The `getSelectors` method works with the `routerReducer` provided by `@ngrx/router-store`. If you use a [custom serializer](guide/router-store/configuration#custom-router-state-serializer), you'll need to provide your own selectors.
+**Note:** The `getRouterSelectors` method works with the `routerReducer` provided by `@ngrx/router-store`. If you use a [custom serializer](guide/router-store/configuration#custom-router-state-serializer), you'll need to provide your own selectors.
 
 Usage:
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3738 

## What is the new behavior?

The `getSelectors` function renamed to `getRouterSelectors`. The `getSelectors` alias is still available but is deprecated.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
