### PR TITLE
fix(eslint-plugin): support inject for use-consistent-global-store-name rule

### DIFF
--- a/modules/eslint-plugin/src/rules/store/use-consistent-global-store-name.ts
+++ b/modules/eslint-plugin/src/rules/store/use-consistent-global-store-name.ts
@@ -62,7 +62,7 @@ export default createRule<Options, MessageIds>({
                 data,
                 fix: (fixer) =>
                   fixer.replaceTextRange(
-                    [range[0], typeAnnotation.range[0]],
+                    [range[0], typeAnnotation?.range[0] ?? range[1]],
                     storeName
                   ),
               },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, use-consistent-global-store-name rule throws the following error when the rule is violated using inject

```
An unhandled exception occurred: Cannot read properties of undefined (reading 'typeAnnotation')
```

Related to https://github.com/ngrx/platform/issues/3943

## What is the new behavior?
Added handling of cases where typeAnnotation does not exist.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
