### PR TITLE
docs: set correct label in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -40,7 +40,7 @@ body:
   - type: textarea
     id: expected_behavior
     attributes:
-      label: Minimal reproduction of the bug/regression with instructions
+      label: Expected behavior
       description: Describe what the expected behavior would be.
     validations:
       required: true


### PR DESCRIPTION
This commit changes a text label in the file "platform\.github\ISSUE_TEMPLATE\bug-report.yml" from "Minimal reproduction of the bug/regression with instructions" to "Expected behavior".

Closes #3977
