### PR TITLE
fix(store-devtools): correctly import state when feature is set to true

### DIFF
--- a/modules/store-devtools/spec/config.spec.ts
+++ b/modules/store-devtools/spec/config.spec.ts
@@ -109,4 +109,30 @@ describe('StoreDevtoolsOptions', () => {
       },
     });
   });
+
+  it('import "true" is updated to "custom"', () => {
+    // setting import to true results in an error while importing a persisted state into the devtools
+    // the imported state only contains the new state without the actions (and config)
+    // while testing this, the imported state also wasn't correct and contained the initial state values
+    const config = createConfig({
+      features: {
+        import: true,
+      },
+    });
+    expect(config).toEqual({
+      maxAge: false,
+      monitor: noMonitor,
+      actionSanitizer: undefined,
+      stateSanitizer: undefined,
+      name: DEFAULT_NAME,
+      serialize: false,
+      logOnly: false,
+      autoPause: false,
+      features: {
+        import: 'custom',
+      },
+      trace: false,
+      traceLimit: 75,
+    });
+  });
 });

--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -172,7 +172,15 @@ export function createConfig(
   const logOnly = options.logOnly
     ? { pause: true, export: true, test: true }
     : false;
-  const features = options.features || logOnly || DEFAULT_OPTIONS.features;
+  const features: NonNullable<Partial<StoreDevtoolsConfig['features']>> =
+    options.features ||
+    logOnly ||
+    (DEFAULT_OPTIONS.features as NonNullable<
+      Partial<StoreDevtoolsConfig['features']>
+    >);
+  if (features.import === true) {
+    features.import = 'custom';
+  }
   const config = Object.assign({}, DEFAULT_OPTIONS, { features }, options);
 
   if (config.maxAge && config.maxAge < 2) {

--- a/projects/example-app/src/app/app.module.ts
+++ b/projects/example-app/src/app/app.module.ts
@@ -62,7 +62,6 @@ import { AppComponent } from '@example-app/core/containers';
      */
     StoreDevtoolsModule.instrument({
       name: 'NgRx Book Store App',
-
       // In a production build you would want to disable the Store Devtools
       // logOnly: !isDevMode(),
     }),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3636

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

While testing this in a react app the behavior was identical.
Setting the `import` feature to `true` resulted in the same error.