### PR TITLE
fix(signals): improve state type and add type tests

### DIFF
--- a/modules/signals/spec/types/helpers.ts
+++ b/modules/signals/spec/types/helpers.ts
@@ -1,0 +1,11 @@
+export const compilerOptions = () => ({
+  moduleResolution: 'node',
+  target: 'ES2022',
+  baseUrl: '.',
+  experimentalDecorators: true,
+  strict: true,
+  noImplicitAny: true,
+  paths: {
+    '@ngrx/signals': ['./modules/signals'],
+  },
+});

--- a/modules/signals/spec/types/signal-state.types.spec.ts
+++ b/modules/signals/spec/types/signal-state.types.spec.ts
@@ -1,0 +1,259 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './helpers';
+
+describe('signalState', () => {
+  const expectSnippet = expecter(
+    (code) => `
+        import { patchState, signalState } from '@ngrx/signals';
+
+        const initialState = {
+          user: {
+            age: 30,
+            details: {
+              first: 'John',
+              last: 'Smith',
+            },
+            address: ['Belgrade', 'Serbia'],
+          },
+          numbers: [1, 2, 3],
+          ngrx: 'rocks',
+        };
+
+        ${code}
+      `,
+    compilerOptions()
+  );
+
+  it('allows passing state as a generic argument', () => {
+    expectSnippet(`
+      type FooState = { foo: string; bar: number };
+      const state = signalState<FooState>({ foo: 'bar', bar: 1 });
+    `).toInfer('state', 'SignalState<FooState>');
+  });
+
+  it('creates deep signals for nested state slices', () => {
+    const snippet = `
+      const state = signalState(initialState);
+
+      const user = state.user;
+      const age = state.user.age;
+      const details = state.user.details;
+      const first = state.user.details.first;
+      const last = state.user.details.last;
+      const address = state.user.address;
+      const numbers = state.numbers;
+      const ngrx = state.ngrx;
+    `;
+
+    expectSnippet(snippet).toInfer(
+      'state',
+      'SignalState<{ user: { age: number; details: { first: string; last: string; }; address: string[]; }; numbers: number[]; ngrx: string; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'user',
+      'DeepSignal<{ age: number; details: { first: string; last: string; }; address: string[]; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'details',
+      'DeepSignal<{ first: string; last: string; }>'
+    );
+    expectSnippet(snippet).toInfer('first', 'Signal<string>');
+    expectSnippet(snippet).toInfer('last', 'Signal<string>');
+    expectSnippet(snippet).toInfer('address', 'Signal<string[]>');
+    expectSnippet(snippet).toInfer('numbers', 'Signal<number[]>');
+    expectSnippet(snippet).toInfer('ngrx', 'Signal<string>');
+  });
+
+  it('does not create deep signals when state slice type is an interface', () => {
+    expectSnippet(`
+      interface User {
+        firstName: string;
+        lastName: string;
+      }
+
+      type State = { user: User };
+
+      const state = signalState<State>({ user: { firstName: 'John', lastName: 'Smith' } });
+      const user = state.user;
+    `).toInfer('user', 'Signal<User>');
+  });
+
+  it('does not create deep signals for optional state slices', () => {
+    const snippet = `
+      type State = {
+        foo?: string;
+        bar: { baz?: number };
+        x?: { y: { z?: boolean } };
+      };
+
+      const state = signalState<State>({ bar: {} });
+      const foo = state.foo;
+      const bar = state.bar;
+      const baz = state.bar.baz;
+      const x = state.x;
+    `;
+
+    expectSnippet(snippet).toInfer('state', 'SignalState<State>');
+    expectSnippet(snippet).toInfer(
+      'foo',
+      'Signal<string | undefined> | undefined'
+    );
+    expectSnippet(snippet).toInfer(
+      'bar',
+      'DeepSignal<{ baz?: number | undefined; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'baz',
+      'Signal<number | undefined> | undefined'
+    );
+    expectSnippet(snippet).toInfer(
+      'x',
+      'Signal<{ y: { z?: boolean | undefined; }; } | undefined> | undefined'
+    );
+  });
+
+  it('succeeds when state is an empty object', () => {
+    expectSnippet(`const state = signalState({})`).toInfer(
+      'state',
+      'SignalState<{}>'
+    );
+  });
+
+  it('succeeds when state slices are union types', () => {
+    const snippet = `
+      type State = {
+        foo: { s: string } | number;
+        bar: { baz: { n: number } | null };
+        x: { y: { z: boolean | undefined } };
+      };
+
+      const state = signalState<State>({
+        foo: { s: 's' },
+        bar: { baz: null },
+        x: { y: { z: undefined } },
+      });
+      const foo = state.foo;
+      const bar = state.bar;
+      const baz = state.bar.baz;
+      const x = state.x;
+      const y = state.x.y;
+      const z = state.x.y.z;
+    `;
+
+    expectSnippet(snippet).toInfer('state', 'SignalState<State>');
+    expectSnippet(snippet).toInfer('foo', 'Signal<number | { s: string; }>');
+    expectSnippet(snippet).toInfer(
+      'bar',
+      'DeepSignal<{ baz: { n: number; } | null; }>'
+    );
+    expectSnippet(snippet).toInfer('baz', 'Signal<{ n: number; } | null>');
+    expectSnippet(snippet).toInfer(
+      'x',
+      'DeepSignal<{ y: { z: boolean | undefined; }; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'y',
+      'DeepSignal<{ z: boolean | undefined; }>'
+    );
+    expectSnippet(snippet).toInfer('z', 'Signal<boolean | undefined>');
+  });
+
+  it('fails when state contains function properties', () => {
+    expectSnippet(`const state = signalState({ name: '' })`).toFail(
+      /@ngrx\/signals: function properties are not allowed/
+    );
+
+    expectSnippet(
+      `const state = signalState({ foo: { arguments: [] } })`
+    ).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(
+      `const state = signalState({ foo: { bar: { call: false }, baz: 1 } })`
+    ).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(
+      `const state = signalState({ foo: { apply: 'apply', bar: true } })`
+    ).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(`const state = signalState({ bind: { foo: 'bar' } })`).toFail(
+      /@ngrx\/signals: function properties are not allowed/
+    );
+
+    expectSnippet(
+      `const state = signalState({ foo: { bar: { prototype: [] }; baz: 1 } })`
+    ).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(`const state = signalState({ foo: { length: 10 } })`).toFail(
+      /@ngrx\/signals: function properties are not allowed/
+    );
+
+    expectSnippet(`const state = signalState({ caller: '' })`).toFail(
+      /@ngrx\/signals: function properties are not allowed/
+    );
+  });
+
+  it('fails when state is not an object', () => {
+    expectSnippet(`const state = signalState(10);`).toFail();
+    expectSnippet(`const state = signalState('');`).toFail();
+    expectSnippet(`const state = signalState(null);`).toFail();
+    expectSnippet(`const state = signalState(true);`).toFail();
+    expectSnippet(`const state = signalState(['ng', 'rx']);`).toFail();
+  });
+
+  it('fails when state type is defined as an interface', () => {
+    expectSnippet(`
+      interface User {
+        firstName: string;
+        lastName: string;
+      }
+
+      const state = signalState<User>({ firstName: 'John', lastName: 'Smith' });
+    `).toFail(
+      /Type 'User' does not satisfy the constraint 'Record<string, unknown>'/
+    );
+  });
+
+  it('patches state via sequence of partial state objects and updater functions', () => {
+    expectSnippet(`
+      const state = signalState(initialState);
+
+      patchState(
+        state,
+        { numbers: [10, 100, 1000] },
+        (state) => ({ user: { ...state.user, age: state.user.age + 1 } }),
+        { ngrx: 'signals' }
+      );
+    `).toSucceed();
+  });
+
+  it('fails when state is patched with a non-record', () => {
+    expectSnippet(`
+      const state = signalState(initialState);
+      patchState(state, 10);
+    `).toFail();
+
+    expectSnippet(`
+      const state = signalState(initialState);
+      patchState(state, undefined);
+    `).toFail();
+
+    expectSnippet(`
+      const state = signalState(initialState);
+      patchState(state, [1, 2, 3]);
+    `).toFail();
+  });
+
+  it('fails when state is patched with a wrong record', () => {
+    expectSnippet(`
+      const state = signalState(initialState);
+      patchState(state, { ngrx: 10 });
+    `).toFail(/Type 'number' is not assignable to type 'string'/);
+  });
+
+  it('fails when state is patched with a wrong updater function', () => {
+    expectSnippet(`
+      const state = signalState(initialState);
+      patchState(state, (state) => ({ user: { ...state.user, age: '30' } }));
+    `).toFail(/Type 'string' is not assignable to type 'number'/);
+  });
+});

