### PR TITLE
feat: add ng add support for standalone config to NgRx packages

### DIFF
--- a/build/config.ts
+++ b/build/config.ts
@@ -20,7 +20,11 @@ export const packages: PackageDescription[] = fs
       return false;
     }
 
-    const hasBuild = fs.existsSync(`${modulesDir}${path}/BUILD`);
+    if (path.includes('eslint-plugin')) {
+      return false;
+    }
+
+    const hasBuild = fs.existsSync(`${modulesDir}${path}/tsconfig.build.json`);
 
     return hasBuild;
   })

--- a/modules/component-store/schematics-core/jest.config.ts
+++ b/modules/component-store/schematics-core/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'Schematics Core',
+  preset: '../../jest.preset.js',
+  coverageDirectory: '../../coverage/modules/schematics-core',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/modules/component-store/schematics-core/tsconfig.spec.json
+++ b/modules/component-store/schematics-core/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/modules/component-store/schematics-core/utility/project.ts
+++ b/modules/component-store/schematics-core/utility/project.ts
@@ -1,9 +1,13 @@
+import { TargetDefinition } from '@angular-devkit/core/src/workspace';
 import { getWorkspace } from './config';
-import { Tree } from '@angular-devkit/schematics';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
 
 export interface WorkspaceProject {
   root: string;
   projectType: string;
+  architect: {
+    [key: string]: TargetDefinition;
+  };
 }
 
 export function getProject(
@@ -51,4 +55,21 @@ export function isLib(
   const project = getProject(host, options);
 
   return project.projectType === 'library';
+}
+
+export function getProjectMainFile(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined }
+) {
+  if (isLib(host, options)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const project = getProject(host, options);
+  const projectOptions = project.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
 }

--- a/modules/component/schematics-core/jest.config.ts
+++ b/modules/component/schematics-core/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'Schematics Core',
+  preset: '../../jest.preset.js',
+  coverageDirectory: '../../coverage/modules/schematics-core',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/modules/component/schematics-core/tsconfig.spec.json
+++ b/modules/component/schematics-core/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/modules/component/schematics-core/utility/project.ts
+++ b/modules/component/schematics-core/utility/project.ts
@@ -1,9 +1,13 @@
+import { TargetDefinition } from '@angular-devkit/core/src/workspace';
 import { getWorkspace } from './config';
-import { Tree } from '@angular-devkit/schematics';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
 
 export interface WorkspaceProject {
   root: string;
   projectType: string;
+  architect: {
+    [key: string]: TargetDefinition;
+  };
 }
 
 export function getProject(
@@ -51,4 +55,21 @@ export function isLib(
   const project = getProject(host, options);
 
   return project.projectType === 'library';
+}
+
+export function getProjectMainFile(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined }
+) {
+  if (isLib(host, options)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const project = getProject(host, options);
+  const projectOptions = project.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
 }

--- a/modules/data/schematics-core/jest.config.ts
+++ b/modules/data/schematics-core/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'Schematics Core',
+  preset: '../../jest.preset.js',
+  coverageDirectory: '../../coverage/modules/schematics-core',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/modules/data/schematics-core/tsconfig.spec.json
+++ b/modules/data/schematics-core/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/modules/data/schematics-core/utility/project.ts
+++ b/modules/data/schematics-core/utility/project.ts
@@ -1,9 +1,13 @@
+import { TargetDefinition } from '@angular-devkit/core/src/workspace';
 import { getWorkspace } from './config';
-import { Tree } from '@angular-devkit/schematics';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
 
 export interface WorkspaceProject {
   root: string;
   projectType: string;
+  architect: {
+    [key: string]: TargetDefinition;
+  };
 }
 
 export function getProject(
@@ -51,4 +55,21 @@ export function isLib(
   const project = getProject(host, options);
 
   return project.projectType === 'library';
+}
+
+export function getProjectMainFile(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined }
+) {
+  if (isLib(host, options)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const project = getProject(host, options);
+  const projectOptions = project.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
 }

--- a/modules/effects/schematics-core/jest.config.ts
+++ b/modules/effects/schematics-core/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'Schematics Core',
+  preset: '../../jest.preset.js',
+  coverageDirectory: '../../coverage/modules/schematics-core',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/modules/effects/schematics-core/tsconfig.spec.json
+++ b/modules/effects/schematics-core/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/modules/effects/schematics-core/utility/project.ts
+++ b/modules/effects/schematics-core/utility/project.ts
@@ -1,9 +1,13 @@
+import { TargetDefinition } from '@angular-devkit/core/src/workspace';
 import { getWorkspace } from './config';
-import { Tree } from '@angular-devkit/schematics';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
 
 export interface WorkspaceProject {
   root: string;
   projectType: string;
+  architect: {
+    [key: string]: TargetDefinition;
+  };
 }
 
 export function getProject(
@@ -51,4 +55,21 @@ export function isLib(
   const project = getProject(host, options);
 
   return project.projectType === 'library';
+}
+
+export function getProjectMainFile(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined }
+) {
+  if (isLib(host, options)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const project = getProject(host, options);
+  const projectOptions = project.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
 }

--- a/modules/effects/schematics/ng-add/__snapshots__/index.spec.ts.snap
+++ b/modules/effects/schematics/ng-add/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Effects ng-add Schematic Effects ng-add Schematic for standalone application provides full effects setup 1`] = `
+"import { ApplicationConfig } from '@angular/core';
+import { provideEffects } from '@ngrx/effects';
+import { FooEffects } from './foo/foo.effects';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideEffects(FooEffects)]
+};
+"
+`;
+
+exports[`Effects ng-add Schematic Effects ng-add Schematic for standalone application provides minimal effects setup 1`] = `
+"import { ApplicationConfig } from '@angular/core';
+import { provideEffects } from '@ngrx/effects';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideEffects()]
+};
+"
+`;

--- a/modules/effects/schematics/ng-add/index.spec.ts
+++ b/modules/effects/schematics/ng-add/index.spec.ts
@@ -222,4 +222,49 @@ describe('Effects ng-add Schematic', () => {
 
     expect(content).toMatch(/effects = TestBed\.inject\(FooEffects\);/);
   });
+
+  describe('Effects ng-add Schematic for standalone application', () => {
+    const projectPath = getTestProjectPath(undefined, {
+      name: 'bar-standalone',
+    });
+
+    const standaloneDefaultOptions = {
+      ...defaultOptions,
+      project: 'bar-standalone',
+      standalone: true,
+    };
+
+    it('provides minimal effects setup', async () => {
+      const options = { ...standaloneDefaultOptions, minimal: true };
+      const tree = await schematicRunner.runSchematic(
+        'ng-add',
+        options,
+        appTree
+      );
+
+      const content = tree.readContent(`${projectPath}/src/app/app.config.ts`);
+
+      expect(content).toMatchSnapshot();
+    });
+
+    it('provides full effects setup', async () => {
+      const options = { ...standaloneDefaultOptions };
+      const tree = await schematicRunner.runSchematic(
+        'ng-add',
+        options,
+        appTree
+      );
+
+      const content = tree.readContent(`${projectPath}/src/app/app.config.ts`);
+      const files = tree.files;
+
+      expect(content).toMatchSnapshot();
+      expect(
+        files.indexOf(`${projectPath}/src/app/foo/foo.effects.spec.ts`)
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        files.indexOf(`${projectPath}/src/app/foo/foo.effects.ts`)
+      ).toBeGreaterThanOrEqual(0);
+    });
+  });
 });

--- a/modules/effects/schematics/ng-add/schema.json
+++ b/modules/effects/schematics/ng-add/schema.json
@@ -55,6 +55,11 @@
       "type": "boolean",
       "default": true,
       "description": "Setup root effects module without registering initial effects."
+    },
+    "standalone": {
+      "type": "boolean",
+      "default": false,
+      "description": "Configure @ngrx/effects for standalone application"
     }
   },
   "required": []

--- a/modules/effects/schematics/ng-add/schema.ts
+++ b/modules/effects/schematics/ng-add/schema.ts
@@ -11,4 +11,5 @@ export interface Schema {
    * Setup root effects module without registering initial effects.
    */
   minimal?: boolean;
+  standalone?: boolean;
 }

--- a/modules/entity/schematics-core/jest.config.ts
+++ b/modules/entity/schematics-core/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'Schematics Core',
+  preset: '../../jest.preset.js',
+  coverageDirectory: '../../coverage/modules/schematics-core',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/modules/entity/schematics-core/tsconfig.spec.json
+++ b/modules/entity/schematics-core/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/modules/entity/schematics-core/utility/project.ts
+++ b/modules/entity/schematics-core/utility/project.ts
@@ -1,9 +1,13 @@
+import { TargetDefinition } from '@angular-devkit/core/src/workspace';
 import { getWorkspace } from './config';
-import { Tree } from '@angular-devkit/schematics';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
 
 export interface WorkspaceProject {
   root: string;
   projectType: string;
+  architect: {
+    [key: string]: TargetDefinition;
+  };
 }
 
 export function getProject(
@@ -51,4 +55,21 @@ export function isLib(
   const project = getProject(host, options);
 
   return project.projectType === 'library';
+}
+
+export function getProjectMainFile(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined }
+) {
+  if (isLib(host, options)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const project = getProject(host, options);
+  const projectOptions = project.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
 }

--- a/modules/router-store/schematics-core/jest.config.ts
+++ b/modules/router-store/schematics-core/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'Schematics Core',
+  preset: '../../jest.preset.js',
+  coverageDirectory: '../../coverage/modules/schematics-core',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/modules/router-store/schematics-core/tsconfig.spec.json
+++ b/modules/router-store/schematics-core/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/modules/router-store/schematics-core/utility/project.ts
+++ b/modules/router-store/schematics-core/utility/project.ts
@@ -1,9 +1,13 @@
+import { TargetDefinition } from '@angular-devkit/core/src/workspace';
 import { getWorkspace } from './config';
-import { Tree } from '@angular-devkit/schematics';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
 
 export interface WorkspaceProject {
   root: string;
   projectType: string;
+  architect: {
+    [key: string]: TargetDefinition;
+  };
 }
 
 export function getProject(
@@ -51,4 +55,21 @@ export function isLib(
   const project = getProject(host, options);
 
   return project.projectType === 'library';
+}
+
+export function getProjectMainFile(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined }
+) {
+  if (isLib(host, options)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const project = getProject(host, options);
+  const projectOptions = project.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
 }

--- a/modules/router-store/schematics/ng-add/__snapshots__/index.spec.ts.snap
+++ b/modules/router-store/schematics/ng-add/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Router Store ng-add Schematic Router Store ng-add Schematic for standalone application provides initial setup 1`] = `
+"import { ApplicationConfig } from '@angular/core';
+import { provideRouterStore } from '@ngrx/router-store';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouterStore()]
+};
+"
+`;

