### PR TITLE
fix(entity): set correct return type for getSelectors signature with parent selector

### DIFF
--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -1,3 +1,5 @@
+import { MemoizedSelector } from '@ngrx/store';
+
 export type Comparer<T> = (a: T, b: T) => number;
 
 export type IdSelectorStr<T> = (model: T) => string;
@@ -85,6 +87,25 @@ export type EntitySelectors<T, V> = {
   selectTotal: (state: V) => number;
 };
 
+export type MemoizedEntitySelectors<T, V> = {
+  selectIds: MemoizedSelector<
+    V,
+    string[] | number[],
+    (entityState: EntityState<T>) => string[] | number[]
+  >;
+  selectEntities: MemoizedSelector<
+    V,
+    Dictionary<T>,
+    (entityState: EntityState<T>) => Dictionary<T>
+  >;
+  selectAll: MemoizedSelector<V, T[], (entityState: EntityState<T>) => T[]>;
+  selectTotal: MemoizedSelector<
+    V,
+    number,
+    (entityState: EntityState<T>) => number
+  >;
+};
+
 export interface EntityAdapter<T> extends EntityStateAdapter<T> {
   selectId: IdSelector<T>;
   sortComparer: false | Comparer<T>;
@@ -93,5 +114,5 @@ export interface EntityAdapter<T> extends EntityStateAdapter<T> {
   getSelectors(): EntitySelectors<T, EntityState<T>>;
   getSelectors<V>(
     selectState: (state: V) => EntityState<T>
-  ): EntitySelectors<T, V>;
+  ): MemoizedEntitySelectors<T, V>;
 }

--- a/modules/entity/src/state_selectors.ts
+++ b/modules/entity/src/state_selectors.ts
@@ -1,11 +1,15 @@
 import { createSelector } from '@ngrx/store';
-import { EntityState, EntitySelectors } from './models';
+import {
+  EntityState,
+  EntitySelectors,
+  MemoizedEntitySelectors,
+} from './models';
 
 export function createSelectorsFactory<T>() {
   function getSelectors(): EntitySelectors<T, EntityState<T>>;
   function getSelectors<V>(
     selectState: (state: V) => EntityState<T>
-  ): EntitySelectors<T, V>;
+  ): MemoizedEntitySelectors<T, V>;
   function getSelectors(
     selectState?: (state: any) => EntityState<T>
   ): EntitySelectors<T, any> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

Closes #2751, #3172

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

```
BREAKING CHANGES:

Selectors returned by the `adapter.getSelectors` signature that accepts a parent selector are strongly typed.

BEFORE:

const {
  selectIds, // type: (state: object) => string[] | number[]
  selectEntities, // type: (state: object) => Dictionary<Book>
  selectAll, // type: (state: object) => Book[]
  selectTotal, // type: (state: object) => number
} = adapter.getSelectors(selectBooksState);

AFTER:

const {
  selectIds, // type: MemoizedSelector<object, string[] | number[]>
  selectEntities, // type: MemoizedSelector<object, Dictionary<Book>>
  selectAll, // type: MemoizedSelector<object, Book[]>
  selectTotal, // type: MemoizedSelector<object, number>
} = adapter.getSelectors(selectBooksState);
```