### PR TITLE
fix(store): correctly infer action group events defined as empty object

### DIFF
--- a/modules/store/spec/types/action_group_creator.spec.ts
+++ b/modules/store/spec/types/action_group_creator.spec.ts
@@ -71,13 +71,28 @@ describe('createActionGroup', () => {
     });
 
     describe('events', () => {
+      it('should infer events dictionary', () => {
+        expectSnippet(`
+          const authApiActions = createActionGroup({
+            source: 'Auth API',
+            events: {
+              'Login Success': props<{ token: string; }>,
+              'Login Failure': (message: string) => ({ message }),
+            },
+          });
+        `).toInfer(
+          'authApiActions',
+          "ActionGroup<\"Auth API\", { 'Login Success': () => ActionCreatorProps<{ token: string; }>; 'Login Failure': (message: string) => { message: string; }; }>"
+        );
+      });
+
       it('should infer events defined as an empty object', () => {
         expectSnippet(`
           const authApiActions = createActionGroup({
             source: 'Auth API',
             events: {},
           });
-      `).toInfer('authApiActions', 'ActionGroup<"Auth API", {}>');
+        `).toInfer('authApiActions', 'ActionGroup<"Auth API", {}>');
       });
     });
 

--- a/modules/store/spec/types/action_group_creator.spec.ts
+++ b/modules/store/spec/types/action_group_creator.spec.ts
@@ -70,6 +70,17 @@ describe('createActionGroup', () => {
       });
     });
 
+    describe('events', () => {
+      it('should infer events defined as an empty object', () => {
+        expectSnippet(`
+          const authApiActions = createActionGroup({
+            source: 'Auth API',
+            events: {},
+          });
+      `).toInfer('authApiActions', 'ActionGroup<"Auth API", {}>');
+      });
+    });
+
     describe('event name', () => {
       it('should create action name by camel casing the event name', () => {
         expectSnippet(`

--- a/modules/store/src/action_group_creator_models.ts
+++ b/modules/store/src/action_group_creator_models.ts
@@ -103,9 +103,11 @@ export interface ActionGroupConfig<
   Events extends Record<string, ActionCreatorProps<unknown> | Creator>
 > {
   source: Source & StringLiteralCheck<Source, 'source'>;
-  events: {
-    [EventName in keyof Events]: Events[EventName] &
-      EmptyStringCheck<EventName & string, 'event name'> &
+  events: Events & {
+    [EventName in keyof Events]: EmptyStringCheck<
+      EventName & string,
+      'event name'
+    > &
       StringLiteralCheck<EventName & string, 'event name'> &
       ForbiddenCharactersCheck<EventName & string, 'event name'> &
       UniqueEventNameCheck<keyof Events & string, EventName & string> &


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The action group type won't be correctly inferred when events are defined as an empty object:

```ts
const fooActions = createActionGroup({
  source: 'Foo',
  events: {},
});

// there is no compilation error
fooActions.x();
fooActions.y();
```

## What is the new behavior?

The action group type will be correctly inferred when events are defined as an empty object, so in the example above, the compilation error will be thrown.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