--- a/modules/router-store/schematics/ng-add/index.spec.ts
+++ b/modules/router-store/schematics/ng-add/index.spec.ts
@@ -76,4 +76,29 @@ describe('Router Store ng-add Schematic', () => {
     }
     expect(thrownError).toBeDefined();
   });
+
+  describe('Router Store ng-add Schematic for standalone application', () => {
+    const projectPath = getTestProjectPath(undefined, {
+      name: 'bar-standalone',
+    });
+
+    const standaloneDefaultOptions = {
+      ...defaultOptions,
+      project: 'bar-standalone',
+      standalone: true,
+    };
+
+    it('provides initial setup', async () => {
+      const options = { ...standaloneDefaultOptions };
+      const tree = await schematicRunner.runSchematic(
+        'ng-add',
+        options,
+        appTree
+      );
+
+      const content = tree.readContent(`${projectPath}/src/app/app.config.ts`);
+
+      expect(content).toMatchSnapshot();
+    });
+  });
 });

--- a/modules/router-store/schematics/ng-add/schema.json
+++ b/modules/router-store/schematics/ng-add/schema.json
@@ -29,6 +29,11 @@
       "description": "Allows specification of the declaring module.",
       "alias": "m",
       "subtype": "filepath"
+    },
+    "standalone": {
+      "type": "boolean",
+      "default": false,
+      "description": "Configure @ngrx/router-store for standalone application"
     }
   },
   "required": []

