### PR TITLE
fix(store): support using factory selectors as extra selectors

### DIFF
--- a/modules/store/spec/feature_creator.spec.ts
+++ b/modules/store/spec/feature_creator.spec.ts
@@ -124,6 +124,12 @@ describe('createFeature()', () => {
             selectCount2,
             (count1, count2) => count1 + count2
           ),
+          selectCount3: (count: number) =>
+            createSelector(
+              selectCount1,
+              selectCount2,
+              (count1, count2) => count1 + count2 + count
+            ),
         }),
       });
 
@@ -142,6 +148,9 @@ describe('createFeature()', () => {
       expect(counterFeature.selectTotalCount({ counter: initialState })).toBe(
         initialState.count1 + initialState.count2
       );
+      expect(counterFeature.selectCount3(1)({ counter: initialState })).toBe(
+        initialState.count1 + initialState.count2 + 1
+      );
       expect(Object.keys(counterFeature)).toEqual([
         'name',
         'reducer',
@@ -150,6 +159,7 @@ describe('createFeature()', () => {
         'selectCount2',
         'selectSquaredCount2',
         'selectTotalCount',
+        'selectCount3',
       ]);
     });
 

--- a/modules/store/spec/types/feature_creator.spec.ts
+++ b/modules/store/spec/types/feature_creator.spec.ts
@@ -425,6 +425,8 @@ describe('createFeature()', () => {
               selectCount,
               (count) => count + 1
             ),
+            selectCountPlusNum: (num: number) =>
+              createSelector(selectCount, (count) => count + num),
           }),
         });
 
@@ -435,6 +437,7 @@ describe('createFeature()', () => {
           selectCount,
           selectCounterState2,
           selectCountPlus1,
+          selectCountPlusNum,
         } = counterFeature;
         let counterFeatureKeys: keyof typeof counterFeature;
       `);
@@ -458,8 +461,12 @@ describe('createFeature()', () => {
         'MemoizedSelector<Record<string, any>, number, (s1: number) => number>'
       );
       snippet.toInfer(
+        'selectCountPlusNum',
+        '(num: number) => MemoizedSelector<Record<string, any>, number, (s1: number) => number>'
+      );
+      snippet.toInfer(
         'counterFeatureKeys',
-        '"name" | "reducer" | "selectCounterState" | "selectCount" | "selectCounterState2" | "selectCountPlus1"'
+        '"name" | "reducer" | "selectCounterState" | "selectCount" | "selectCounterState2" | "selectCountPlus1" | "selectCountPlusNum"'
       );
     });
 
@@ -633,6 +640,7 @@ describe('createFeature()', () => {
       const snippet = expectSnippet(`
         type ExtraSelectors = {
           selectCountStr: Selector<Record<string, any>, string>;
+          selectCountPlusNum: (num: number) => Selector<Record<string, any>, number>;
         }
 
         function getExtraSelectors(
@@ -643,6 +651,8 @@ describe('createFeature()', () => {
               selectCount,
               (count) => count + ''
             ),
+            selectCountPlusNum: (num: number) =>
+              createSelector(selectCount, (count) => count + num)
           };
         }
 
@@ -653,7 +663,7 @@ describe('createFeature()', () => {
             getExtraSelectors(selectCounterState),
         });
 
-        const { selectCountStr } = counterFeature;
+        const { selectCountStr, selectCountPlusNum } = counterFeature;
         let counterFeatureKeys: keyof typeof counterFeature;
       `);
 
@@ -662,8 +672,12 @@ describe('createFeature()', () => {
         'Selector<Record<string, any>, string>'
       );
       snippet.toInfer(
+        'selectCountPlusNum',
+        '(num: number) => Selector<Record<string, any>, number>'
+      );
+      snippet.toInfer(
         'counterFeatureKeys',
-        '"name" | "reducer" | "selectCounterState" | "selectCountStr"'
+        '"name" | "reducer" | "selectCounterState" | keyof ExtraSelectors'
       );
     });
 

--- a/modules/store/src/feature_creator.ts
+++ b/modules/store/src/feature_creator.ts
@@ -41,7 +41,8 @@ type BaseSelectors<
 
 type SelectorsDictionary = Record<
   string,
-  Selector<Record<string, any>, unknown>
+  | Selector<Record<string, any>, unknown>
+  | ((...args: any[]) => Selector<Record<string, any>, unknown>)
 >;
 
 type ExtraSelectorsFactory<


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?

We can return factory selectors as `createFeature.extraSelectors` result:

```ts
export const usersFeature = createFeature({
  name: 'users',
  reducers: createReducer(initialState),
  extraSelectors: ({ selectUsers }) => ({
    selectUserById: (id: number) => createSelector(
      selectUsers,
      (users) => users.find((user) => user.id === id)
    ),
  }),
});
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
