### PR TITLE
feat(schematics): replace `any` type with `unknown` type

### DIFF
--- a/modules/schematics/src/action/files/__name@dasherize@if-flat__/__name@dasherize__.actions.ts.template
+++ b/modules/schematics/src/action/files/__name@dasherize@if-flat__/__name@dasherize__.actions.ts.template
@@ -6,10 +6,10 @@ export const <%= prefix %><%= classify(name) %>s = createAction(
 
 <% if (api) { %>export const <%= prefix %><%= classify(name) %>sSuccess = createAction(
   '[<%= classify(name) %>] <%= classify(prefix) %> <%= classify(name) %>s Success',
-  props<{ data: any }>()
+  props<{ data: unknown }>()
 );<% } %>
 
 <% if (api) { %>export const <%= prefix %><%= classify(name) %>sFailure = createAction(
   '[<%= classify(name) %>] <%= classify(prefix) %> <%= classify(name) %>s Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );<% } %>

--- a/modules/schematics/src/action/index.spec.ts
+++ b/modules/schematics/src/action/index.spec.ts
@@ -99,9 +99,9 @@ describe('Action Schematic', () => {
 
     expect(fileContent).toMatch(/export const loadFoos = createAction\(/);
     expect(fileContent).toMatch(/\[Foo\] Load Foos Success/);
-    expect(fileContent).toMatch(/props<{ data: any }>\(\)/);
+    expect(fileContent).toMatch(/props<{ data: unknown }>\(\)/);
     expect(fileContent).toMatch(/\[Foo\] Load Foos Failure/);
-    expect(fileContent).toMatch(/props<{ error: any }>\(\)/);
+    expect(fileContent).toMatch(/props<{ error: unknown }>\(\)/);
   });
 
   it.each(['load', 'delete', 'update'])(

--- a/modules/schematics/src/data/files/__name@dasherize@if-flat__/__name@dasherize__.ts.template
+++ b/modules/schematics/src/data/files/__name@dasherize@if-flat__/__name@dasherize__.ts.template
@@ -1,3 +1,3 @@
 export interface <%= classify(name) %> {
-  id?: any;
+  id?: unknown;
 }

--- a/modules/schematics/src/data/index.spec.ts
+++ b/modules/schematics/src/data/index.spec.ts
@@ -108,7 +108,7 @@ describe('Data Schematic', () => {
     const fileContent = tree.readContent(`${projectPath}/src/app/foo.ts`);
 
     expect(fileContent).toMatch(/export interface Foo {/);
-    expect(fileContent).toMatch(/id\?: any;/);
+    expect(fileContent).toMatch(/id\?: unknown;/);
   });
 
   it('should create spec class with right imports', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGE:

BEFORE:

Schematics used the `any` type to declare some types.

AFTER:

Schematics use the `unknown` type to declare some types.

## Other information
