### PR TITLE
docs(data): clarify entity dispatcher fires action once

### DIFF
--- a/projects/ngrx.io/content/guide/data/entity-collection-service.md
+++ b/projects/ngrx.io/content/guide/data/entity-collection-service.md
@@ -157,8 +157,10 @@ An entity argument **must never be a cached entity object**.
 It can be a _copy_ of a cached entity object and it often is.
 The demo application always calls these command methods with copies of the entity data.
 
-All _command methods_ return `void`.
+All _command methods_ return `void` or an `Observable`.
 A core principle of the _redux pattern_ is that _commands_ never return a value. They just _do things_ that have side-effects.
+Thus, the action is only fired when the command is invoked, and re-subscribing to a command's returned `Observable` will not
+create another action.
 
 Rather than expect a result from the command,
 you subscribe to a _selector$_ property that reflects


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3979

## What is the new behavior?
Mention that re-subscribing to an `EntityCollectionService` command
does not create a new action, even though some commands return
an `Observable` with the result.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