--- a/modules/router-store/schematics/ng-add/schema.ts
+++ b/modules/router-store/schematics/ng-add/schema.ts
@@ -3,4 +3,5 @@ export interface Schema {
   path?: string;
   project?: string;
   module?: string;
+  standalone?: string;
 }

--- a/modules/schematics-core/utility/project.ts
+++ b/modules/schematics-core/utility/project.ts
@@ -1,9 +1,13 @@
+import { TargetDefinition } from '@angular-devkit/core/src/workspace';
 import { getWorkspace } from './config';
-import { Tree } from '@angular-devkit/schematics';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
 
 export interface WorkspaceProject {
   root: string;
   projectType: string;
+  architect: {
+    [key: string]: TargetDefinition;
+  };
 }
 
 export function getProject(
@@ -51,4 +55,21 @@ export function isLib(
   const project = getProject(host, options);
 
   return project.projectType === 'library';
+}
+
+export function getProjectMainFile(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined }
+) {
+  if (isLib(host, options)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const project = getProject(host, options);
+  const projectOptions = project.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
 }

--- a/modules/schematics/schematics-core/jest.config.ts
+++ b/modules/schematics/schematics-core/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'Schematics Core',
+  preset: '../../jest.preset.js',
+  coverageDirectory: '../../coverage/modules/schematics-core',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/modules/schematics/schematics-core/tsconfig.spec.json
+++ b/modules/schematics/schematics-core/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/modules/schematics/schematics-core/utility/project.ts
+++ b/modules/schematics/schematics-core/utility/project.ts
@@ -1,9 +1,13 @@
+import { TargetDefinition } from '@angular-devkit/core/src/workspace';
 import { getWorkspace } from './config';
-import { Tree } from '@angular-devkit/schematics';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
 
 export interface WorkspaceProject {
   root: string;
   projectType: string;
+  architect: {
+    [key: string]: TargetDefinition;
+  };
 }
 
 export function getProject(
@@ -51,4 +55,21 @@ export function isLib(
   const project = getProject(host, options);
 
   return project.projectType === 'library';
+}
+
+export function getProjectMainFile(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined }
+) {
+  if (isLib(host, options)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const project = getProject(host, options);
+  const projectOptions = project.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
 }

--- a/modules/store-devtools/schematics-core/jest.config.ts
+++ b/modules/store-devtools/schematics-core/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'Schematics Core',
+  preset: '../../jest.preset.js',
+  coverageDirectory: '../../coverage/modules/schematics-core',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/modules/store-devtools/schematics-core/tsconfig.spec.json
+++ b/modules/store-devtools/schematics-core/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/modules/store-devtools/schematics-core/utility/project.ts
+++ b/modules/store-devtools/schematics-core/utility/project.ts
@@ -1,9 +1,13 @@
+import { TargetDefinition } from '@angular-devkit/core/src/workspace';
 import { getWorkspace } from './config';
-import { Tree } from '@angular-devkit/schematics';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
 
 export interface WorkspaceProject {
   root: string;
   projectType: string;
+  architect: {
+    [key: string]: TargetDefinition;
+  };
 }
 
 export function getProject(
@@ -51,4 +55,21 @@ export function isLib(
   const project = getProject(host, options);
 
   return project.projectType === 'library';
+}
+
+export function getProjectMainFile(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined }
+) {
+  if (isLib(host, options)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const project = getProject(host, options);
+  const projectOptions = project.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
 }

--- a/modules/store-devtools/schematics/ng-add/__snapshots__/index.spec.ts.snap
+++ b/modules/store-devtools/schematics/ng-add/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Store-Devtools ng-add Schematic Store Devtools ng-add Schematic for standalone application provides initial setup 1`] = `
+"import { ApplicationConfig, isDevMode } from '@angular/core';
+import { provideStoreDevtools } from '@ngrx/store-devtools';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideStoreDevtools({ maxAge: 25, logOnly: !isDevMode() })]
+};
+"
+`;

--- a/modules/store-devtools/schematics/ng-add/index.spec.ts
+++ b/modules/store-devtools/schematics/ng-add/index.spec.ts
@@ -125,4 +125,29 @@ describe('Store-Devtools ng-add Schematic', () => {
     const content = tree.readContent(`${projectPath}/src/app/app.module.ts`);
     expect(content).toMatch(/maxAge: 5/);
   });
+
+  describe('Store Devtools ng-add Schematic for standalone application', () => {
+    const projectPath = getTestProjectPath(undefined, {
+      name: 'bar-standalone',
+    });
+
+    const standaloneDefaultOptions = {
+      ...defaultOptions,
+      project: 'bar-standalone',
+      standalone: true,
+    };
+
+    it('provides initial setup', async () => {
+      const options = { ...standaloneDefaultOptions };
+      const tree = await schematicRunner.runSchematic(
+        'ng-add',
+        options,
+        appTree
+      );
+
+      const content = tree.readContent(`${projectPath}/src/app/app.config.ts`);
+
+      expect(content).toMatchSnapshot();
+    });
+  });
 });

--- a/modules/store-devtools/schematics/ng-add/schema.json
+++ b/modules/store-devtools/schematics/ng-add/schema.json
@@ -39,6 +39,11 @@
       "type": "boolean",
       "default": false,
       "description": "boolean - pauses recording actions and state changes when the extension window is not open."
+    },
+    "standalone": {
+      "type": "boolean",
+      "default": false,
+      "description": "Configure @ngrx/store-devtools for standalone application"
     }
   },
   "required": []

--- a/modules/store-devtools/schematics/ng-add/schema.ts
+++ b/modules/store-devtools/schematics/ng-add/schema.ts
@@ -5,4 +5,5 @@ export interface Schema {
   module?: string;
   maxAge?: number;
   autoPause?: boolean;
+  standalone?: boolean;
 }

--- a/modules/store/schematics-core/jest.config.ts
+++ b/modules/store/schematics-core/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'Schematics Core',
+  preset: '../../jest.preset.js',
+  coverageDirectory: '../../coverage/modules/schematics-core',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/modules/store/schematics-core/tsconfig.spec.json
+++ b/modules/store/schematics-core/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/projects/ngrx.io/content/guide/effects/install.md
+++ b/projects/ngrx.io/content/guide/effects/install.md
@@ -19,12 +19,14 @@ ng add @ngrx/effects@latest
 | `--module` | Name of file containing the module that you wish to add the import for the `EffectsModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts` | `string` | `app`
 | `--minimal` | When true, only provide minimal setup for the root effects setup. Only registers `EffectsModule.forRoot()` in the provided `module` with an empty array. | `boolean` | `true`
 | `--group` | Group effects file within `effects` folder. | `boolean` | `false`
+| `--standalone` | Flag to configure `@ngrx/effects` in the standalone application config. | `boolean` |`false` |
 
 This command will automate the following steps:
 
 1. Update `package.json` > `dependencies` with `@ngrx/effects`.
 2. Run `npm install` to install those dependencies. 
 3. Update your `src/app/app.module.ts` > `imports` array with `EffectsModule.forRoot([AppEffects])`. If you provided flags then the command will attempt to locate and update module found by the flags.
+4. If the flag `--standalone` is provided, it adds `provideEffects()` into the application config.
 
 ## Installing with `npm`
 

--- a/projects/ngrx.io/content/guide/router-store/install.md
+++ b/projects/ngrx.io/content/guide/router-store/install.md
@@ -15,12 +15,14 @@ ng add @ngrx/router-store@latest
 | `--path` | Path to the module that you wish to add the import for the `StoreRouterConnectingModule` to. | `string` |
 | `--project` | Name of the project defined in your `angular.json` to help locating the module to add the `StoreRouterConnectingModule` to. | `string`
 | `--module` | Name of file containing the module that you wish to add the import for the `StoreRouterConnectingModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`. | `string` | `app`
+| `--standalone` | Flag to configure `@ngrx/router-store` in the standalone application config. | `boolean` |`false` |
 
 This command will automate the following steps:
 
 1. Update `package.json` > `dependencies` with `@ngrx/router-store`.
 2. Run `npm install` to install those dependencies. 
 3. By default, will update  `src/app/app.module.ts` > `imports` array with `StoreRouterConnectingModule.forRoot()`. If you provided flags then the command will attempt to locate and update module found by the flags.
+4. If the flag `--standalone` is provided, it adds `provideRouterStore()` into the application config.
 
 ## Installing with `npm`
 

--- a/projects/ngrx.io/content/guide/store-devtools/install.md
+++ b/projects/ngrx.io/content/guide/store-devtools/install.md
@@ -16,13 +16,14 @@ ng add @ngrx/store-devtools@latest
 | `--project` | Name of the project defined in your `angular.json` to help locating the module to add the `StoreDevtoolsModule` to. | `string` | 
 | `--module` | Name of file containing the module that you wish to add the import for the `StoreDevtoolsModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`. | `string` | `app`
 | `--maxAge` | Maximum allowed actions to be stored in the history tree. The oldest actions are removed once maxAge is reached. It's critical for performance. 0 is infinite. Must be greater than 1 or 0. | `number` | `25`
+| `--standalone` | Flag to configure `@ngrx/store-devtools` in the standalone application config. | `boolean` |`false` |
 
 This command will automate the following steps:
 
 1. Update `package.json` > `dependencies` with `@ngrx/store-devtools`.
 2. Run `npm install` to install those dependencies. 
 3. Update your `src/app.module.ts` > `imports` array with `StoreDevtoolsModule.instrument({ maxAge: 25, logOnly: !isDevMode() })`. The maxAge property will be set to the flag `maxAge` if provided. 
-
+4. If the flag `--standalone` is provided, it adds `provideStoreDevtools({ maxAge: 25, logOnly: !isDevMode() })` into the application config.
 
 ## Installing with `npm`
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Fixed bug with syncing `schematics-core` across packages.

Adds `ng add` support for NgRx packages

```sh
ng add @ngrx/effects --standalone
ng add @ngrx/store-devtools --standalone
ng add @ngrx/router-store --standalone
```


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
