### PR TITLE
fix(data): make non-optimistic add command entity partial

### DIFF
--- a/modules/data/src/dispatchers/entity-commands.ts
+++ b/modules/data/src/dispatchers/entity-commands.ts
@@ -11,6 +11,10 @@ export interface EntityServerCommands<T> {
    * @returns A terminating Observable of the entity
    * after server reports successful save or the save error.
    */
+  add(
+    entity: Partial<T>,
+    options: EntityActionOptions & { isOptimistic: false }
+  ): Observable<T>;
   add(entity: T, options?: EntityActionOptions): Observable<T>;
 
   /**
@@ -101,10 +105,10 @@ export interface EntityServerCommands<T> {
    * after server reports successful query or the query error.
    * @see getWithQuery
    */
-  loadWithQuery(queryParams: QueryParams | string,
-                options?: EntityActionOptions
+  loadWithQuery(
+    queryParams: QueryParams | string,
+    options?: EntityActionOptions
   ): Observable<T[]>;
-
 
   /**
    * Dispatch action to save the updated entity (or partial entity) in remote storage.


### PR DESCRIPTION
Mirror the type definition of EntityCollectionServiceBase.add on EntityServerCommands.add.

Closes EntityServerCommands.add does not allow optional id #3847

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`EntityServerCommands.add()` allows only full entities.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3847

## What is the new behavior?
`EntityServerCommands.add()` allows partial entities if non-optimistic, just like `EntityCollectionServiceBase.add()`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
