### PR TITLE
feat: convert entity and router selectors interfaces to types

### DIFF
--- a/modules/entity/spec/types/entity_selectors.types.spec.ts
+++ b/modules/entity/spec/types/entity_selectors.types.spec.ts
@@ -1,0 +1,31 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('EntitySelectors', () => {
+  const expectSnippet = expecter(
+    (code) => `
+        import { Selector } from '@ngrx/store';
+        import { EntitySelectors } from './modules/entity/src/models';
+
+        ${code}
+      `,
+    compilerOptions()
+  );
+
+  it('is compatible with a dictionary of selectors', () => {
+    expectSnippet(`
+      type SelectorsDictionary = Record<
+        string,
+        | Selector<Record<string, any>, unknown>
+        | ((...args: any[]) => Selector<Record<string, any>, unknown>)
+      >;
+      type ExtendsSelectorsDictionary<T> = T extends SelectorsDictionary
+        ? true
+        : false;
+
+      let result: ExtendsSelectorsDictionary<
+        EntitySelectors<unknown, Record<string, any>>
+      >;
+    `).toInfer('result', 'true');
+  });
+});

--- a/modules/entity/spec/types/utils.ts
+++ b/modules/entity/spec/types/utils.ts
@@ -1,0 +1,11 @@
+export const compilerOptions = () => ({
+  moduleResolution: 'node',
+  target: 'ES2022',
+  baseUrl: '.',
+  experimentalDecorators: true,
+  strict: true,
+  paths: {
+    '@ngrx/entity': ['./modules/entity'],
+    '@ngrx/store': ['./modules/store'],
+  },
+});

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -78,12 +78,12 @@ export interface EntityStateAdapter<T> {
   map<S extends EntityState<T>>(map: EntityMap<T>, state: S): S;
 }
 
-export interface EntitySelectors<T, V> {
+export type EntitySelectors<T, V> = {
   selectIds: (state: V) => string[] | number[];
   selectEntities: (state: V) => Dictionary<T>;
   selectAll: (state: V) => T[];
   selectTotal: (state: V) => number;
-}
+};
 
 export interface EntityAdapter<T> extends EntityStateAdapter<T> {
   selectId: IdSelector<T>;

--- a/modules/entity/src/state_selectors.ts
+++ b/modules/entity/src/state_selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from '@ngrx/store';
-import { EntityState, EntitySelectors, Dictionary } from './models';
+import { EntityState, EntitySelectors } from './models';
 
 export function createSelectorsFactory<T>() {
   function getSelectors(): EntitySelectors<T, EntityState<T>>;

--- a/modules/router-store/spec/types/router_selectors.types.spec.ts
+++ b/modules/router-store/spec/types/router_selectors.types.spec.ts
@@ -1,7 +1,7 @@
 import { expecter } from 'ts-snippet';
 import { compilerOptions } from './utils';
 
-describe('router selectors', () => {
+describe('getRouterSelectors', () => {
   const expectSnippet = expecter(
     (code) => `
       import { getRouterSelectors, RouterReducerState } from '@ngrx/router-store';
@@ -122,5 +122,34 @@ describe('router selectors', () => {
       'selector',
       'MemoizedSelector<State, string, (s1: string) => string>'
     );
+  });
+});
+
+describe('RouterStateSelectors', () => {
+  const expectSnippet = expecter(
+    (code) => `
+      import { Selector } from '@ngrx/store';
+      import { RouterStateSelectors } from './modules/router-store/src/models';
+
+      ${code}
+    `,
+    compilerOptions()
+  );
+
+  it('is compatible with a dictionary of selectors', () => {
+    expectSnippet(`
+      type SelectorsDictionary = Record<
+        string,
+        | Selector<Record<string, any>, unknown>
+        | ((...args: any[]) => Selector<Record<string, any>, unknown>)
+      >;
+      type ExtendsSelectorsDictionary<T> = T extends SelectorsDictionary
+        ? true
+        : false;
+
+      let result: ExtendsSelectorsDictionary<
+        RouterStateSelectors<Record<string, any>>
+      >;
+    `).toInfer('result', 'true');
   });
 });

--- a/modules/router-store/src/models.ts
+++ b/modules/router-store/src/models.ts
@@ -1,7 +1,7 @@
 import { Data, Params } from '@angular/router';
 import { MemoizedSelector } from '@ngrx/store';
 
-export interface RouterStateSelectors<V> {
+export type RouterStateSelectors<V> = {
   selectCurrentRoute: MemoizedSelector<V, any>;
   selectFragment: MemoizedSelector<V, string | undefined>;
   selectQueryParams: MemoizedSelector<V, Params>;
@@ -14,4 +14,4 @@ export interface RouterStateSelectors<V> {
   ) => MemoizedSelector<V, string | undefined>;
   selectUrl: MemoizedSelector<V, string>;
   selectTitle: MemoizedSelector<V, string | undefined>;
-}
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Interfaces `EntitySelectors` and `RouterStateSelectors` are not compatible with `Record<string, Selector>` which is expected as `createSelector.extraSelectors` result. For example, we cannot add entity selectors to a specific feature in the following way:

```ts
export const productsFeature = createFeature({
  name: 'products',
  reducer: createReducer(initialState),
  extraSelectors: ({ selectProductsState }) =>
    adapter.getSelectors(selectProductsState) // compilation error
  ),
});
```

Workaround:

```ts
  extraSelectors: ({ selectProductsState }) => ({
    ...adapter.getSelectors(selectProductsState),
  }),
```

## What is the new behavior?

Types `EntitySelectors` and `RouterStateSelectors` are compatible with `Record<string, Selector>` and there is no compilation error in the example above.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
