### PR TITLE
feat(store): preserve the event name case with createActionGroup

### DIFF
--- a/modules/store/spec/action_group_creator.spec.ts
+++ b/modules/store/spec/action_group_creator.spec.ts
@@ -14,16 +14,21 @@ describe('createActionGroup', () => {
     source: 'Books API',
     events: {
       ' Load BOOKS  suCCess  ': emptyProps(),
+      loadBooksFailure: emptyProps(),
     },
   });
 
   it('should create action name by camel casing the event name', () => {
-    expect(booksApiActions.loadBooksSuccess).toBeDefined();
+    expect(booksApiActions.loadBOOKSSuCCess).toBeDefined();
+    expect(booksApiActions.loadBooksFailure).toBeDefined();
   });
 
   it('should create action type using the "[Source] Event" pattern', () => {
-    expect(booksApiActions.loadBooksSuccess().type).toBe(
+    expect(booksApiActions.loadBOOKSSuCCess().type).toBe(
       '[Books API]  Load BOOKS  suCCess  '
+    );
+    expect(booksApiActions.loadBooksFailure().type).toBe(
+      '[Books API] loadBooksFailure'
     );
   });
 

--- a/modules/store/spec/helpers.spec.ts
+++ b/modules/store/spec/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { capitalize } from '../src/helpers';
+import { capitalize, uncapitalize } from '../src/helpers';
 
 describe('helpers', () => {
   describe('capitalize', () => {
@@ -8,6 +8,16 @@ describe('helpers', () => {
 
     it('should return an empty string when the text is an empty string', () => {
       expect(capitalize('')).toEqual('');
+    });
+  });
+
+  describe('uncapitalize', () => {
+    it('should uncapitalize the text', () => {
+      expect(uncapitalize('NGRX')).toEqual('nGRX');
+    });
+
+    it('should return an empty string when the text is an empty string', () => {
+      expect(uncapitalize('')).toEqual('');
     });
   });
 });

--- a/modules/store/spec/types/action_group_creator.spec.ts
+++ b/modules/store/spec/types/action_group_creator.spec.ts
@@ -98,20 +98,31 @@ describe('createActionGroup', () => {
 
     describe('event name', () => {
       it('should create action name by camel casing the event name', () => {
-        expectSnippet(`
+        const snippet = expectSnippet(`
           const booksApiActions = createActionGroup({
             source: 'Books API',
             events: {
               ' Load BOOKS  suCCess  ': emptyProps(),
+              loadBooksFailure: emptyProps(),
             },
           });
 
-          let loadBooksSuccess: typeof booksApiActions.loadBooksSuccess;
-        `).toInfer(
+          let loadBooksSuccess: typeof booksApiActions.loadBOOKSSuCCess;
+          let loadBooksFailure: typeof booksApiActions.loadBooksFailure;
+        `);
+
+        snippet.toInfer(
           'loadBooksSuccess',
           `ActionCreator<
             "[Books API]  Load BOOKS  suCCess  ",
             () => TypedAction<"[Books API]  Load BOOKS  suCCess  ">
+          >`
+        );
+        snippet.toInfer(
+          'loadBooksFailure',
+          `ActionCreator<
+            "[Books API] loadBooksFailure",
+            () => TypedAction<"[Books API] loadBooksFailure">
           >`
         );
       });
@@ -222,7 +233,7 @@ describe('createActionGroup', () => {
           const booksApiActions = createActionGroup({
             source: 'Books API',
             events: {
-              '  Load BOOks  success ': emptyProps(),
+              '  Load Books  success ': emptyProps(),
               'load Books Success': props<{ books: string[] }>(),
             }
           });

--- a/modules/store/src/action_group_creator.ts
+++ b/modules/store/src/action_group_creator.ts
@@ -1,6 +1,6 @@
 import { createAction, props } from './action_creator';
 import { ActionCreatorProps, Creator } from './models';
-import { capitalize } from './helpers';
+import { capitalize, uncapitalize } from './helpers';
 import {
   ActionGroup,
   ActionGroupConfig,
@@ -75,9 +75,8 @@ function toActionName<EventName extends string>(
 ): ActionName<EventName> {
   return eventName
     .trim()
-    .toLowerCase()
     .split(' ')
-    .map((word, i) => (i === 0 ? word : capitalize(word)))
+    .map((word, i) => (i === 0 ? uncapitalize(word) : capitalize(word)))
     .join('') as ActionName<EventName>;
 }
 

--- a/modules/store/src/action_group_creator_models.ts
+++ b/modules/store/src/action_group_creator_models.ts
@@ -95,7 +95,7 @@ type EventCreator<
   : never;
 
 export type ActionName<EventName extends string> = Uncapitalize<
-  Join<TitleCase<Lowercase<Trim<EventName>>>>
+  Join<TitleCase<EventName>>
 >;
 
 export interface ActionGroupConfig<

--- a/modules/store/src/helpers.ts
+++ b/modules/store/src/helpers.ts
@@ -1,3 +1,7 @@
 export function capitalize<T extends string>(text: T): Capitalize<T> {
   return (text.charAt(0).toUpperCase() + text.substring(1)) as Capitalize<T>;
 }
+
+export function uncapitalize<T extends string>(text: T): Uncapitalize<T> {
+  return (text.charAt(0).toLowerCase() + text.substring(1)) as Uncapitalize<T>;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3693

All letters of the event name will be lowercase, except for the initial letters of words starting from the second word, which will be uppercase.

## What is the new behavior?

The initial letter of the first word of the event name will be lowercase, and the initial letters of the other words will be uppercase. The case of other letters in the event name will remain the same.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

BREAKING CHANGES:

The event name case is preserved when converting to the action name by using the `createActionGroup` function.

BEFORE:

All letters of the event name will be lowercase, except for the initial letters of words starting from the second word, which will be uppercase.

```ts
const authApiActions = createActionGroup({
  source: 'Auth API',
  events: {
    'LogIn Success': emptyProps(),
    'login failure': emptyProps(),
    'Logout Success': emptyProps(),
    logoutFailure: emptyProps(),
  },
});

// generated actions:
const {
  loginSuccess,
  loginFailure,
  logoutSuccess,
  logoutfailure,
} = authApiActions;
```

AFTER:

The initial letter of the first word of the event name will be lowercase, and the initial letters of the other words will be uppercase. The case of other letters in the event name will remain the same.

```ts
const {
  logInSuccess,
  loginFailure,
  logoutSuccess,
  logoutFailure,
} = authApiActions;
```
