### PR TITLE
fix(store): move Angular Signal interop into State service

### DIFF
--- a/modules/data/spec/selectors/entity-selectors$.spec.ts
+++ b/modules/data/spec/selectors/entity-selectors$.spec.ts
@@ -1,4 +1,5 @@
-import { Action, MemoizedSelector, Store } from '@ngrx/store';
+import { Signal, signal } from '@angular/core';
+import { Action, MemoizedSelector, StateObservable, Store } from '@ngrx/store';
 
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import {
@@ -75,7 +76,7 @@ describe('EntitySelectors$', () => {
       actions$ = new Subject<Action>();
       state$ = new BehaviorSubject({ entityCache: emptyCache });
       store = new Store<{ entityCache: EntityCache }>(
-        state$,
+        state$ as unknown as StateObservable,
         null as any,
         null as any
       );

--- a/modules/data/spec/selectors/entity-selectors$.spec.ts
+++ b/modules/data/spec/selectors/entity-selectors$.spec.ts
@@ -1,4 +1,3 @@
-import { Signal, signal } from '@angular/core';
 import { Action, MemoizedSelector, StateObservable, Store } from '@ngrx/store';
 
 import { BehaviorSubject, Observable, Subject } from 'rxjs';

--- a/modules/store/spec/store_pipes.spec.ts
+++ b/modules/store/spec/store_pipes.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import { Store, provideStore } from '@ngrx/store';
+import { Component, inject, Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'test', standalone: true })
+export class TestPipe implements PipeTransform {
+  store = inject(Store);
+
+  transform(s: number) {
+    this.store.select('count');
+    return s * 2;
+  }
+}
+
+@Component({
+  selector: 'test-component',
+  standalone: true,
+  imports: [TestPipe],
+  template: `{{ 3 | test }}`,
+})
+export class TestComponent {}
+
+describe('NgRx Store Integration', () => {
+  describe('with pipes', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+        providers: [
+          provideStore({ count: () => 2 }, { initialState: { count: 2 } }),
+        ],
+      });
+    });
+
+    it('should not throw an error', () => {
+      const component = TestBed.createComponent(TestComponent);
+
+      component.detectChanges();
+
+      expect(component.nativeElement.textContent).toBe('6');
+    });
+  });
+});

--- a/modules/store/src/state.ts
+++ b/modules/store/src/state.ts
@@ -15,7 +15,10 @@ import { ScannedActionsSubject } from './scanned_actions_subject';
 import { INITIAL_STATE } from './tokens';
 
 export abstract class StateObservable extends Observable<any> {
-  state!: Signal<any>;
+  /**
+   * @internal
+   */
+  abstract readonly state: Signal<any>;
 }
 
 @Injectable()
