### PR TITLE
fix(eslint): fix inject function based injection not detecting store (#3834)

### DIFF
--- a/modules/eslint-plugin/spec/rules/no-store-subscription.spec.ts
+++ b/modules/eslint-plugin/spec/rules/no-store-subscription.spec.ts
@@ -48,19 +48,9 @@ class Ok3 {
   constructor(private store: Store) {}
 }`,
   `
-class Ok4 {
-  readonly items$: Observable<readonly Item[]>
-  readonly metrics$: Observable<Metric>
-
-  constructor(store: Store) {
-    this.items$ = store.pipe(select(selectItems))
-    this.metrics$ = store.select(selectMetrics)
-  }
-}`,
-  `
 import { Store } from '@ngrx/store'
 
-class Ok5 {
+class Ok4 {
   readonly items$: Observable<readonly Item[]>
   readonly metrics$: Observable<Metric>
 
@@ -73,7 +63,7 @@ class Ok5 {
 import { Store } from '@ngrx/store'
 import { inject } from '@angular/core'
 
-class Ok6 {
+class Ok5 {
   readonly items$: Observable<readonly Item[]>
   readonly metrics$: Observable<Metric>
   readonly store = inject(Store)
@@ -87,7 +77,7 @@ class Ok6 {
 import { Store } from '@ngrx/store'
 import { inject } from 'some-other-package'
 
-class Ok7 {
+class Ok6 {
   readonly items$: Observable<readonly Item[]>
   readonly metrics$: Observable<Metric>
   readonly store = inject(Store)

--- a/modules/eslint-plugin/spec/rules/no-store-subscription.spec.ts
+++ b/modules/eslint-plugin/spec/rules/no-store-subscription.spec.ts
@@ -49,6 +49,18 @@ class Ok3 {
 }`,
   `
 import { Store } from '@ngrx/store'
+
+class Ok4 {
+  readonly items$: Observable<readonly Item[]>
+  readonly metrics$: Observable<Metric>
+
+  constructor(store: Store) {
+    this.items$ = store.pipe(select(selectItems))
+    this.metrics$ = store.select(selectMetrics)
+  }
+}`,
+  `
+import { Store } from '@ngrx/store'
 import { inject } from '@angular/core'
 
 class Ok5 {
@@ -151,7 +163,7 @@ class NotOk6 {
   fromFixture(`
 import { Store } from '@ngrx/store'
 
-class NotOk6 {
+class NotOk7 {
   readonly items: readonly Item[]
 
   constructor(store: Store) {
@@ -162,7 +174,7 @@ class NotOk6 {
   fromFixture(`
 import { Store } from '@ngrx/store'
 
-class NotOk7 {
+class NotOk8 {
   readonly control = new FormControl()
 
   constructor(store: Store) {
@@ -176,7 +188,7 @@ class NotOk7 {
 import { Store } from '@ngrx/store'
 import { inject } from '@angular/core'
 
-class NotOk8 {
+class NotOk9 {
   readonly control = new FormControl()
   store = inject(Store)
 
@@ -191,7 +203,7 @@ class NotOk8 {
 import { Store } from '@ngrx/store'
 import { inject } from '@angular/core'
 
-class NotOk9 {
+class NotOk10 {
   readonly items$: Observable<readonly Item[]>
   readonly metrics$: Observable<Metric>
   readonly store = inject(Store)

--- a/modules/eslint-plugin/spec/rules/no-store-subscription.spec.ts
+++ b/modules/eslint-plugin/spec/rules/no-store-subscription.spec.ts
@@ -60,7 +60,7 @@ class Ok4 {
   `
 import { Store } from '@ngrx/store'
 
-class Ok4 {
+class Ok5 {
   readonly items$: Observable<readonly Item[]>
   readonly metrics$: Observable<Metric>
 
@@ -73,7 +73,7 @@ class Ok4 {
 import { Store } from '@ngrx/store'
 import { inject } from '@angular/core'
 
-class Ok5 {
+class Ok6 {
   readonly items$: Observable<readonly Item[]>
   readonly metrics$: Observable<Metric>
   readonly store = inject(Store)
@@ -87,7 +87,7 @@ class Ok5 {
 import { Store } from '@ngrx/store'
 import { inject } from 'some-other-package'
 
-class Ok6 {
+class Ok7 {
   readonly items$: Observable<readonly Item[]>
   readonly metrics$: Observable<Metric>
   readonly store = inject(Store)

--- a/modules/eslint-plugin/spec/rules/no-store-subscription.spec.ts
+++ b/modules/eslint-plugin/spec/rules/no-store-subscription.spec.ts
@@ -49,14 +49,29 @@ class Ok3 {
 }`,
   `
 import { Store } from '@ngrx/store'
+import { inject } from '@angular/core'
 
-class Ok4 {
+class Ok5 {
   readonly items$: Observable<readonly Item[]>
   readonly metrics$: Observable<Metric>
+  readonly store = inject(Store)
 
-  constructor(store: Store) {
+  constructor() {
     this.items$ = store.pipe(select(selectItems))
     this.metrics$ = store.select(selectMetrics)
+  }
+}`,
+  `
+import { Store } from '@ngrx/store'
+import { inject } from 'some-other-package'
+
+class Ok6 {
+  readonly items$: Observable<readonly Item[]>
+  readonly metrics$: Observable<Metric>
+  readonly store = inject(Store)
+
+  constructor() {
+    store.pipe(select(selectItems)).subscribe()
   }
 }`,
 ];
@@ -155,6 +170,35 @@ class NotOk7 {
       store.pipe(select(selectItems)).subscribe()
                                       ~~~~~~~~~ [${messageId}]
     })
+  }
+}`),
+  fromFixture(`
+import { Store } from '@ngrx/store'
+import { inject } from '@angular/core'
+
+class NotOk8 {
+  readonly control = new FormControl()
+  store = inject(Store)
+
+  constructor() {
+    this.control.valueChanges.subscribe(() => {
+      store.pipe(select(selectItems)).subscribe()
+                                      ~~~~~~~~~ [${messageId}]
+    })
+  }
+}`),
+  fromFixture(`
+import { Store } from '@ngrx/store'
+import { inject } from '@angular/core'
+
+class NotOk9 {
+  readonly items$: Observable<readonly Item[]>
+  readonly metrics$: Observable<Metric>
+  readonly store = inject(Store)
+
+  constructor() {
+    store.pipe(select(selectItems)).subscribe()
+                                    ~~~~~~~~~ [${messageId}] 
   }
 }`),
 ];


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the eslint plugin does not detect the store, if it is injected via the new ``inject`` method

Closes #3834

## What is the new behavior?

Updated store detection logic to also check for stores injected via ``inject`` method from the ``@angular/core`` package

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I only updated a single spec file for now, so check if the implementation approach is okay. I'll add more test files later.
Also maybe other rules are affected as well, since for example ``Actions`` could also be injected using ``inject``