--- a/modules/signals/spec/types/signal-state.types.spec.ts
+++ b/modules/signals/spec/types/signal-state.types.spec.ts
@@ -272,47 +272,47 @@ describe('signalState', () => {
 
   it('fails when state contains Function properties', () => {
     expectSnippet(`const state = signalState({ name: '' })`).toFail(
-      /@ngrx\/signals: signal state properties must be different from `Function` properties/
+      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
     );
 
     expectSnippet(
       `const state = signalState({ foo: { arguments: [] } })`
     ).toFail(
-      /@ngrx\/signals: signal state properties must be different from `Function` properties/
+      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
     );
 
     expectSnippet(`
       type State = { foo: { bar: { call?: boolean }; baz: number } };
       const state = signalState<State>({ foo: { bar: {}, baz: 1 } });
     `).toFail(
-      /@ngrx\/signals: signal state properties must be different from `Function` properties/
+      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
     );
 
     expectSnippet(
       `const state = signalState({ foo: { apply: 'apply', bar: true } })`
     ).toFail(
-      /@ngrx\/signals: signal state properties must be different from `Function` properties/
+      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
     );
 
     expectSnippet(`
       type State = { bind?: { foo: string } };
       const state = signalState<State>({ bind: { foo: 'bar' } });
     `).toFail(
-      /@ngrx\/signals: signal state properties must be different from `Function` properties/
+      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
     );
 
     expectSnippet(
       `const state = signalState({ foo: { bar: { prototype: [] }; baz: 1 } })`
     ).toFail(
-      /@ngrx\/signals: signal state properties must be different from `Function` properties/
+      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
     );
 
     expectSnippet(`const state = signalState({ foo: { length: 10 } })`).toFail(
-      /@ngrx\/signals: signal state properties must be different from `Function` properties/
+      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
     );
 
     expectSnippet(`const state = signalState({ caller: '' })`).toFail(
-      /@ngrx\/signals: signal state properties must be different from `Function` properties/
+      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
     );
   });
 

--- a/modules/signals/spec/types/signal-state.types.spec.ts
+++ b/modules/signals/spec/types/signal-state.types.spec.ts
@@ -49,18 +49,25 @@ describe('signalState', () => {
       'state',
       'SignalState<{ user: { age: number; details: { first: string; last: string; }; address: string[]; }; numbers: number[]; ngrx: string; }>'
     );
+
     expectSnippet(snippet).toInfer(
       'user',
       'DeepSignal<{ age: number; details: { first: string; last: string; }; address: string[]; }>'
     );
+
     expectSnippet(snippet).toInfer(
       'details',
       'DeepSignal<{ first: string; last: string; }>'
     );
+
     expectSnippet(snippet).toInfer('first', 'Signal<string>');
+
     expectSnippet(snippet).toInfer('last', 'Signal<string>');
+
     expectSnippet(snippet).toInfer('address', 'Signal<string[]>');
+
     expectSnippet(snippet).toInfer('numbers', 'Signal<number[]>');
+
     expectSnippet(snippet).toInfer('ngrx', 'Signal<string>');
   });
 
@@ -94,18 +101,22 @@ describe('signalState', () => {
     `;
 
     expectSnippet(snippet).toInfer('state', 'SignalState<State>');
+
     expectSnippet(snippet).toInfer(
       'foo',
       'Signal<string | undefined> | undefined'
     );
+
     expectSnippet(snippet).toInfer(
       'bar',
       'DeepSignal<{ baz?: number | undefined; }>'
     );
+
     expectSnippet(snippet).toInfer(
       'baz',
       'Signal<number | undefined> | undefined'
     );
+
     expectSnippet(snippet).toInfer(
       'x',
       'Signal<{ y: { z?: boolean | undefined; }; } | undefined> | undefined'
@@ -141,62 +152,72 @@ describe('signalState', () => {
     `;
 
     expectSnippet(snippet).toInfer('state', 'SignalState<State>');
+
     expectSnippet(snippet).toInfer('foo', 'Signal<number | { s: string; }>');
+
     expectSnippet(snippet).toInfer(
       'bar',
       'DeepSignal<{ baz: { n: number; } | null; }>'
     );
+
     expectSnippet(snippet).toInfer('baz', 'Signal<{ n: number; } | null>');
+
     expectSnippet(snippet).toInfer(
       'x',
       'DeepSignal<{ y: { z: boolean | undefined; }; }>'
     );
+
     expectSnippet(snippet).toInfer(
       'y',
       'DeepSignal<{ z: boolean | undefined; }>'
     );
+
     expectSnippet(snippet).toInfer('z', 'Signal<boolean | undefined>');
   });
 
   it('fails when state contains function properties', () => {
     expectSnippet(`const state = signalState({ name: '' })`).toFail(
-      /@ngrx\/signals: function properties are not allowed/
+      /@ngrx\/signals: state cannot contain `Function` properties/
     );
 
     expectSnippet(
       `const state = signalState({ foo: { arguments: [] } })`
-    ).toFail(/@ngrx\/signals: function properties are not allowed/);
+    ).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(
       `const state = signalState({ foo: { bar: { call: false }, baz: 1 } })`
-    ).toFail(/@ngrx\/signals: function properties are not allowed/);
+    ).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(
       `const state = signalState({ foo: { apply: 'apply', bar: true } })`
-    ).toFail(/@ngrx\/signals: function properties are not allowed/);
+    ).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(`const state = signalState({ bind: { foo: 'bar' } })`).toFail(
-      /@ngrx\/signals: function properties are not allowed/
+      /@ngrx\/signals: state cannot contain `Function` properties/
     );
 
     expectSnippet(
       `const state = signalState({ foo: { bar: { prototype: [] }; baz: 1 } })`
-    ).toFail(/@ngrx\/signals: function properties are not allowed/);
+    ).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(`const state = signalState({ foo: { length: 10 } })`).toFail(
-      /@ngrx\/signals: function properties are not allowed/
+      /@ngrx\/signals: state cannot contain `Function` properties/
     );
 
     expectSnippet(`const state = signalState({ caller: '' })`).toFail(
-      /@ngrx\/signals: function properties are not allowed/
+      /@ngrx\/signals: state cannot contain `Function` properties/
     );
   });
 
   it('fails when state is not an object', () => {
     expectSnippet(`const state = signalState(10);`).toFail();
+
     expectSnippet(`const state = signalState('');`).toFail();
+
     expectSnippet(`const state = signalState(null);`).toFail();
+
     expectSnippet(`const state = signalState(true);`).toFail();
+
     expectSnippet(`const state = signalState(['ng', 'rx']);`).toFail();
   });
 

