### PR TITLE
feat(component-store): added custom equal option in select

### DIFF
--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -40,8 +40,9 @@ import {
 import { isOnStateInitDefined, isOnStoreInitDefined } from './lifecycle_hooks';
 import { toSignal } from '@angular/core/rxjs-interop';
 
-export interface SelectConfig {
+export interface SelectConfig<T = unknown> {
   debounce?: boolean;
+  equal?: ValueEqualityFn<T>;
 }
 
 export const INITIAL_STATE_TOKEN = new InjectionToken(
@@ -248,11 +249,13 @@ export class ComponentStore<T extends object> implements OnDestroy {
    */
   select<Result>(
     projector: (s: T) => Result,
-    config?: SelectConfig
+    config?: SelectConfig<Result>
   ): Observable<Result>;
   select<SelectorsObject extends Record<string, Observable<unknown>>>(
     selectorsObject: SelectorsObject,
-    config?: SelectConfig
+    config?: SelectConfig<{
+      [K in keyof SelectorsObject]: ObservedValueOf<SelectorsObject[K]>;
+    }>
   ): Observable<{
     [K in keyof SelectorsObject]: ObservedValueOf<SelectorsObject[K]>;
   }>;
@@ -266,12 +269,12 @@ export class ComponentStore<T extends object> implements OnDestroy {
     ...selectorsWithProjectorAndConfig: [
       ...selectors: Selectors,
       projector: Projector<Selectors, Result>,
-      config: SelectConfig
+      config: SelectConfig<Result>
     ]
   ): Observable<Result>;
   select<
     Selectors extends Array<
-      Observable<unknown> | SelectConfig | ProjectorFn | SelectorsObject
+      Observable<unknown> | SelectConfig<Result> | ProjectorFn | SelectorsObject
     >,
     Result,
     ProjectorFn extends (...a: unknown[]) => Result,
@@ -297,7 +300,7 @@ export class ComponentStore<T extends object> implements OnDestroy {
               : projector(projectorArgs)
           )
         : noopOperator()) as () => Observable<Result>,
-      distinctUntilChanged(),
+      distinctUntilChanged(config.equal),
       shareReplay({
         refCount: true,
         bufferSize: 1,
@@ -456,7 +459,7 @@ export class ComponentStore<T extends object> implements OnDestroy {
 
 function processSelectorArgs<
   Selectors extends Array<
-    Observable<unknown> | SelectConfig | ProjectorFn | SelectorsObject
+    Observable<unknown> | SelectConfig<Result> | ProjectorFn | SelectorsObject
   >,
   Result,
   ProjectorFn extends (...a: unknown[]) => Result,
@@ -467,16 +470,22 @@ function processSelectorArgs<
   | {
       observablesOrSelectorsObject: Observable<unknown>[];
       projector: ProjectorFn;
-      config: Required<SelectConfig>;
+      config: Required<SelectConfig<Result>>;
     }
   | {
       observablesOrSelectorsObject: SelectorsObject;
       projector: undefined;
-      config: Required<SelectConfig>;
+      config: Required<SelectConfig<Result>>;
     } {
   const selectorArgs = Array.from(args);
+  const defaultEqualityFn: ValueEqualityFn<Result> = (previous, current) =>
+    previous === current;
+
   // Assign default values.
-  let config: Required<SelectConfig> = { debounce: false };
+  let config: Required<SelectConfig<Result>> = {
+    debounce: false,
+    equal: defaultEqualityFn,
+  };
 
   // Last argument is either config or projector or selectorsObject
   if (isSelectConfig(selectorArgs[selectorArgs.length - 1])) {
@@ -504,8 +513,14 @@ function processSelectorArgs<
   };
 }
 
-function isSelectConfig(arg: SelectConfig | unknown): arg is SelectConfig {
-  return typeof (arg as SelectConfig).debounce !== 'undefined';
+function isSelectConfig(
+  arg: SelectConfig<unknown> | unknown
+): arg is SelectConfig<unknown> {
+  const typedArg = arg as SelectConfig<unknown>;
+  return (
+    typeof typedArg.debounce !== 'undefined' ||
+    typeof typedArg.equal !== 'undefined'
+  );
 }
 
 function hasProjectFnOnly(

--- a/projects/ngrx.io/content/guide/component-store/read.md
+++ b/projects/ngrx.io/content/guide/component-store/read.md
@@ -137,6 +137,28 @@ export class MoviesStore extends ComponentStore&lt;MoviesState&gt; {
 }
 </code-example>
 
+## Using a custom equality function
+
+The observable created by the `select` method compares the newly emitted value with the previous one using the default equality check (`===`) and emits only if the value has changed. However, the default behavior can be overridden by passing a custom equality function to the `select` method config.
+
+<code-example header="movies.store.ts">
+export interface MoviesState {
+  movies: Movie[];
+}
+
+@Injectable()
+export class MoviesStore extends ComponentStore&lt;MoviesState&gt; {
+  
+  constructor() {
+    super({movies:[]});
+  }
+
+  readonly movies$: Observable&lt;Movie[]&gt; = this.select(
+    state => state.movies,
+    {equal: (prev, curr) => prev.length === curr.length} // 👈 custom equality function
+  );
+}
+</code-example>
 
 ## Selecting from global `@ngrx/store`
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`select` uses `distinctUntilChanged` but there was no way to provide a custom equality fn.

Closes #3931

## What is the new behavior?
Added `equal` option to provide a custom equality function for `distinctUntilChanged` in `select` method.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
