### PR TITLE
refactor(component-store): remove default equality function

### DIFF
--- a/modules/component-store/src/component-store.ts
+++ b/modules/component-store/src/component-store.ts
@@ -346,17 +346,10 @@ export class ComponentStore<T extends object> implements OnDestroy {
         ]
   ): Signal<unknown> {
     const selectSignalArgs = [...args];
-    const defaultEqualityFn: ValueEqualityFn<unknown> = (previous, current) =>
-      previous === current;
-
     const options: CreateComputedOptions<unknown> =
       typeof selectSignalArgs[args.length - 1] === 'object'
-        ? {
-            equal:
-              (selectSignalArgs.pop() as SelectSignalOptions<unknown>).equal ||
-              defaultEqualityFn,
-          }
-        : { equal: defaultEqualityFn };
+        ? (selectSignalArgs.pop() as SelectSignalOptions<unknown>)
+        : {};
     const projector = selectSignalArgs.pop() as (
       ...values: unknown[]
     ) => unknown;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?

In v17, Angular introduced a default equality check for reference types so it's not needed to pass it anymore explicitly.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