--- a/modules/signals/spec/types/signal-store.types.spec.ts
+++ b/modules/signals/spec/types/signal-store.types.spec.ts
@@ -1,0 +1,662 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './helpers';
+
+describe('signalStore', () => {
+  const expectSnippet = expecter(
+    (code) => `
+        import { inject, Signal } from '@angular/core';
+        import {
+          patchState,
+          selectSignal,
+          signalStore,
+          signalStoreFeature,
+          type,
+          withHooks,
+          withMethods,
+          withSignals,
+          withState,
+        } from '@ngrx/signals';
+
+        ${code}
+      `,
+    compilerOptions()
+  );
+
+  it('allows passing state as a generic argument', () => {
+    const snippet = `
+      type State = { foo: string; bar: number[] };
+      const Store = signalStore(
+        withState<State>({ foo: 'bar', bar: [1, 2] })
+      );
+    `;
+
+    expectSnippet(snippet).toInfer(
+      'Store',
+      'Type<{ foo: Signal<string>; bar: Signal<number[]>; [STATE_SIGNAL]: WritableSignal<{ foo: string; bar: number[]; }>; }>'
+    );
+  });
+
+  it('creates deep signals for nested state slices', () => {
+    const snippet = `
+      const Store = signalStore(
+        withState({
+          user: {
+            age: 10,
+            details: {
+              first: 'John',
+              flags: [true, false],
+            },
+          },
+        })
+      );
+
+      const store = new Store();
+      const user = store.user;
+      const age = store.user.age;
+      const details = store.user.details;
+      const first = store.user.details.first;
+      const flags = store.user.details.flags;
+    `;
+
+    expectSnippet(snippet).toInfer(
+      'store',
+      '{ user: DeepSignal<{ age: number; details: { first: string; flags: boolean[]; }; }>; [STATE_SIGNAL]: WritableSignal<{ user: { age: number; details: { first: string; flags: boolean[]; }; }; }>; }'
+    );
+    expectSnippet(snippet).toInfer(
+      'user',
+      'DeepSignal<{ age: number; details: { first: string; flags: boolean[]; }; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'details',
+      'DeepSignal<{ first: string; flags: boolean[]; }>'
+    );
+    expectSnippet(snippet).toInfer('first', 'Signal<string>');
+    expectSnippet(snippet).toInfer('flags', 'Signal<boolean[]>');
+  });
+
+  it('does not create deep signals when state slice type is an interface', () => {
+    expectSnippet(`
+      interface User {
+        firstName: string;
+        lastName: string;
+      }
+
+      type State = { user: User };
+
+      const Store = signalStore(
+        withState<State>({ user: { firstName: 'John', lastName: 'Smith' } })
+      );
+
+      const store = new Store();
+      const user = store.user;
+    `).toInfer('user', 'Signal<User>');
+  });
+
+  it('succeeds when state is an empty object', () => {
+    expectSnippet(`const Store = signalStore(withState({}))`).toInfer(
+      'Store',
+      'Type<{ [STATE_SIGNAL]: WritableSignal<{}>; }>'
+    );
+  });
+
+  it('succeeds when state slices are union types', () => {
+    const snippet = `
+      type State = {
+        foo: { s: string } | number;
+        bar: { baz: { b: boolean } | null };
+        x: { y: { z: number | undefined } };
+      };
+
+      const Store = signalStore(
+        withState<State>({
+          foo: { s: 's' },
+          bar: { baz: null },
+          x: { y: { z: undefined } },
+        })
+      );
+      const store = inject(Store);
+      const foo = store.foo;
+      const bar = store.bar;
+      const baz = store.bar.baz;
+      const x = store.x;
+      const y = store.x.y;
+      const z = store.x.y.z;
+    `;
+
+    expectSnippet(snippet).toInfer(
+      'store',
+      '{ foo: Signal<number | { s: string; }>; bar: DeepSignal<{ baz: { b: boolean; } | null; }>; x: DeepSignal<{ y: { z: number | undefined; }; }>; [STATE_SIGNAL]: WritableSignal<...>; }'
+    );
+    expectSnippet(snippet).toInfer('foo', 'Signal<number | { s: string; }>');
+    expectSnippet(snippet).toInfer(
+      'bar',
+      'DeepSignal<{ baz: { b: boolean; } | null; }>'
+    );
+    expectSnippet(snippet).toInfer('baz', 'Signal<{ b: boolean; } | null>');
+    expectSnippet(snippet).toInfer(
+      'x',
+      'DeepSignal<{ y: { z: number | undefined; }; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'y',
+      'DeepSignal<{ z: number | undefined; }>'
+    );
+    expectSnippet(snippet).toInfer('z', 'Signal<number | undefined>');
+  });
+
+  it('succeeds when root state slices contain function properties', () => {
+    expectSnippet(`
+      const Store = signalStore(
+        withState({
+          name: { x: { y: 'z' } },
+          arguments: [1, 2, 3],
+          call: false,
+        })
+      );
+    `).toInfer(
+      'Store',
+      'Type<{ name: DeepSignal<{ x: { y: string; }; }>; arguments: Signal<number[]>; call: Signal<boolean>; [STATE_SIGNAL]: WritableSignal<{ name: { x: { y: string; }; }; arguments: number[]; call: boolean; }>; }>'
+    );
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({
+          apply: 'apply',
+          bind: { foo: 'bar' },
+          prototype: ['ngrx'],
+        })
+      );
+    `).toInfer(
+      'Store',
+      ' Type<{ apply: Signal<string>; bind: DeepSignal<{ foo: string; }>; prototype: Signal<string[]>; [STATE_SIGNAL]: WritableSignal<{ apply: string; bind: { foo: string; }; prototype: string[]; }>; }>'
+    );
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({
+          length: 10,
+          caller: undefined,
+        })
+      );
+    `).toInfer(
+      'Store',
+      'Type<{ length: Signal<number>; caller: Signal<undefined>; [STATE_SIGNAL]: WritableSignal<{ length: number; caller: undefined; }>; }>'
+    );
+  });
+
+  it('fails when nested state slices contain function properties', () => {
+    expectSnippet(`
+      const Store = signalStore(withState({ x: { name?: '' } }));
+    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(`
+      const Store = signalStore(withState({ x: { arguments: [] } }));
+    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ x: { bar: { call: false }, baz: 1 } })
+      );
+    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ x: { apply: 'apply', bar: true } })
+      )
+    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ x: { bind: { foo: 'bar' } } })
+      );
+    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ x: { bar: { prototype: [] }; baz: 1 } })
+      );
+    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(`
+      const Store = signalStore(withState({ x: { length: 10 } }));
+    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+
+    expectSnippet(`
+      const Store = signalStore(withState({ x: { caller: '' } }));
+    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+  });
+
+  it('succeeds when nested state slices are optional', () => {
+    const snippet = `
+      type State = {
+        bar: { baz?: number };
+        x: { y?: { z: boolean } };
+      };
+
+      const Store = signalStore(withState<State>({ bar: {}, x: {} }));
+
+      const store = new Store();
+      const bar = store.bar;
+      const baz = store.bar.baz;
+      const x = store.x;
+      const y = store.x.y;
+    `;
+
+    expectSnippet(snippet).toInfer(
+      'store',
+      '{ bar: DeepSignal<{ baz?: number | undefined; }>; x: DeepSignal<{ y?: { z: boolean; } | undefined; }>; [STATE_SIGNAL]: WritableSignal<{ bar: { baz?: number | undefined; }; x: { y?: { ...; } | undefined; }; }>; }'
+    );
+    expectSnippet(snippet).toInfer(
+      'bar',
+      'DeepSignal<{ baz?: number | undefined; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'baz',
+      'Signal<number | undefined> | undefined'
+    );
+    expectSnippet(snippet).toInfer(
+      'x',
+      'DeepSignal<{ y?: { z: boolean; } | undefined; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'y',
+      'Signal<{ z: boolean; } | undefined> | undefined'
+    );
+  });
+
+  it('fails when root state slices are optional', () => {
+    expectSnippet(`
+      type State = {
+        foo?: { s: string };
+      };
+
+      const Store = signalStore(
+        withState<State>({ foo: { s: '' } })
+      );
+    `).toFail(/@ngrx\/signals: optional properties are not allowed/);
+  });
+
+  it('fails when state is not an object', () => {
+    expectSnippet(`const Store = signalStore(withState(10));`).toFail();
+    expectSnippet(`const Store = signalStore(withState(''));`).toFail();
+    expectSnippet(`const Store = signalStore(withState(null));`).toFail();
+    expectSnippet(`const Store = signalStore(withState(true));`).toFail();
+    expectSnippet(
+      `const Store = signalStore(withState(['ng', 'rx']));`
+    ).toFail();
+  });
+
+  it('fails when state type is defined as an interface', () => {
+    expectSnippet(`
+      interface User {
+        firstName: string;
+        lastName: string;
+      }
+
+      const Store = signalStore(
+        withState<User>({ firstName: 'John', lastName: 'Smith' })
+      );
+    `).toFail(
+      /Type 'User' does not satisfy the constraint 'Record<string, unknown>'/
+    );
+  });
+
+  it('patches state via sequence of partial state objects and updater functions', () => {
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ ngrx: 'signals' }),
+        withState({ user: { age: 10, first: 'John' } }),
+        withMethods((store) => {
+          patchState(
+            store,
+            (state) => ({ user: { ...state.user, first: 'Peter' } }),
+            { ngrx: 'rocks' }
+          );
+
+          return {};
+        }),
+        withState({ flags: [true, false, true] }),
+        withMethods(({ ngrx, flags, ...store }) => {
+          patchState(
+            store,
+            { ngrx: 'rocks' },
+            (state) => ({ flags: [...state.flags, true] })
+          );
+
+          return {};
+        })
+      );
+
+      const store = new Store();
+      patchState(
+        store,
+        { flags: [true] },
+        (state) => ({ user: { ...state.user, age: state.user.age + 1 } }),
+        { ngrx: 'store' }
+      );
+    `).toSucceed();
+  });
+
+  it('fails when state is patched with a non-record', () => {
+    expectSnippet(`
+      const Store = signalStore(withState({ foo: 'bar' }));
+
+      const store = new Store();
+      patchState(store, 10);
+    `).toFail();
+
+    expectSnippet(`
+      const Store = signalStore(withState({ foo: 'bar' }));
+
+      const store = new Store();
+      patchState(store, undefined);
+    `).toFail();
+
+    expectSnippet(`
+      const Store = signalStore(withState({ foo: 'bar' }));
+
+      const store = new Store();
+      patchState(store, [1, 2, 3]);
+    `).toFail();
+  });
+
+  it('fails when state is patched with a wrong record', () => {
+    expectSnippet(`
+      const Store = signalStore(withState({ foo: 'bar' }));
+
+      const store = new Store();
+      patchState(store, { foo: 10 });
+    `).toFail(/Type 'number' is not assignable to type 'string'/);
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ foo: 'bar' }),
+        withMethods((store) => {
+          patchState(store, { foo: 10 });
+          return {};
+        })
+      );
+    `).toFail(/Type 'number' is not assignable to type 'string'/);
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ foo: 'bar' }),
+        withMethods(({ foo, ...store }) => {
+          patchState(store, { foo: 10 });
+          return {};
+        })
+      );
+    `).toFail(/Type 'number' is not assignable to type 'string'/);
+  });
+
+  it('fails when state is patched with a wrong updater function', () => {
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ user: { first: 'John', age: 20 } })
+      );
+
+      const store = new Store();
+      patchState(store, (state) => ({ user: { ...state.user, age: '30' } }));
+    `).toFail(/Type 'string' is not assignable to type 'number'/);
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ user: { first: 'John', age: 20 } }),
+        withMethods((store) => {
+          patchState(store, (state) => ({ user: { ...state.user, age: '30' } }));
+          return {};
+        })
+      );
+    `).toFail(/Type 'string' is not assignable to type 'number'/);
+
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ user: { first: 'John', age: 20 } }),
+        withMethods(({ user, ...store }) => {
+          patchState(store, (state) => ({ user: { ...state.user, first: 10 } }));
+          return {};
+        })
+      );
+    `).toFail(/Type 'number' is not assignable to type 'string'/);
+  });
+
+  it('allows injecting store using the `inject` function', () => {
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ ngrx: 'rocks', x: { y: 'z' } }),
+        withSignals(() => ({ signals: selectSignal(() => [1, 2, 3]) })),
+        withMethods(() => ({
+          mgmt(arg: boolean): number {
+            return 1;
+          }
+        }))
+      );
+
+      const store = inject(Store);
+    `).toInfer(
+      'store',
+      '{ ngrx: Signal<string>; x: DeepSignal<{ y: string; }>; signals: Signal<number[]>; mgmt: (arg: boolean) => number; [STATE_SIGNAL]: WritableSignal<{ ngrx: string; x: { y: string; }; }>; }'
+    );
+  });
+
+  it('allows using store via constructor-based dependency injection', () => {
+    expectSnippet(`
+      const Store = signalStore(
+        withState({ foo: 10 }),
+        withSignals(({ foo }) => ({ bar: selectSignal(() => foo() + '1') })),
+        withMethods(() => ({
+          baz(x: number): void {}
+        }))
+      );
+
+      type Store = InstanceType<typeof Store>;
+
+      class Component {
+        constructor (readonly store: Store) {}
+      }
+
+      const component = new Component(new Store());
+      const store = component.store;
+    `).toInfer(
+      'store',
+      '{ foo: Signal<number>; bar: Signal<string>; baz: (x: number) => void; [STATE_SIGNAL]: WritableSignal<{ foo: number; }>; }'
+    );
+  });
+
+  describe('custom features', () => {
+    const baseSnippet = `
+      function withX() {
+        return signalStoreFeature(withState({ x: 1 }));
+      }
+
+      type Y = { a: string; b: number };
+      const initialY: Y = { a: '', b: 5 };
+
+      function withY<_>() {
+        return signalStoreFeature(
+          {
+            state: type<{ q1: string }>(),
+            signals: type<{ sig: Signal<boolean> }>(),
+          },
+          withState({ y: initialY }),
+          withSignals(() => ({ sigY: selectSignal(() => 'sigY') })),
+          withHooks({
+            onInit({ q1, y, sigY, ...store }) {
+              patchState(store, { q1: '', y: { a: 'a', b: 2 } });
+            },
+          })
+        );
+      }
+
+      function withZ<_>() {
+        return signalStoreFeature(
+          { methods: type<{ f: () => void }>() },
+          withMethods(({ f }) => ({
+            z() {
+              f();
+            }
+          }))
+        );
+      }
+    `;
+
+    it('combines custom features', () => {
+      expectSnippet(`
+        function withFoo() {
+          return withState({ foo: 'foo' });
+        }
+
+        function withBar() {
+          return signalStoreFeature(
+            { state: type<{ foo: string }>() },
+            withState({ bar: 'bar' })
+          );
+        }
+
+        export function withBaz() {
+          return signalStoreFeature(
+            withFoo(),
+            withState({ count: 0 }),
+            withBar()
+          );
+        }
+
+        export function withBaz2() {
+          return signalStoreFeature(
+            withState({ foo: 'foo' }),
+            withState({ count: 0 }),
+            withBar()
+          );
+        }
+
+        const BazStore = signalStore(
+          withFoo(),
+          withState({ count: 0 }),
+          withBar()
+        );
+
+        const Baz2Store = signalStore(
+          withState({ foo: 'foo' }),
+          withState({ count: 0 }),
+          withBar()
+        );
+      `).toSucceed();
+
+      expectSnippet(
+        baseSnippet +
+          `
+          const Store = signalStore(
+            withSignals(() => ({ sig: selectSignal(() => 1) })),
+            withMethods(() => ({ q1: () => false })),
+            withSignals(() => ({ sig: selectSignal(() => false) })),
+            withState({ q1: 'q1', q2: 'q2' }),
+            withX(),
+            withY(),
+            withSignals(() => ({ q1: selectSignal(() => 10) })),
+            withMethods((store) => ({
+              f() {
+                patchState(store, { x: 1, y: { a: '', b: 0 }, q2: 'q2new' });
+              },
+            })),
+            withZ()
+          );
+
+          const feature = signalStoreFeature(
+            { signals: type<{ sig: Signal<boolean> }>() },
+            withX(),
+            withState({ q1: 'q1' }),
+            withY(),
+            withMethods((store) => ({
+              f() {
+                patchState(store, { x: 1, q1: 'xyz', y: { a: '', b: 0 } });
+              },
+            })),
+            withZ()
+          );
+          `
+      ).toSucceed();
+    });
+
+    it('fails when custom feature is used with wrong input', () => {
+      expectSnippet(
+        baseSnippet + 'const Store = signalStore(withY());'
+      ).toFail();
+
+      expectSnippet(
+        baseSnippet + 'const withY2 = () => signalStoreFeature(withY());'
+      ).toFail();
+
+      expectSnippet(
+        baseSnippet +
+          `
+          const Store = signalStore(
+            withSignals(() => ({ sig: selectSignal(() => 1) })),
+            withState({ q1: 'q1', q2: 'q2' }),
+            withState({ q1: 1 }),
+            withSignals(() => ({ sig: selectSignal(() => false) })),
+            withX(),
+            withY(),
+            withSignals(() => ({ q1: selectSignal(() => 10) })),
+            withMethods((store) => ({
+              f() {
+                patchState(store, { x: 1, y: { a: '', b: 0 }, q2: 'q2new' });
+              },
+            }))
+          );
+          `
+      ).toFail();
+
+      expectSnippet(
+        baseSnippet +
+          `
+          const feature = signalStoreFeature(
+            { signals: type<{ sig: Signal<boolean> }>() },
+            withSignals(() => ({ sig: selectSignal(() => 1) })),
+            withX(),
+            withState({ q1: 'q1' }),
+            withY(),
+            withMethods((store) => ({
+              f() {
+                patchState(store, { x: 1, q1: 'xyz', y: { a: '', b: 0 } });
+              },
+            }))
+          );
+          `
+      ).toFail();
+
+      expectSnippet(
+        baseSnippet +
+          `
+          const Store = signalStore(
+            withSignals(() => ({ sig: selectSignal(() => 1) })),
+            withState({ q1: 1 }),
+            withState({ q1: 'q1', q2: 'q2' }),
+            withSignals(() => ({ sig: selectSignal(() => false) })),
+            withX(),
+            withY(),
+            withSignals(() => ({ q1: selectSignal(() => 10) })),
+            withMethods((store) => ({
+              f() {
+                patchState(store, { x: 1, y: { a: '', b: 0 }, q2: 'q2new' });
+              },
+            }))
+          );
+
+          const feature = signalStoreFeature(
+            { signals: type<{ sig: Signal<boolean> }>() },
+            withSignals(() => ({ sig: selectSignal(() => 1) })),
+            withX(),
+            withState({ q1: 'q1' }),
+            withSignals(() => ({ sig: selectSignal(() => false) })),
+            withY(),
+            withMethods((store) => ({
+              f() {
+                patchState(store, { x: 1, q1: 'xyz', y: { a: '', b: 0 } });
+              },
+            }))
+          );
+          `
+      ).toSucceed();
+    });
+  });
+});

--- a/modules/signals/spec/types/signal-store.types.spec.ts
+++ b/modules/signals/spec/types/signal-store.types.spec.ts
@@ -62,15 +62,19 @@ describe('signalStore', () => {
       'store',
       '{ user: DeepSignal<{ age: number; details: { first: string; flags: boolean[]; }; }>; [STATE_SIGNAL]: WritableSignal<{ user: { age: number; details: { first: string; flags: boolean[]; }; }; }>; }'
     );
+
     expectSnippet(snippet).toInfer(
       'user',
       'DeepSignal<{ age: number; details: { first: string; flags: boolean[]; }; }>'
     );
+
     expectSnippet(snippet).toInfer(
       'details',
       'DeepSignal<{ first: string; flags: boolean[]; }>'
     );
+
     expectSnippet(snippet).toInfer('first', 'Signal<string>');
+
     expectSnippet(snippet).toInfer('flags', 'Signal<boolean[]>');
   });
 
@@ -127,20 +131,26 @@ describe('signalStore', () => {
       'store',
       '{ foo: Signal<number | { s: string; }>; bar: DeepSignal<{ baz: { b: boolean; } | null; }>; x: DeepSignal<{ y: { z: number | undefined; }; }>; [STATE_SIGNAL]: WritableSignal<...>; }'
     );
+
     expectSnippet(snippet).toInfer('foo', 'Signal<number | { s: string; }>');
+
     expectSnippet(snippet).toInfer(
       'bar',
       'DeepSignal<{ baz: { b: boolean; } | null; }>'
     );
+
     expectSnippet(snippet).toInfer('baz', 'Signal<{ b: boolean; } | null>');
+
     expectSnippet(snippet).toInfer(
       'x',
       'DeepSignal<{ y: { z: number | undefined; }; }>'
     );
+
     expectSnippet(snippet).toInfer(
       'y',
       'DeepSignal<{ z: number | undefined; }>'
     );
+
     expectSnippet(snippet).toInfer('z', 'Signal<number | undefined>');
   });
 
@@ -187,43 +197,43 @@ describe('signalStore', () => {
   it('fails when nested state slices contain function properties', () => {
     expectSnippet(`
       const Store = signalStore(withState({ x: { name?: '' } }));
