### PR TITLE
feat(component-store): resubscribe on errors

### DIFF
--- a/modules/component-store/spec/component-store.spec.ts
+++ b/modules/component-store/spec/component-store.spec.ts
@@ -25,7 +25,9 @@ import {
   of,
   queueScheduler,
   scheduled,
+  Subject,
   Subscription,
+  switchMap,
   throwError,
   timer,
 } from 'rxjs';
@@ -1774,6 +1776,65 @@ describe('Component Store', () => {
         setTimeout(() => componentStore.ngOnDestroy(), 20);
 
         jest.advanceTimersByTime(20);
+      });
+    });
+
+    describe('Resubscribes on errors', () => {
+      let eff: ReturnType<typeof componentStore.effect<string>>;
+      let lastResult: string | undefined;
+      let lastError: string | undefined;
+
+      beforeEach(() => {
+        lastResult = undefined;
+
+        eff = componentStore.effect<string>((_) =>
+          _.pipe(
+            tap((r) => (lastResult = r)),
+            switchMap((v) => {
+              if (v === 'error') {
+                lastError = v;
+                return throwError(() => 'err');
+              }
+              lastError = undefined;
+              return of(v);
+            })
+          )
+        );
+      });
+
+      it('resubscribes on error in generator', () => {
+        expect(lastError).toEqual(undefined);
+        eff('error');
+        expect(lastResult).toEqual('error');
+        expect(lastError).toEqual('error');
+
+        eff('next');
+        expect(lastResult).toEqual('next');
+        expect(lastError).toEqual(undefined);
+      });
+
+      it('resubscribes when value$ throws an error', () => {
+        expect(lastError).toEqual(undefined);
+        const s = new Subject<string>();
+        const m = s.pipe(
+          switchMap((v) => {
+            if (v === 'error') {
+              return throwError(() => 'err');
+            }
+            return of(v);
+          })
+        );
+        eff(m);
+        s.next('a');
+        expect(lastResult).toEqual('a');
+        s.next('error');
+        expect(lastResult).toEqual('a');
+        s.next('b');
+        expect(lastResult).toEqual('b');
+
+        eff('next');
+        expect(lastResult).toEqual('next');
+        expect(lastError).toEqual(undefined);
       });
     });
   });

--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -12,6 +12,7 @@ import {
   asapScheduler,
   EMPTY,
   ObservedValueOf,
+  retry,
 } from 'rxjs';
 import {
   takeUntil,
@@ -403,14 +404,14 @@ export class ComponentStore<T extends object> implements OnDestroy {
     const origin$ = new Subject<ObservableType>();
     generator(origin$ as OriginType)
       // tied to the lifecycle 👇 of ComponentStore
-      .pipe(takeUntil(this.destroy$))
+      .pipe(retry(), takeUntil(this.destroy$))
       .subscribe();
 
     return ((
       observableOrValue?: ObservableType | Observable<ObservableType>
     ): Subscription => {
       const observable$ = isObservable(observableOrValue)
-        ? observableOrValue
+        ? observableOrValue.pipe(retry())
         : of(observableOrValue);
       return observable$.pipe(takeUntil(this.destroy$)).subscribe((value) => {
         // any new 👇 value is pushed into a stream


### PR DESCRIPTION
When function passed to `effect()` throws an error, or a value passed to `effect()` throws an error - resubscribe using `retry()`.

Closes #3962

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

I'm ready to modify the documentation if RFC will be approved.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
