### PR TITLE
docs: use select method instead of state pipe

### DIFF
--- a/projects/ngrx.io/content/guide/component-store/initialization.md
+++ b/projects/ngrx.io/content/guide/component-store/initialization.md
@@ -43,9 +43,7 @@ would be to initialize the state lazily by calling [`setState`](guide/component-
   providers: [ComponentStore],
 })
 export class MoviesPageComponent {
-  readonly movies$ = this.componentStore.state$.pipe(
-    map(state => state.movies),
-  );
+  readonly movies$ = this.componentStore.select(state => state.movies);
 
   constructor(
     private readonly componentStore: ComponentStore&lt;{movies: Movie[]}&gt;


### PR DESCRIPTION
accessing the store directly may confuse users because they might get weird behaviors when using observables like this in the state (like infinite loops), I think we should probably discourage examples that access the store directly without the select method to avoid confusion.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

confusing example (accessing state directly) that may lead to wrong implementation if people don't read full docs

Closes #

## What is the new behavior?

use select method to get the state

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