@@ -24,6 +27,9 @@ export class State<T> extends BehaviorSubject<any> implements OnDestroy {
 
   private stateSubscription: Subscription;
 
+  /**
+   * @internal
+   */
   public state: Signal<T>;
 
   constructor(
@@ -56,7 +62,7 @@ export class State<T> extends BehaviorSubject<any> implements OnDestroy {
       scannedActions.next(action as Action);
     });
 
-    this.state = toSignal(this, { manualCleanup: true });
+    this.state = toSignal(this, { manualCleanup: true, requireSync: true });
   }
 
   ngOnDestroy() {

--- a/modules/store/src/state.ts
+++ b/modules/store/src/state.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, OnDestroy, Provider } from '@angular/core';
+import { Inject, Injectable, OnDestroy, Provider, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import {
   BehaviorSubject,
   Observable,
@@ -13,13 +14,17 @@ import { ReducerObservable } from './reducer_manager';
 import { ScannedActionsSubject } from './scanned_actions_subject';
 import { INITIAL_STATE } from './tokens';
 
-export abstract class StateObservable extends Observable<any> {}
+export abstract class StateObservable extends Observable<any> {
+  state!: Signal<any>;
+}
 
 @Injectable()
 export class State<T> extends BehaviorSubject<any> implements OnDestroy {
   static readonly INIT = INIT;
 
   private stateSubscription: Subscription;
+
+  public state: Signal<T>;
 
   constructor(
     actions$: ActionsSubject,
@@ -50,6 +55,8 @@ export class State<T> extends BehaviorSubject<any> implements OnDestroy {
       this.next(state);
       scannedActions.next(action as Action);
     });
+
+    this.state = toSignal(this, { manualCleanup: true });
   }
 
   ngOnDestroy() {

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -2,7 +2,6 @@
 import { computed, Injectable, Provider, Signal } from '@angular/core';
 import { Observable, Observer, Operator } from 'rxjs';
 import { distinctUntilChanged, map, pluck } from 'rxjs/operators';
-import { toSignal } from '@angular/core/rxjs-interop';
 
 import { ActionsSubject } from './actions_subject';
 import {
@@ -19,17 +18,17 @@ export class Store<T = object>
   extends Observable<T>
   implements Observer<Action>
 {
-  private readonly state: Signal<T>;
+  state: Signal<T>;
 
   constructor(
-    state$: StateObservable,
+    readonly state$: StateObservable,
     private actionsObserver: ActionsSubject,
     private reducerManager: ReducerManager
   ) {
     super();
 
     this.source = state$;
-    this.state = toSignal(state$, { manualCleanup: true });
+    this.state = state$.state;
   }
 
   select<K>(mapFn: (state: T) => K): Observable<K>;

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -18,7 +18,10 @@ export class Store<T = object>
   extends Observable<T>
   implements Observer<Action>
 {
-  state: Signal<T>;
+  /**
+   * @internal
+   */
+  readonly state: Signal<T>;
 
   constructor(
     readonly state$: StateObservable,

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -24,7 +24,7 @@ export class Store<T = object>
   readonly state: Signal<T>;
 
   constructor(
-    readonly state$: StateObservable,
+    state$: StateObservable,
     private actionsObserver: ActionsSubject,
     private reducerManager: ReducerManager
   ) {

--- a/modules/store/testing/src/mock_state.ts
+++ b/modules/store/testing/src/mock_state.ts
@@ -3,6 +3,9 @@ import { BehaviorSubject } from 'rxjs';
 
 @Injectable()
 export class MockState<T> extends BehaviorSubject<T> {
+  /**
+   * @internal
+   */
   state!: Signal<T | undefined>;
 
   constructor() {

--- a/modules/store/testing/src/mock_state.ts
+++ b/modules/store/testing/src/mock_state.ts
@@ -1,4 +1,5 @@
 import { Injectable, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { BehaviorSubject } from 'rxjs';
 
 @Injectable()
@@ -6,9 +7,11 @@ export class MockState<T> extends BehaviorSubject<T> {
   /**
    * @internal
    */
-  state!: Signal<T | undefined>;
+  readonly state: Signal<T>;
 
   constructor() {
     super(<T>{});
+
+    this.state = toSignal(this, { manualCleanup: true, requireSync: true });
   }
 }

--- a/modules/store/testing/src/mock_state.ts
+++ b/modules/store/testing/src/mock_state.ts
@@ -1,8 +1,10 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Signal } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 @Injectable()
 export class MockState<T> extends BehaviorSubject<T> {
+  state!: Signal<T | undefined>;
+
   constructor() {
     super(<T>{});
   }

--- a/modules/store/testing/src/mock_store.ts
+++ b/modules/store/testing/src/mock_store.ts
@@ -32,7 +32,7 @@ export class MockStore<T = object> extends Store<T> {
   private lastState?: T;
 
   constructor(
-    override state$: MockState<T>,
+    private state$: MockState<T>,
     actionsObserver: ActionsSubject,
     reducerManager: ReducerManager,
     @Inject(INITIAL_STATE) private initialState: T,

--- a/modules/store/testing/src/mock_store.ts
+++ b/modules/store/testing/src/mock_store.ts
@@ -32,7 +32,7 @@ export class MockStore<T = object> extends Store<T> {
   private lastState?: T;
 
   constructor(
-    private state$: MockState<T>,
+    override state$: MockState<T>,
     actionsObserver: ActionsSubject,
     reducerManager: ReducerManager,
     @Inject(INITIAL_STATE) private initialState: T,

--- a/projects/standalone-app/src/app/app.component.spec.ts
+++ b/projects/standalone-app/src/app/app.component.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { RouterTestingModule } from '@angular/router/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, AppComponent],
+      providers: [provideMockStore()],
     }).compileComponents();
   });
 

--- a/projects/standalone-app/src/app/app.component.ts
+++ b/projects/standalone-app/src/app/app.component.ts
@@ -5,15 +5,18 @@ import {
   INITIAL_STATE_TOKEN,
   provideComponentStore,
 } from '@ngrx/component-store';
+import { TestPipe } from './test.pipe';
 
 @Component({
   selector: 'ngrx-root',
   standalone: true,
-  imports: [RouterModule],
+  imports: [RouterModule, TestPipe],
   template: `
     <h1>Welcome {{ title }} {{ val() }}</h1>
 
     <a routerLink="/feature">Load Feature</a>
+
+    {{ 3 | test }}
 
     <router-outlet></router-outlet>
   `,

--- a/projects/standalone-app/src/app/test.pipe.ts
+++ b/projects/standalone-app/src/app/test.pipe.ts
@@ -1,0 +1,11 @@
+import { inject, Pipe, PipeTransform } from '@angular/core';
+import { Store } from '@ngrx/store';
+
+@Pipe({ name: 'test', standalone: true })
+export class TestPipe implements PipeTransform {
+  store = inject(Store);
+  transform(s: number) {
+    this.store.select('count');
+    return s * 2;
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Store.select throws an error about writing to a signal from a computed when used in a pipe. This happens when the `Store.lift` method is called when the observable flows through operators, creating a new instance of the Store. Moving the signal to the `State` service only creates only subscribes to the StateObservable once for the signal integration.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3869 

## What is the new behavior?

Store.select works correctly when used inside a pipe.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
