### PR TITLE
docs(component-store): typo fix in effect example

### DIFF
--- a/projects/ngrx.io/content/guide/component-store/effect.md
+++ b/projects/ngrx.io/content/guide/component-store/effect.md
@@ -100,7 +100,7 @@ To make this possible set the generic type of the `effect` method to `void`.
 <code-example header="movies.store.ts">
   readonly getAllMovies = this.effect&lt;void&gt;(
     // The name of the source stream doesn't matter: `trigger$`, `source$` or `$` are good 
-    // names. We encourage to choose one of these and them consistently in your codebase.
+    // names. We encourage to choose one of these and use them consistently in your codebase.
     trigger$ => trigger$.pipe(
       exhaustMap(() => this.moviesService.fetchAllMovies().pipe(
         tapResponse(


### PR DESCRIPTION
Fix the verb omission in the effect example comment encouraging users to *use* a specific source stream name.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [n/a] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The comment in the effect example for component-store has a typo of a missing word, it reads
```
We encourage to choose one of these and them consistently in your codebase.
```

Closes #

## What is the new behavior?

The comment in the effect example for component-store now reads:
```
We encourage to choose one of these and use them consistently in your codebase.
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
This is only a typo fix for a comment in an example.