### PR TITLE
refactor: detect standalone application when using ng add

### DIFF
--- a/modules/component-store/schematics-core/utility/standalone.ts
+++ b/modules/component-store/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/component/schematics-core/utility/standalone.ts
+++ b/modules/component/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/data/schematics-core/utility/standalone.ts
+++ b/modules/data/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/effects/schematics-core/utility/standalone.ts
+++ b/modules/effects/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/effects/schematics/ng-add/index.spec.ts
+++ b/modules/effects/schematics/ng-add/index.spec.ts
@@ -231,7 +231,6 @@ describe('Effects ng-add Schematic', () => {
     const standaloneDefaultOptions = {
       ...defaultOptions,
       project: 'bar-standalone',
-      standalone: true,
     };
 
     it('provides minimal effects setup', async () => {

--- a/modules/effects/schematics/ng-add/index.ts
+++ b/modules/effects/schematics/ng-add/index.ts
@@ -33,6 +33,7 @@ import {
   callsProvidersFunction,
 } from '@schematics/angular/private/standalone';
 import { getProjectMainFile } from '../../schematics-core/utility/project';
+import { isStandaloneApp } from '../../schematics-core/utility/standalone';
 
 function addImportToNgModule(options: EffectOptions): Rule {
   return (host: Tree) => {
@@ -199,9 +200,12 @@ function addStandaloneConfig(options: EffectOptions): Rule {
 
 export default function (options: EffectOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
+    const mainFile = getProjectMainFile(host, options);
+    const isStandalone = isStandaloneApp(host, mainFile);
+
     options.path = getProjectPath(host, options);
 
-    if (options.module && !options.standalone) {
+    if (options.module && !isStandalone) {
       options.module = findModuleFromOptions(host, options);
     }
 
@@ -226,7 +230,7 @@ export default function (options: EffectOptions): Rule {
       move(parsedPath.path),
     ]);
 
-    const configOrModuleUpdate = options.standalone
+    const configOrModuleUpdate = isStandalone
       ? addStandaloneConfig(options)
       : addImportToNgModule(options);
 

--- a/modules/effects/schematics/ng-add/schema.json
+++ b/modules/effects/schematics/ng-add/schema.json
@@ -55,11 +55,6 @@
       "type": "boolean",
       "default": true,
       "description": "Setup root effects module without registering initial effects."
-    },
-    "standalone": {
-      "type": "boolean",
-      "default": false,
-      "description": "Configure @ngrx/effects for standalone application"
     }
   },
   "required": []

--- a/modules/effects/schematics/ng-add/schema.ts
+++ b/modules/effects/schematics/ng-add/schema.ts
@@ -11,5 +11,4 @@ export interface Schema {
    * Setup root effects module without registering initial effects.
    */
   minimal?: boolean;
-  standalone?: boolean;
 }

--- a/modules/entity/schematics-core/utility/standalone.ts
+++ b/modules/entity/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/router-store/schematics-core/utility/standalone.ts
+++ b/modules/router-store/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/router-store/schematics/ng-add/index.spec.ts
+++ b/modules/router-store/schematics/ng-add/index.spec.ts
@@ -85,7 +85,6 @@ describe('Router Store ng-add Schematic', () => {
     const standaloneDefaultOptions = {
       ...defaultOptions,
       project: 'bar-standalone',
-      standalone: true,
     };
 
     it('provides initial setup', async () => {

--- a/modules/router-store/schematics/ng-add/index.ts
+++ b/modules/router-store/schematics/ng-add/index.ts
@@ -25,6 +25,7 @@ import {
   callsProvidersFunction,
 } from '@schematics/angular/private/standalone';
 import { getProjectMainFile } from '../../schematics-core/utility/project';
+import { isStandaloneApp } from '../../schematics-core/utility/standalone';
 
 function addImportToNgModule(options: RouterStoreOptions): Rule {
   return (host: Tree) => {
@@ -130,9 +131,12 @@ function addStandaloneConfig(options: RouterStoreOptions): Rule {
 
 export default function (options: RouterStoreOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
+    const mainFile = getProjectMainFile(host, options);
+    const isStandalone = isStandaloneApp(host, mainFile);
+
     options.path = getProjectPath(host, options);
 
-    if (options.module && !options.standalone) {
+    if (options.module && !isStandalone) {
       options.module = findModuleFromOptions(host, {
         name: '',
         module: options.module,
@@ -143,7 +147,7 @@ export default function (options: RouterStoreOptions): Rule {
     const parsedPath = parseName(options.path, '');
     options.path = parsedPath.path;
 
-    const configOrModuleUpdate = options.standalone
+    const configOrModuleUpdate = isStandalone
       ? addStandaloneConfig(options)
       : addImportToNgModule(options);
 

--- a/modules/router-store/schematics/ng-add/schema.json
+++ b/modules/router-store/schematics/ng-add/schema.json
@@ -29,11 +29,6 @@
       "description": "Allows specification of the declaring module.",
       "alias": "m",
       "subtype": "filepath"
-    },
-    "standalone": {
-      "type": "boolean",
-      "default": false,
-      "description": "Configure @ngrx/router-store for standalone application"
     }
   },
   "required": []

--- a/modules/router-store/schematics/ng-add/schema.ts
+++ b/modules/router-store/schematics/ng-add/schema.ts
@@ -3,5 +3,4 @@ export interface Schema {
   path?: string;
   project?: string;
   module?: string;
-  standalone?: string;
 }

--- a/modules/schematics-core/utility/standalone.ts
+++ b/modules/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/schematics/schematics-core/utility/standalone.ts
+++ b/modules/schematics/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/store-devtools/schematics-core/utility/standalone.ts
+++ b/modules/store-devtools/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/store-devtools/schematics/ng-add/index.spec.ts
+++ b/modules/store-devtools/schematics/ng-add/index.spec.ts
@@ -134,7 +134,6 @@ describe('Store-Devtools ng-add Schematic', () => {
     const standaloneDefaultOptions = {
       ...defaultOptions,
       project: 'bar-standalone',
-      standalone: true,
     };
 
     it('provides initial setup', async () => {

--- a/modules/store-devtools/schematics/ng-add/index.ts
+++ b/modules/store-devtools/schematics/ng-add/index.ts
@@ -25,6 +25,7 @@ import {
   callsProvidersFunction,
 } from '@schematics/angular/private/standalone';
 import { getProjectMainFile } from '../../schematics-core/utility/project';
+import { isStandaloneApp } from '../../schematics-core/utility/standalone';
 
 function addImportToNgModule(options: StoreDevtoolsOptions): Rule {
   return (host: Tree) => {
@@ -154,9 +155,12 @@ function addStandaloneConfig(options: StoreDevtoolsOptions): Rule {
 
 export default function (options: StoreDevtoolsOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
+    const mainFile = getProjectMainFile(host, options);
+    const isStandalone = isStandaloneApp(host, mainFile);
+
     options.path = getProjectPath(host, options);
 
-    if (options.module && !options.standalone) {
+    if (options.module && !isStandalone) {
       options.module = findModuleFromOptions(host, {
         name: '',
         module: options.module,
@@ -173,7 +177,7 @@ export default function (options: StoreDevtoolsOptions): Rule {
       );
     }
 
-    const configOrModuleUpdate = options.standalone
+    const configOrModuleUpdate = isStandalone
       ? addStandaloneConfig(options)
       : addImportToNgModule(options);
 

--- a/modules/store-devtools/schematics/ng-add/schema.json
+++ b/modules/store-devtools/schematics/ng-add/schema.json
@@ -39,11 +39,6 @@
       "type": "boolean",
       "default": false,
       "description": "boolean - pauses recording actions and state changes when the extension window is not open."
-    },
-    "standalone": {
-      "type": "boolean",
-      "default": false,
-      "description": "Configure @ngrx/store-devtools for standalone application"
     }
   },
   "required": []

--- a/modules/store-devtools/schematics/ng-add/schema.ts
+++ b/modules/store-devtools/schematics/ng-add/schema.ts
@@ -5,5 +5,4 @@ export interface Schema {
   module?: string;
   maxAge?: number;
   autoPause?: boolean;
-  standalone?: boolean;
 }

--- a/modules/store/schematics-core/utility/standalone.ts
+++ b/modules/store/schematics-core/utility/standalone.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/modules/store/schematics/ng-add/index.spec.ts
+++ b/modules/store/schematics/ng-add/index.spec.ts
@@ -169,7 +169,6 @@ describe('Store ng-add Schematic', () => {
     const standaloneDefaultOptions = {
       ...defaultOptions,
       project: 'bar-standalone',
-      standalone: true,
     };
 
     it('provides minimal store setup', async () => {

--- a/modules/store/schematics/ng-add/index.ts
+++ b/modules/store/schematics/ng-add/index.ts
@@ -36,6 +36,7 @@ import {
   callsProvidersFunction,
 } from '@schematics/angular/private/standalone';
 import { getProjectMainFile } from '../../schematics-core/utility/project';
+import { isStandaloneApp } from '../../schematics-core/utility/standalone';
 
 function addImportToNgModule(options: RootStoreOptions): Rule {
   return (host: Tree) => {
@@ -212,12 +213,15 @@ function addStandaloneConfig(options: RootStoreOptions): Rule {
 
 export default function (options: RootStoreOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
+    const mainFile = getProjectMainFile(host, options);
+    const isStandalone = isStandaloneApp(host, mainFile);
+
     options.path = getProjectPath(host, options);
 
     const parsedPath = parseName(options.path, '');
     options.path = parsedPath.path;
 
-    if (options.module && !options.standalone) {
+    if (options.module && !isStandalone) {
       options.module = findModuleFromOptions(host, {
         name: '',
         module: options.module,
@@ -238,7 +242,7 @@ export default function (options: RootStoreOptions): Rule {
       move(parsedPath.path),
     ]);
 
-    const configOrModuleUpdate = options.standalone
+    const configOrModuleUpdate = isStandalone
       ? addStandaloneConfig(options)
       : addImportToNgModule(options);
 

--- a/modules/store/schematics/ng-add/schema.json
+++ b/modules/store/schematics/ng-add/schema.json
@@ -49,11 +49,6 @@
       "type": "boolean",
       "default": false,
       "description": "Do not register the NgRx ESLint Plugin."
-    },
-    "standalone": {
-      "type": "boolean",
-      "default": false,
-      "description": "Configure store for standalone application"
     }
   },
   "required": []

--- a/modules/store/schematics/ng-add/schema.ts
+++ b/modules/store/schematics/ng-add/schema.ts
@@ -10,5 +10,4 @@ export interface Schema {
    */
   minimal?: boolean;
   skipESLintPlugin?: boolean;
-  standalone?: boolean;
 }

--- a/projects/ngrx.io/content/guide/effects/install.md
+++ b/projects/ngrx.io/content/guide/effects/install.md
@@ -19,14 +19,13 @@ ng add @ngrx/effects@latest
 | `--module` | Name of file containing the module that you wish to add the import for the `EffectsModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts` | `string` | `app`
 | `--minimal` | When true, only provide minimal setup for the root effects setup. Only registers `EffectsModule.forRoot()` in the provided `module` with an empty array. | `boolean` | `true`
 | `--group` | Group effects file within `effects` folder. | `boolean` | `false`
-| `--standalone` | Flag to configure `@ngrx/effects` in the standalone application config. | `boolean` |`false` |
 
 This command will automate the following steps:
 
 1. Update `package.json` > `dependencies` with `@ngrx/effects`.
 2. Run `npm install` to install those dependencies. 
 3. Update your `src/app/app.module.ts` > `imports` array with `EffectsModule.forRoot([AppEffects])`. If you provided flags then the command will attempt to locate and update module found by the flags.
-4. If the flag `--standalone` is provided, it adds `provideEffects()` into the application config.
+4. If the project is using a `standalone bootstrap`, it adds `provideEffects()` into the application config.
 
 ## Installing with `npm`
 

--- a/projects/ngrx.io/content/guide/router-store/install.md
+++ b/projects/ngrx.io/content/guide/router-store/install.md
@@ -15,14 +15,13 @@ ng add @ngrx/router-store@latest
 | `--path` | Path to the module that you wish to add the import for the `StoreRouterConnectingModule` to. | `string` |
 | `--project` | Name of the project defined in your `angular.json` to help locating the module to add the `StoreRouterConnectingModule` to. | `string`
 | `--module` | Name of file containing the module that you wish to add the import for the `StoreRouterConnectingModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`. | `string` | `app`
-| `--standalone` | Flag to configure `@ngrx/router-store` in the standalone application config. | `boolean` |`false` |
 
 This command will automate the following steps:
 
 1. Update `package.json` > `dependencies` with `@ngrx/router-store`.
 2. Run `npm install` to install those dependencies. 
 3. By default, will update  `src/app/app.module.ts` > `imports` array with `StoreRouterConnectingModule.forRoot()`. If you provided flags then the command will attempt to locate and update module found by the flags.
-4. If the flag `--standalone` is provided, it adds `provideRouterStore()` into the application config.
+4. If the project is using a `standalone bootstrap`, it adds `provideRouterStore()` into the application config.
 
 ## Installing with `npm`
 

--- a/projects/ngrx.io/content/guide/store-devtools/install.md
+++ b/projects/ngrx.io/content/guide/store-devtools/install.md
@@ -16,14 +16,13 @@ ng add @ngrx/store-devtools@latest
 | `--project` | Name of the project defined in your `angular.json` to help locating the module to add the `StoreDevtoolsModule` to. | `string` | 
 | `--module` | Name of file containing the module that you wish to add the import for the `StoreDevtoolsModule` to. Can also include the relative path to the file. For example, `src/app/app.module.ts`. | `string` | `app`
 | `--maxAge` | Maximum allowed actions to be stored in the history tree. The oldest actions are removed once maxAge is reached. It's critical for performance. 0 is infinite. Must be greater than 1 or 0. | `number` | `25`
-| `--standalone` | Flag to configure `@ngrx/store-devtools` in the standalone application config. | `boolean` |`false` |
 
 This command will automate the following steps:
 
 1. Update `package.json` > `dependencies` with `@ngrx/store-devtools`.
 2. Run `npm install` to install those dependencies. 
 3. Update your `src/app.module.ts` > `imports` array with `StoreDevtoolsModule.instrument({ maxAge: 25, logOnly: !isDevMode() })`. The maxAge property will be set to the flag `maxAge` if provided. 
-4. If the flag `--standalone` is provided, it adds `provideStoreDevtools({ maxAge: 25, logOnly: !isDevMode() })` into the application config.
+4. If the project is using a `standalone bootstrap`, it adds `provideStoreDevtools({ maxAge: 25, logOnly: !isDevMode() })` into the application config.
 
 ## Installing with `npm`
 

--- a/projects/ngrx.io/content/guide/store/install.md
+++ b/projects/ngrx.io/content/guide/store/install.md
@@ -17,14 +17,13 @@ ng add @ngrx/store@latest
 | `--minimal` | Flag to only provide minimal setup for the root state management. Only registers `StoreModule.forRoot()` in the provided `module` with an empty object, and default runtime checks. | `boolean` |`true`
 | `--statePath` | The file path to create the state in. | `string` | `reducers` |
 | `--stateInterface` | The type literal of the defined interface for the state. | `string` | `State` |
-| `--standalone` | Flag to configure store for standalone application. | `boolean` |`false` |
 
 This command will automate the following steps:
 
 1. Update `package.json` > `dependencies` with `@ngrx/store`.
 2. Run `npm install` to install those dependencies.
 3. Update your `src/app/app.module.ts` > `imports` array with `StoreModule.forRoot({})`
-4. If the flag `--standalone` is provided, it adds `provideStore()` into the application config.
+4. If the project is using a `standalone bootstrap`, it adds `provideStore()` into the application config.
 
 ```sh
 ng add @ngrx/store@latest --no-minimal


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When running ng add commands

```sh
ng add @ngrx/store
ng add @ngrx/effects
ng add @ngrx/store-devtools
ng add @ngrx/router-store
```

The schematic detects where the application is using `bootstrapApplication` and applies the appropriate provider functions to the application config. Module-based setups remain the same.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Reference code: https://github.com/angular/angular-cli/blob/c109fb6a1630983d9f775e29a9ca7293bf465b94/packages/schematics/angular/utility/ng-ast-utils.ts#L83-L93