### PR TITLE
fix(signals): do not create nested signals for STATE_SIGNAL property

### DIFF
--- a/modules/signals/spec/signal-state.spec.ts
+++ b/modules/signals/spec/signal-state.spec.ts
@@ -59,6 +59,15 @@ describe('signalState', () => {
     expect((state.user.firstName as any).y).toBe(undefined);
   });
 
+  it('does not modify STATE_SIGNAL', () => {
+    const state = signalState(initialState);
+
+    expect((state[STATE_SIGNAL] as any).user).toBe(undefined);
+    expect((state[STATE_SIGNAL] as any).foo).toBe(undefined);
+    expect((state[STATE_SIGNAL] as any).numbers).toBe(undefined);
+    expect((state[STATE_SIGNAL] as any).ngrx).toBe(undefined);
+  });
+
   it(
     'emits new values only for affected signals',
     testEffects((tick) => {

--- a/modules/signals/src/deep-signal.ts
+++ b/modules/signals/src/deep-signal.ts
@@ -1,4 +1,4 @@
-import { isSignal, Signal, untracked } from '@angular/core';
+import { Signal, untracked } from '@angular/core';
 import { selectSignal } from './select-signal';
 
 export type DeepSignal<T> = Signal<T> &
@@ -14,11 +14,15 @@ export function toDeepSignal<T>(signal: Signal<T>): DeepSignal<T> {
 
   return new Proxy(signal, {
     get(target: any, prop) {
-      if (prop in value && !target[prop]) {
+      if (!(prop in value)) {
+        return target[prop];
+      }
+
+      if (!target[prop]) {
         target[prop] = selectSignal(() => target()[prop]);
       }
 
-      return isSignal(target[prop]) ? toDeepSignal(target[prop]) : target[prop];
+      return toDeepSignal(target[prop]);
     },
   });
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `toDeepSignal` function accidentally creates nested signals for the `STATE_SIGNAL` property that is part of the `signalState` instance. This caused a runtime error when the `signalState` instance was used with `patchState`:

![state-signal-error](https://github.com/ngrx/platform/assets/17877290/d66707bb-b869-4e81-a39a-88eeaa4c52c1)

Thanks to @manfredsteyer for reporting this bug!

## What is the new behavior?

The `toDeepSignal` function does not create nested signals for the `STATE_SIGNAL` or any other property that is not part of the state object.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
