### PR TITLE
fix(store-devtools): add state signal to StateObservable

### DIFF
--- a/modules/store-devtools/spec/store.spec.ts
+++ b/modules/store-devtools/spec/store.spec.ts
@@ -885,4 +885,17 @@ describe('Store Devtools', () => {
       expect(oldComputedStates).not.toBe(liftedState.computedStates);
     });
   });
+
+  describe('StateObservable', () => {
+    it('should contain state signal that is updated on state changes', () => {
+      const { state, store } = createStore(counter);
+      expect(state.state()).toEqual({ state: 0 });
+
+      store.dispatch({ type: 'INCREMENT' });
+      expect(store.state()).toEqual({ state: 1 });
+
+      store.dispatch({ type: 'DECREMENT' });
+      expect(store.state()).toEqual({ state: 0 });
+    });
+  });
 });

--- a/modules/store-devtools/src/devtools.ts
+++ b/modules/store-devtools/src/devtools.ts
@@ -1,4 +1,5 @@
 import { Injectable, Inject, ErrorHandler } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import {
   Action,
   ActionReducer,
@@ -6,6 +7,7 @@ import {
   INITIAL_STATE,
   ReducerObservable,
   ScannedActionsSubject,
+  StateObservable,
 } from '@ngrx/store';
 import {
   merge,
@@ -36,7 +38,7 @@ export class StoreDevtools implements Observer<any> {
   private extensionStartSubscription: Subscription;
   public dispatcher: ActionsSubject;
   public liftedState: Observable<LiftedState>;
-  public state: Observable<any>;
+  public state: StateObservable;
 
   constructor(
     dispatcher: DevtoolsDispatcher,
@@ -114,7 +116,10 @@ export class StoreDevtools implements Observer<any> {
 
     const liftedState$ =
       liftedStateSubject.asObservable() as Observable<LiftedState>;
-    const state$ = liftedState$.pipe(map(unliftState));
+    const state$ = liftedState$.pipe(map(unliftState)) as StateObservable;
+    Object.defineProperty(state$, 'state', {
+      value: toSignal(state$, { manualCleanup: true, requireSync: true }),
+    });
 
     this.extensionStartSubscription = extensionStartSubscription;
     this.stateSubscription = liftedStateSubscription;

--- a/modules/store-devtools/src/instrument.ts
+++ b/modules/store-devtools/src/instrument.ts
@@ -1,12 +1,12 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { Observable } from 'rxjs';
+import { StateObservable } from '@ngrx/store';
 import { StoreDevtoolsOptions } from './config';
 import { StoreDevtools } from './devtools';
 import { provideStoreDevtools } from './provide-store-devtools';
 
 export function createStateObservable(
   devtools: StoreDevtools
-): Observable<any> {
+): StateObservable {
   return devtools.state;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`Store.selectSignal` method is not working when `store-devtools` package is used because it replaces `StateObservable` with a custom one that doesn't contain the `state` signal.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