-    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+    `).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(`
       const Store = signalStore(withState({ x: { arguments: [] } }));
-    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+    `).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(`
       const Store = signalStore(
         withState({ x: { bar: { call: false }, baz: 1 } })
       );
-    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+    `).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(`
       const Store = signalStore(
         withState({ x: { apply: 'apply', bar: true } })
       )
-    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+    `).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(`
       const Store = signalStore(
         withState({ x: { bind: { foo: 'bar' } } })
       );
-    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+    `).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(`
       const Store = signalStore(
         withState({ x: { bar: { prototype: [] }; baz: 1 } })
       );
-    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+    `).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(`
       const Store = signalStore(withState({ x: { length: 10 } }));
-    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+    `).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
 
     expectSnippet(`
       const Store = signalStore(withState({ x: { caller: '' } }));
-    `).toFail(/@ngrx\/signals: function properties are not allowed/);
+    `).toFail(/@ngrx\/signals: state cannot contain `Function` properties/);
   });
 
   it('succeeds when nested state slices are optional', () => {
@@ -246,18 +256,22 @@ describe('signalStore', () => {
       'store',
       '{ bar: DeepSignal<{ baz?: number | undefined; }>; x: DeepSignal<{ y?: { z: boolean; } | undefined; }>; [STATE_SIGNAL]: WritableSignal<{ bar: { baz?: number | undefined; }; x: { y?: { ...; } | undefined; }; }>; }'
     );
+
     expectSnippet(snippet).toInfer(
       'bar',
       'DeepSignal<{ baz?: number | undefined; }>'
     );
+
     expectSnippet(snippet).toInfer(
       'baz',
       'Signal<number | undefined> | undefined'
     );
+
     expectSnippet(snippet).toInfer(
       'x',
       'DeepSignal<{ y?: { z: boolean; } | undefined; }>'
     );
+
     expectSnippet(snippet).toInfer(
       'y',
       'Signal<{ z: boolean; } | undefined> | undefined'
@@ -268,19 +282,24 @@ describe('signalStore', () => {
     expectSnippet(`
       type State = {
         foo?: { s: string };
+        bar: number;
       };
 
       const Store = signalStore(
-        withState<State>({ foo: { s: '' } })
+        withState<State>({ foo: { s: '' }, bar: 1 })
       );
-    `).toFail(/@ngrx\/signals: optional properties are not allowed/);
+    `).toFail(/@ngrx\/signals: state cannot contain optional properties/);
   });
 
   it('fails when state is not an object', () => {
     expectSnippet(`const Store = signalStore(withState(10));`).toFail();
+
     expectSnippet(`const Store = signalStore(withState(''));`).toFail();
+
     expectSnippet(`const Store = signalStore(withState(null));`).toFail();
+
     expectSnippet(`const Store = signalStore(withState(true));`).toFail();
+
     expectSnippet(
       `const Store = signalStore(withState(['ng', 'rx']));`
     ).toFail();

--- a/modules/signals/spec/types/signal-store.types.spec.ts
+++ b/modules/signals/spec/types/signal-store.types.spec.ts
@@ -258,13 +258,13 @@ describe('signalStore', () => {
     expectSnippet(`
       const Store = signalStore(withState({ x: { name?: '' } }));
     `).toFail(
-      /@ngrx\/signals: nested state slices must be different from `Function` properties/
+      /@ngrx\/signals: nested state slices cannot contain `Function` property or method names/
     );
 
     expectSnippet(`
       const Store = signalStore(withState({ x: { arguments: [] } }));
     `).toFail(
-      /@ngrx\/signals: nested state slices must be different from `Function` properties/
+      /@ngrx\/signals: nested state slices cannot contain `Function` property or method names/
     );
 
     expectSnippet(`
@@ -272,7 +272,7 @@ describe('signalStore', () => {
         withState({ x: { bar: { call: false }, baz: 1 } })
       );
     `).toFail(
-      /@ngrx\/signals: nested state slices must be different from `Function` properties/
+      /@ngrx\/signals: nested state slices cannot contain `Function` property or method names/
     );
 
     expectSnippet(`
@@ -280,7 +280,7 @@ describe('signalStore', () => {
         withState({ x: { apply: 'apply', bar: true } })
       )
     `).toFail(
-      /@ngrx\/signals: nested state slices must be different from `Function` properties/
+      /@ngrx\/signals: nested state slices cannot contain `Function` property or method names/
     );
 
     expectSnippet(`
@@ -288,7 +288,7 @@ describe('signalStore', () => {
         withState({ x: { bind: { foo: 'bar' } } })
       );
     `).toFail(
-      /@ngrx\/signals: nested state slices must be different from `Function` properties/
+      /@ngrx\/signals: nested state slices cannot contain `Function` property or method names/
     );
 
     expectSnippet(`
@@ -296,19 +296,19 @@ describe('signalStore', () => {
         withState({ x: { bar: { prototype: [] }; baz: 1 } })
       );
     `).toFail(
-      /@ngrx\/signals: nested state slices must be different from `Function` properties/
+      /@ngrx\/signals: nested state slices cannot contain `Function` property or method names/
     );
 
     expectSnippet(`
       const Store = signalStore(withState({ x: { length: 10 } }));
     `).toFail(
-      /@ngrx\/signals: nested state slices must be different from `Function` properties/
+      /@ngrx\/signals: nested state slices cannot contain `Function` property or method names/
     );
 
     expectSnippet(`
       const Store = signalStore(withState({ x: { caller: '' } }));
     `).toFail(
-      /@ngrx\/signals: nested state slices must be different from `Function` properties/
+      /@ngrx\/signals: nested state slices cannot contain `Function` property or method names/
     );
   });
 

--- a/modules/signals/src/deep-signal.ts
+++ b/modules/signals/src/deep-signal.ts
@@ -1,13 +1,18 @@
 import { Signal, untracked } from '@angular/core';
 import { selectSignal } from './select-signal';
+import { IsUnknownRecord } from './ts-helpers';
 
 export type DeepSignal<T> = Signal<T> &
   (T extends Record<string, unknown>
-    ? Readonly<{
-        [K in keyof T]: T[K] extends Record<string, unknown>
-          ? DeepSignal<T[K]>
-          : Signal<T[K]>;
-      }>
+    ? IsUnknownRecord<T> extends true
+      ? unknown
+      : Readonly<{
+          [K in keyof T]: T[K] extends Record<string, unknown>
+            ? IsUnknownRecord<T[K]> extends true
+              ? Signal<T[K]>
+              : DeepSignal<T[K]>
+            : Signal<T[K]>;
+        }>
     : unknown);
 
 export function toDeepSignal<T>(signal: Signal<T>): DeepSignal<T> {

--- a/modules/signals/src/deep-signal.ts
+++ b/modules/signals/src/deep-signal.ts
@@ -3,7 +3,11 @@ import { selectSignal } from './select-signal';
 
 export type DeepSignal<T> = Signal<T> &
   (T extends Record<string, unknown>
-    ? Readonly<{ [K in keyof T]: DeepSignal<T[K]> }>
+    ? Readonly<{
+        [K in keyof T]: T[K] extends Record<string, unknown>
+          ? DeepSignal<T[K]>
+          : Signal<T[K]>;
+      }>
     : unknown);
 
 export function toDeepSignal<T>(signal: Signal<T>): DeepSignal<T> {

--- a/modules/signals/src/patch-state.ts
+++ b/modules/signals/src/patch-state.ts
@@ -1,12 +1,12 @@
 import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
 
-export type PartialStateUpdater<State extends Record<string, unknown>> =
-  | Partial<State>
-  | ((state: State) => Partial<State>);
+export type PartialStateUpdater<State extends Record<string, unknown>> = (
+  state: State
+) => Partial<State>;
 
 export function patchState<State extends Record<string, unknown>>(
   signalState: SignalStateMeta<State>,
-  ...updaters: PartialStateUpdater<State>[]
+  ...updaters: Array<Partial<State> | PartialStateUpdater<State>>
 ): void {
   signalState[STATE_SIGNAL].update((currentState) =>
     updaters.reduce(

--- a/modules/signals/src/signal-state.ts
+++ b/modules/signals/src/signal-state.ts
@@ -11,7 +11,7 @@ export type SignalStateMeta<State extends Record<string, unknown>> = {
 
 type SignalStateCheck<State> = HasFunctionKeys<State> extends false | undefined
   ? unknown
-  : '@ngrx/signals: signal state properties must be different from `Function` properties';
+  : '@ngrx/signals: signal state cannot contain `Function` property or method names';
 
 type SignalState<State extends Record<string, unknown>> = DeepSignal<State> &
   SignalStateMeta<State>;

--- a/modules/signals/src/signal-state.ts
+++ b/modules/signals/src/signal-state.ts
@@ -9,13 +9,13 @@ export type SignalStateMeta<State extends Record<string, unknown>> = {
 };
 
 /**
- * Signal state cannot properties that exist on the function object
- * because signal is a function.
+ * State cannot contain properties that exist on the `Function` object
+ * because `Signal` is a function.
  */
 export type SignalStateInput<State> = State extends Record<string, unknown>
   ? ContainsFunctionProps<State> extends false
     ? { [K in keyof State]: SignalStateInput<State[K]> }
-    : '@ngrx/signals: function properties are not allowed'
+    : '@ngrx/signals: state cannot contain `Function` properties'
   : State;
 
 type ContainsFunctionProps<State> = Exclude<

--- a/modules/signals/src/signal-state.ts
+++ b/modules/signals/src/signal-state.ts
@@ -1,6 +1,7 @@
 import { signal, WritableSignal } from '@angular/core';
 import { DeepSignal, toDeepSignal } from './deep-signal';
 import { defaultEqual } from './select-signal';
+import { HasFunctionKeys } from './ts-helpers';
 
 export const STATE_SIGNAL = Symbol('STATE_SIGNAL');
 
@@ -8,28 +9,15 @@ export type SignalStateMeta<State extends Record<string, unknown>> = {
   [STATE_SIGNAL]: WritableSignal<State>;
 };
 
-/**
- * State cannot contain properties that exist on the `Function` object
- * because `Signal` is a function.
- */
-export type SignalStateInput<State> = State extends Record<string, unknown>
-  ? ContainsFunctionProps<State> extends false
-    ? { [K in keyof State]: SignalStateInput<State[K]> }
-    : '@ngrx/signals: state cannot contain `Function` properties'
-  : State;
-
-type ContainsFunctionProps<State> = Exclude<
-  {
-    [K in keyof State]: K extends keyof Function ? true : false;
-  }[keyof State],
-  undefined
->;
+type SignalStateCheck<State> = HasFunctionKeys<State> extends false | undefined
+  ? unknown
+  : '@ngrx/signals: signal state properties must be different from `Function` properties';
 
 type SignalState<State extends Record<string, unknown>> = DeepSignal<State> &
   SignalStateMeta<State>;
 
 export function signalState<State extends Record<string, unknown>>(
-  initialState: SignalStateInput<State>
+  initialState: State & SignalStateCheck<State>
 ): SignalState<State> {
   const stateSignal = signal(initialState as State, { equal: defaultEqual });
   const deepSignal = toDeepSignal(stateSignal.asReadonly());

--- a/modules/signals/src/signal-store-feature.ts
+++ b/modules/signals/src/signal-store-feature.ts
@@ -4,6 +4,7 @@ import {
   SignalStoreFeature,
   SignalStoreFeatureResult,
 } from './signal-store-models';
+import { Prettify } from './ts-helpers';
 
 export function signalStoreFeature<F1 extends SignalStoreFeatureResult>(
   f1: SignalStoreFeature<EmptyFeatureResult, F1>
@@ -78,21 +79,21 @@ export function signalStoreFeature<
   F1 extends SignalStoreFeatureResult
 >(
   input: Input,
-  f1: SignalStoreFeature<EmptyFeatureResult & Input, F1>
-): SignalStoreFeature<EmptyFeatureResult & Input, F1>;
+  f1: SignalStoreFeature<Prettify<EmptyFeatureResult & Input>, F1>
+): SignalStoreFeature<Prettify<EmptyFeatureResult & Input>, F1>;
 export function signalStoreFeature<
   Input extends Partial<SignalStoreFeatureResult>,
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult
 >(
   input: Input,
-  f1: SignalStoreFeature<EmptyFeatureResult & Input, F1>,
+  f1: SignalStoreFeature<Prettify<EmptyFeatureResult & Input>, F1>,
   f2: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1]>,
     F2
   >
 ): SignalStoreFeature<
-  EmptyFeatureResult & Input,
+  Prettify<EmptyFeatureResult & Input>,
   MergeFeatureResults<[F1, F2]>
 >;
 export function signalStoreFeature<
@@ -102,17 +103,17 @@ export function signalStoreFeature<
   F3 extends SignalStoreFeatureResult
 >(
   input: Input,
-  f1: SignalStoreFeature<EmptyFeatureResult & Input, F1>,
+  f1: SignalStoreFeature<Prettify<EmptyFeatureResult & Input>, F1>,
   f2: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1]>,
     F2
   >,
   f3: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1, F2]>,
     F3
   >
 ): SignalStoreFeature<
-  EmptyFeatureResult & Input,
+  Prettify<EmptyFeatureResult & Input>,
   MergeFeatureResults<[F1, F2, F3]>
 >;
 export function signalStoreFeature<
@@ -123,21 +124,21 @@ export function signalStoreFeature<
   F4 extends SignalStoreFeatureResult
 >(
   Input: Input,
-  f1: SignalStoreFeature<EmptyFeatureResult & Input, F1>,
+  f1: SignalStoreFeature<Prettify<EmptyFeatureResult & Input>, F1>,
   f2: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1]>,
     F2
   >,
   f3: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1, F2]>,
     F3
   >,
   f4: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2, F3]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1, F2, F3]>,
     F4
   >
 ): SignalStoreFeature<
-  EmptyFeatureResult & Input,
+  Prettify<EmptyFeatureResult & Input>,
   MergeFeatureResults<[F1, F2, F3, F4]>
 >;
 export function signalStoreFeature<
@@ -149,25 +150,25 @@ export function signalStoreFeature<
   F5 extends SignalStoreFeatureResult
 >(
   input: Input,
-  f1: SignalStoreFeature<EmptyFeatureResult & Input, F1>,
+  f1: SignalStoreFeature<Prettify<EmptyFeatureResult & Input>, F1>,
   f2: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1]>,
     F2
   >,
   f3: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1, F2]>,
     F3
   >,
   f4: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2, F3]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1, F2, F3]>,
     F4
   >,
   f5: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2, F3, F4]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1, F2, F3, F4]>,
     F5
   >
 ): SignalStoreFeature<
-  EmptyFeatureResult & Input,
+  Prettify<EmptyFeatureResult & Input>,
   MergeFeatureResults<[F1, F2, F3, F4, F5]>
 >;
 export function signalStoreFeature<
@@ -180,29 +181,31 @@ export function signalStoreFeature<
   F6 extends SignalStoreFeatureResult
 >(
   input: Input,
-  f1: SignalStoreFeature<EmptyFeatureResult & Input, F1>,
+  f1: SignalStoreFeature<Prettify<EmptyFeatureResult & Input>, F1>,
   f2: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1]>,
     F2
   >,
   f3: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1, F2]>,
     F3
   >,
   f4: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2, F3]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1, F2, F3]>,
     F4
   >,
   f5: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2, F3, F4]>,
+    MergeFeatureResults<[Prettify<EmptyFeatureResult & Input>, F1, F2, F3, F4]>,
     F5
   >,
   f6: SignalStoreFeature<
-    MergeFeatureResults<[EmptyFeatureResult & Input, F1, F2, F3, F4, F5]>,
+    MergeFeatureResults<
+      [Prettify<EmptyFeatureResult & Input>, F1, F2, F3, F4, F5]
+    >,
     F6
   >
 ): SignalStoreFeature<
-  EmptyFeatureResult & Input,
+  Prettify<EmptyFeatureResult & Input>,
   MergeFeatureResults<[F1, F2, F3, F4, F5, F6]>
 >;
 

--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -7,7 +7,9 @@ export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 export type SignalStoreConfig = { providedIn: 'root' };
 
 export type SignalStoreSlices<State> = {
-  [Key in keyof State]: DeepSignal<State[Key]>;
+  [Key in keyof State]: State[Key] extends Record<string, unknown>
+    ? DeepSignal<State[Key]>
+    : Signal<State[Key]>;
 };
 
 export type SignalStore<FeatureResult extends SignalStoreFeatureResult> =

--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -1,14 +1,15 @@
 import { Signal } from '@angular/core';
 import { DeepSignal } from './deep-signal';
 import { SignalStateMeta } from './signal-state';
-
-export type Prettify<T> = { [K in keyof T]: T[K] } & {};
+import { IsUnknownRecord, Prettify } from './ts-helpers';
 
 export type SignalStoreConfig = { providedIn: 'root' };
 
 export type SignalStoreSlices<State> = {
   [Key in keyof State]: State[Key] extends Record<string, unknown>
-    ? DeepSignal<State[Key]>
+    ? IsUnknownRecord<State[Key]> extends true
+      ? Signal<State[Key]>
+      : DeepSignal<State[Key]>
     : Signal<State[Key]>;
 };
 

--- a/modules/signals/src/ts-helpers.ts
+++ b/modules/signals/src/ts-helpers.ts
@@ -1,0 +1,19 @@
+export type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+export type IsUnknownRecord<T> = string extends keyof T
+  ? true
+  : number extends keyof T
+  ? true
+  : false;
+
+export type HasOptionalProps<T> = T extends Required<T> ? false : true;
+
+export type HasFunctionKeys<T> = T extends Record<string, unknown>
+  ? {
+      [K in keyof T]: K extends keyof Function ? true : HasFunctionKeys<T[K]>;
+    }[keyof T]
+  : false;
+
+export type HasNestedFunctionKeys<T> = {
+  [K in keyof T]: HasFunctionKeys<T[K]>;
+}[keyof T];

--- a/modules/signals/src/with-hooks.ts
+++ b/modules/signals/src/with-hooks.ts
@@ -1,11 +1,11 @@
 import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
 import {
   EmptyFeatureResult,
-  Prettify,
   SignalStoreFeature,
   SignalStoreSlices,
   SignalStoreFeatureResult,
 } from './signal-store-models';
+import { Prettify } from './ts-helpers';
 
 type HooksFactory<Input extends SignalStoreFeatureResult> = (
   store: Prettify<

--- a/modules/signals/src/with-methods.ts
+++ b/modules/signals/src/with-methods.ts
@@ -4,12 +4,12 @@ import {
   EmptyFeatureResult,
   InnerSignalStore,
   MethodsDictionary,
-  Prettify,
   SignalsDictionary,
   SignalStoreFeature,
   SignalStoreFeatureResult,
   SignalStoreSlices,
 } from './signal-store-models';
+import { Prettify } from './ts-helpers';
 
 export function withMethods<
   Input extends SignalStoreFeatureResult,

--- a/modules/signals/src/with-signals.ts
+++ b/modules/signals/src/with-signals.ts
@@ -2,12 +2,12 @@ import { excludeKeys } from './helpers';
 import {
   EmptyFeatureResult,
   InnerSignalStore,
-  Prettify,
   SignalsDictionary,
   SignalStoreFeature,
   SignalStoreFeatureResult,
   SignalStoreSlices,
 } from './signal-store-models';
+import { Prettify } from './ts-helpers';
 
 export function withSignals<
   Input extends SignalStoreFeatureResult,

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -22,7 +22,7 @@ type WithStateCheck<State> = IsUnknownRecord<State> extends true
   ? '@ngrx/signals: root state slices cannot be optional'
   : HasNestedFunctionKeys<State> extends false | undefined
   ? unknown
-  : '@ngrx/signals: nested state slices must be different from `Function` properties';
+  : '@ngrx/signals: nested state slices cannot contain `Function` property or method names';
 
 export function withState<State extends Record<string, unknown>>(
   state: State & WithStateCheck<State>

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -2,7 +2,7 @@ import { toDeepSignal } from './deep-signal';
 import { excludeKeys } from './helpers';
 import { patchState } from './patch-state';
 import { selectSignal } from './select-signal';
-import { NotAllowedStateCheck, STATE_SIGNAL } from './signal-state';
+import { SignalStateInput, STATE_SIGNAL } from './signal-state';
 import {
   EmptyFeatureResult,
   InnerSignalStore,
@@ -11,21 +11,26 @@ import {
   SignalStoreFeatureResult,
 } from './signal-store-models';
 
+/**
+ * Root state slices cannot be optional.
+ */
+type WithStateInput<State> = State & {} extends Required<State>
+  ? keyof State extends never
+    ? State
+    : { [K in keyof State]: SignalStateInput<State[K]> }
+  : '@ngrx/signals: optional properties are not allowed';
+
 export function withState<State extends Record<string, unknown>>(
-  state: State & NotAllowedStateCheck<State>
+  state: WithStateInput<State>
 ): SignalStoreFeature<
   EmptyFeatureResult,
-  EmptyFeatureResult & {
-    state: State;
-  }
+  EmptyFeatureResult & { state: State }
 >;
 export function withState<State extends Record<string, unknown>>(
-  stateFactory: () => State & NotAllowedStateCheck<State>
+  stateFactory: () => WithStateInput<State>
 ): SignalStoreFeature<
   EmptyFeatureResult,
-  EmptyFeatureResult & {
-    state: State;
-  }
+  EmptyFeatureResult & { state: State }
 >;
 export function withState<State extends Record<string, unknown>>(
   stateOrFactory: State | (() => State)

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -2,7 +2,7 @@ import { toDeepSignal } from './deep-signal';
 import { excludeKeys } from './helpers';
 import { patchState } from './patch-state';
 import { selectSignal } from './select-signal';
-import { SignalStateInput, STATE_SIGNAL } from './signal-state';
+import { STATE_SIGNAL } from './signal-state';
 import {
   EmptyFeatureResult,
   InnerSignalStore,
@@ -10,24 +10,28 @@ import {
   SignalStoreFeature,
   SignalStoreFeatureResult,
 } from './signal-store-models';
+import {
+  HasNestedFunctionKeys,
+  HasOptionalProps,
+  IsUnknownRecord,
+} from './ts-helpers';
 
-/**
- * Root state slices cannot be optional.
- */
-type WithStateInput<State> = State & {} extends Required<State>
-  ? keyof State extends never
-    ? State
-    : { [K in keyof State]: SignalStateInput<State[K]> }
-  : '@ngrx/signals: state cannot contain optional properties';
+type WithStateCheck<State> = IsUnknownRecord<State> extends true
+  ? '@ngrx/signals: root state keys must be string literals'
+  : HasOptionalProps<State> extends true
+  ? '@ngrx/signals: root state slices cannot be optional'
+  : HasNestedFunctionKeys<State> extends false | undefined
+  ? unknown
+  : '@ngrx/signals: nested state slices must be different from `Function` properties';
 
 export function withState<State extends Record<string, unknown>>(
-  state: WithStateInput<State>
+  state: State & WithStateCheck<State>
 ): SignalStoreFeature<
   EmptyFeatureResult,
   EmptyFeatureResult & { state: State }
 >;
 export function withState<State extends Record<string, unknown>>(
-  stateFactory: () => WithStateInput<State>
+  stateFactory: () => State & WithStateCheck<State>
 ): SignalStoreFeature<
   EmptyFeatureResult,
   EmptyFeatureResult & { state: State }

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -18,7 +18,7 @@ type WithStateInput<State> = State & {} extends Required<State>
   ? keyof State extends never
     ? State
     : { [K in keyof State]: SignalStateInput<State[K]> }
-  : '@ngrx/signals: optional properties are not allowed';
+  : '@ngrx/signals: state cannot contain optional properties';
 
 export function withState<State extends Record<string, unknown>>(
   state: WithStateInput<State>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4065

1. `DeepSignal` result is not prettified:

```ts
const state = signalState({ user: { firstName: 'Marko' } });

const user = state.user; // type: DeepSignal<{ firstName: string }>
const firstName = user.firstName; // type: DeepSignal<string>
```

2. The state can contain function properties (`name`, `bind`, `call`, `apply`, etc.) which will throw a runtime error because signal function properties cannot be overridden.

3. Deep signals for unknown dictionaries are accidentally created:

```ts
type State = { foo: Record<string, { bar: number }> };
const state = signalState<State>({ foo: {} });

const foo = state.foo; // type: DeepSignal<Record<string, { bar: number }>
const foo = state.foo['asdf'] // type: DeepSignal<{ bar: number }>
```

4. Signal store allows the unknown dictionary to be the state type:

```ts
const Store = signalStore(
  withState<Record<string, { foo: number }>>({})
);

const store = new Store();
const x = store['x']; // type: DeepSignal<{ foo: number }>
const y = store['y']; // type: DeepSignal<{ foo: number }>
```

## What is the new behavior?

1. `DeepSignal` result is prettified:

```ts
const state = signalState({ user: { firstName: 'Marko' } });

const user = state.user; // type: DeepSignal<{ firstName: string }>
const firstName = user.firstName; // type: Signal<string> 👈
```

2. The state cannot contain function properties:

```ts
// compilation error: @ngrx/signals: signal state properties must be different from `Function` properties
const state = signalState({ bind: 'Marko' });
```

3. Deep signals for unknown dictionaries are not accidentally created:

```ts
type State = { foo: Record<string, { bar: number }> };
const state = signalState<State>({ foo: {} });

const foo = state.foo; // type: Signal<Record<string, { bar: number }>
const foo = state.foo['asdf'] // compilation error
```

4. Signal store doesn't allow the unknown dictionary to be the state type:

```ts
const Store = signalStore(
  // compilation error: @ngrx/signals: root state keys must be string literals
  withState<Record<string, { foo: number }>>({})
);

const store = new Store();
const x = store['x']; // type: DeepSignal<{ foo: number }> // compilation error
const y = store['y']; // type: DeepSignal<{ foo: number }> // compilation error
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
