### PR TITLE
fix(ngrx.io): preserve sidenav width for larger menu items

### DIFF
--- a/projects/ngrx.io/src/styles/1-layouts/_sidenav.scss
+++ b/projects/ngrx.io/src/styles/1-layouts/_sidenav.scss
@@ -8,6 +8,7 @@
 aio-nav-menu {
   display: block;
   margin: 0 auto;
+  max-width: 268px;
   @include typescale-small;
   ul, a {
     padding: 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Sidenav width is increased after adding the "Entity Adapter with Feature Creator" item:

![before](https://github.com/ngrx/platform/assets/17877290/d569d6c5-7658-411f-96a9-88e66da86316)

## What is the new behavior?

![after](https://github.com/ngrx/platform/assets/17877290/90c73efd-f599-45cb-88db-692a2ff0cc15)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
