### PR TITLE
feat(store): use strict projectors for createFeature selectors

### DIFF
--- a/modules/store/spec/types/feature_creator.spec.ts
+++ b/modules/store/spec/types/feature_creator.spec.ts
@@ -71,15 +71,15 @@ describe('createFeature()', () => {
       snippet.toInfer('reducer', 'ActionReducer<State, Action>');
       snippet.toInfer(
         'selectProductsState',
-        'MemoizedSelector<Record<string, any>, State, DefaultProjectorFn<State>>'
+        'MemoizedSelector<Record<string, any>, State, (featureState: State) => State>'
       );
       snippet.toInfer(
         'selectProducts',
-        'MemoizedSelector<Record<string, any>, string[] | null, DefaultProjectorFn<string[] | null>>'
+        'MemoizedSelector<Record<string, any>, string[] | null, (featureState: State) => string[] | null>'
       );
       snippet.toInfer(
         'selectQuery',
-        'MemoizedSelector<Record<string, any>, string, DefaultProjectorFn<string>>'
+        'MemoizedSelector<Record<string, any>, string, (featureState: State) => string>'
       );
       snippet.toInfer(
         'productsFeatureKeys',
@@ -107,11 +107,11 @@ describe('createFeature()', () => {
       snippet.toInfer('reducer', 'ActionReducer<{ count: number; }, Action>');
       snippet.toInfer(
         'selectCounterState',
-        'MemoizedSelector<Record<string, any>, { count: number; }, DefaultProjectorFn<{ count: number; }>>'
+        'MemoizedSelector<Record<string, any>, { count: number; }, (featureState: { count: number; }) => { count: number; }>'
       );
       snippet.toInfer(
         'selectCount',
-        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+        'MemoizedSelector<Record<string, any>, number, (featureState: { count: number; }) => number>'
       );
     });
 
@@ -231,15 +231,15 @@ describe('createFeature()', () => {
       snippet.toInfer('reducer', 'ActionReducer<BooksState, Action>');
       snippet.toInfer(
         'selectBooksState',
-        'MemoizedSelector<AppState, BooksState, DefaultProjectorFn<BooksState>>'
+        'MemoizedSelector<AppState, BooksState, (featureState: BooksState) => BooksState>'
       );
       snippet.toInfer(
         'selectBooks',
-        'MemoizedSelector<AppState, Book[], DefaultProjectorFn<Book[]>>'
+        'MemoizedSelector<AppState, Book[], (featureState: BooksState) => Book[]>'
       );
       snippet.toInfer(
         'selectLoadState',
-        'MemoizedSelector<AppState, LoadState, DefaultProjectorFn<LoadState>>'
+        'MemoizedSelector<AppState, LoadState, (featureState: BooksState) => LoadState>'
       );
       snippet.toInfer(
         'booksFeatureKeys',
@@ -272,11 +272,11 @@ describe('createFeature()', () => {
       snippet.toInfer('reducer', 'ActionReducer<State, Action>');
       snippet.toInfer(
         'selectFooState',
-        'MemoizedSelector<{ foo: State; }, State, DefaultProjectorFn<State>>'
+        'MemoizedSelector<{ foo: State; }, State, (featureState: State) => State>'
       );
       snippet.toInfer(
         'selectBar',
-        'MemoizedSelector<{ foo: State; }, string, DefaultProjectorFn<string>>'
+        'MemoizedSelector<{ foo: State; }, string, (featureState: State) => string>'
       );
     });
 
@@ -446,11 +446,11 @@ describe('createFeature()', () => {
       snippet.toInfer('reducer', 'ActionReducer<State, Action>');
       snippet.toInfer(
         'selectCounterState',
-        'MemoizedSelector<Record<string, any>, State, DefaultProjectorFn<State>>'
+        'MemoizedSelector<Record<string, any>, State, (featureState: State) => State>'
       );
       snippet.toInfer(
         'selectCount',
-        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+        'MemoizedSelector<Record<string, any>, number, (featureState: State) => number>'
       );
       snippet.toInfer(
         'selectCounterState2',
@@ -500,11 +500,11 @@ describe('createFeature()', () => {
       snippet.toInfer('reducer', 'ActionReducer<{ count: number; }, Action>');
       snippet.toInfer(
         'selectCounterState',
-        'MemoizedSelector<Record<string, any>, { count: number; }, DefaultProjectorFn<{ count: number; }>>'
+        'MemoizedSelector<Record<string, any>, { count: number; }, (featureState: { count: number; }) => { count: number; }>'
       );
       snippet.toInfer(
         'selectCount',
-        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+        'MemoizedSelector<Record<string, any>, number, (featureState: { count: number; }) => number>'
       );
       snippet.toInfer(
         'selectSquaredCount',
@@ -551,7 +551,7 @@ describe('createFeature()', () => {
       );
       snippet.toInfer(
         'selectCount2',
-        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+        'MemoizedSelector<Record<string, any>, number, (featureState: { count1: number; count2: number; }) => number>'
       );
       snippet.toInfer(
         'selectCount10',
@@ -598,11 +598,11 @@ describe('createFeature()', () => {
 
       snippet.toInfer(
         'selectCounter1State',
-        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+        'MemoizedSelector<Record<string, any>, number, (featureState: number) => number>'
       );
       snippet.toInfer(
         'selectCounter2State',
-        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+        'MemoizedSelector<Record<string, any>, number, (featureState: number) => number>'
       );
       snippet.toInfer(
         'counterFeature1Keys',
@@ -628,7 +628,7 @@ describe('createFeature()', () => {
 
       snippet.toInfer(
         'selectCounterState',
-        'MemoizedSelector<Record<string, any>, number, DefaultProjectorFn<number>>'
+        'MemoizedSelector<Record<string, any>, number, (featureState: number) => number>'
       );
       snippet.toInfer(
         'counterFeatureKeys',

--- a/modules/store/src/feature_creator_models.ts
+++ b/modules/store/src/feature_creator_models.ts
@@ -13,7 +13,8 @@ export type FeatureSelector<
 > = {
   [K in FeatureName as `select${Capitalize<K>}State`]: MemoizedSelector<
     AppState,
-    FeatureState
+    FeatureState,
+    (featureState: FeatureState) => FeatureState
   >;
 };
 
@@ -26,6 +27,7 @@ export type NestedSelectors<
       [K in keyof FeatureState &
         string as `select${Capitalize<K>}`]: MemoizedSelector<
         AppState,
-        FeatureState[K]
+        FeatureState[K],
+        (featureState: FeatureState) => FeatureState[K]
       >;
     };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3740

## What is the new behavior?

Projector function arguments of selectors generated by createFeature are strongly typed.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

BREAKING CHANGES:

Projectors of selectors generated by createFeature are strongly typed.

BEFORE:

Projector function arguments of selectors generated by createFeature are not strongly typed:

```ts
const counterFeature = createFeature({
  name: 'counter',
  reducer: createReducer({ count: 0 }),
});

counterFeature.selectCount.projector
// type: (...args: any[]) => number
```

AFTER:

Projector function arguments of selectors generated by createFeature are strongly typed:

```ts
const counterFeature = createFeature({
  name: 'counter',
  reducer: createReducer({ count: 0 }),
});

counterFeature.selectCount.projector
// type: (featureState: { count: number; }) => number
```
