### PR TITLE
fix(store): add Signal equal function for immutable object comparison

### DIFF
--- a/modules/store/spec/integration_signals.spec.ts
+++ b/modules/store/spec/integration_signals.spec.ts
@@ -12,6 +12,7 @@ import {
   VisibilityFilters,
   resetId,
 } from './fixtures/todos';
+import { computed } from '@angular/core';
 
 interface Todo {
   id: number;
@@ -128,6 +129,32 @@ describe('NgRx and Signals Integration spec', () => {
       }
 
       expect(error).toBeUndefined();
+    });
+  });
+
+  describe('immutable state integration spec', () => {
+    it('Store.selectSignal should not trigger on unrelated global state changes', () => {
+      let todosTriggerCount = 0;
+
+      const todos = TestBed.runInInjectionContext(() =>
+        store.selectSignal((state) => state.todos)
+      );
+
+      const todosTriggerState = TestBed.runInInjectionContext(() =>
+        computed(() => {
+          todos();
+          return ++todosTriggerCount;
+        })
+      );
+
+      store.dispatch({ type: ADD_TODO, payload: { text: 'first todo' } });
+      expect(todosTriggerState()).toBe(1);
+
+      store.dispatch({
+        type: SET_VISIBILITY_FILTER,
+        payload: VisibilityFilters.SHOW_ACTIVE,
+      });
+      expect(todosTriggerState()).toBe(1);
     });
   });
 });

--- a/modules/store/spec/integration_signals.spec.ts
+++ b/modules/store/spec/integration_signals.spec.ts
@@ -136,16 +136,12 @@ describe('NgRx and Signals Integration spec', () => {
     it('Store.selectSignal should not trigger on unrelated global state changes', () => {
       let todosTriggerCount = 0;
 
-      const todos = TestBed.runInInjectionContext(() =>
-        store.selectSignal((state) => state.todos)
-      );
+      const todos = store.selectSignal((state) => state.todos);
 
-      const todosTriggerState = TestBed.runInInjectionContext(() =>
-        computed(() => {
-          todos();
-          return ++todosTriggerCount;
-        })
-      );
+      const todosTriggerState = computed(() => {
+        todos();
+        return ++todosTriggerCount;
+      });
 
       store.dispatch({ type: ADD_TODO, payload: { text: 'first todo' } });
       expect(todosTriggerState()).toBe(1);

--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -112,7 +112,9 @@ export class Store<T = object>
     selector: (state: T) => K,
     options?: SelectSignalOptions<K>
   ): Signal<K> {
-    return computed(() => selector(this.state()), { equal: options?.equal });
+    return computed(() => selector(this.state()), {
+      equal: options?.equal || ((previous, current) => previous === current),
+    });
   }
 
   override lift<R>(operator: Operator<T, R>): Store<R> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

All selectors created with `store.selectSignal()` fire on every global state change, even if the related state received no update.

Closes #3882 

## What is the new behavior?

If `selector(this.state())` returns the same object reference the computed Signal does not trigger a value update anymore.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
