### PR TITLE
fix(data): make DataServiceError extend from Error

### DIFF
--- a/modules/data/src/dataservices/data-service-error.ts
+++ b/modules/data/src/dataservices/data-service-error.ts
@@ -7,13 +7,12 @@ import { RequestData } from './interfaces';
  * @param error the HttpErrorResponse or the error thrown by the service
  * @param requestData the HTTP request information such as the method and the url.
  */
-// If extend from Error, `dse instanceof DataServiceError` returns false
-// in some (all?) unit tests so don't bother trying.
-export class DataServiceError {
-  message: string | null;
-
+export class DataServiceError extends Error {
   constructor(public error: any, public requestData: RequestData | null) {
-    this.message = typeof error === 'string' ? error : extractMessage(error);
+    super(
+      typeof error === 'string' ? error : extractMessage(error) ?? undefined
+    );
+    this.name = this.constructor.name;
   }
 }
 


### PR DESCRIPTION
I was kind of surprised when `DataServiceError instanceof Error` returned `false` but then I saw the note in the source code (4 years ago) about how `dse instanceof DataServiceError` didn't work in unit tests when extending from `Error`.  As long as `super()` is called in the child class constructor when extending from `Error`, then `instanceof` should work fine.  I made the change, then ran the unit tests and they all passed so it seems it's ok.

This is not a big deal but it's usually good form to have `Error` in the inheritance chain of custom errors. I don't believe this is a breaking change.