### PR TITLE
feat(router-store): remove deprecated getSelectors method

### DIFF
--- a/modules/router-store/src/index.ts
+++ b/modules/router-store/src/index.ts
@@ -44,9 +44,5 @@ export {
   MinimalRouterStateSnapshot,
   MinimalRouterStateSerializer,
 } from './serializers/minimal_serializer';
-export {
-  getRouterSelectors,
-  getSelectors,
-  createRouterSelector,
-} from './router_selectors';
+export { getRouterSelectors, createRouterSelector } from './router_selectors';
 export { provideRouterStore } from './provide_router_store';

--- a/modules/router-store/src/router_selectors.ts
+++ b/modules/router-store/src/router_selectors.ts
@@ -13,12 +13,6 @@ export function createRouterSelector<
   return createFeatureSelector(DEFAULT_ROUTER_FEATURENAME);
 }
 
-/**
- * @deprecated This function is deprecated in favor of `getRouterSelectors`.
- * For more info see: https://github.com/ngrx/platform/issues/3738
- */
-export const getSelectors = getRouterSelectors;
-
 export function getRouterSelectors<V extends Record<string, any>>(
   selectState: (state: V) => RouterReducerState<any> = createRouterSelector<V>()
 ): RouterStateSelectors<V> {


### PR DESCRIPTION
Removes deprecated getSelectors method from router-store

Closes #3813

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: removes deprecated method
```

## What is the current behavior?

Closes #3815

## What is the new behavior?

The deprecated method getSelectors is removed from router-store

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Migration script for the renaming of the method is already in place.