### PR TITLE
fix(eslint-plugin): ignore select name within createFeature

### DIFF
--- a/modules/eslint-plugin/spec/rules/prefix-selectors-with-select.spec.ts
+++ b/modules/eslint-plugin/spec/rules/prefix-selectors-with-select.spec.ts
@@ -25,6 +25,15 @@ const valid: () => RunTests['valid'] = () => [
   `export const select_feature = createSelectorFactory(factoryFn)`,
   `export const select$feature = createSelectorFactory(factoryFn)`,
   `export const selectF01 = createSelector(factoryFn)`,
+  `
+    export const authFeature = createFeature({
+      name: 'auth',
+      reducer: authReducer,
+      extraSelectors: ({selectToken}) => ({
+        selectIsAuthorized: createSelector(selectToken, token => !!token)
+      }),
+    })
+  `,
 ];
 
 const invalid: () => RunTests['invalid'] = () => [

--- a/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
+++ b/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
@@ -34,7 +34,7 @@ export default createRule<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     return {
-      'VariableDeclarator[id.name!=/^select[^a-z].+$/]:matches([id.typeAnnotation.typeAnnotation.typeName.name=/^MemoizedSelector(WithProps)?$/], :has(CallExpression[callee.name=/^(create(Feature)?Selector|createSelectorFactory)$/]))'({
+      'VariableDeclarator[id.name!=/^select[^a-z].+$/]:not(:has(Identifier[name="createFeature"])):matches([id.typeAnnotation.typeAnnotation.typeName.name=/^MemoizedSelector(WithProps)?$/], :has(CallExpression[callee.name=/^(create(Feature)?Selector|createSelectorFactory)$/]))'({
         id,
       }: TSESTree.VariableDeclarator & { id: TSESTree.Identifier }) {
         const suggestedName = getSuggestedName(id.name);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3786

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

In a version for v16 this rule should also lint `extraSelectors`.
I didn't choose to address that in this PR because it could result in errors for existing applications.
