### PR TITLE
refactor(store): remove default equality function

### DIFF
--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -114,9 +114,7 @@ export class Store<T = object>
     selector: (state: T) => K,
     options?: SelectSignalOptions<K>
   ): Signal<K> {
-    return computed(() => selector(this.state()), {
-      equal: options?.equal || ((previous, current) => previous === current),
-    });
+    return computed(() => selector(this.state()), options);
   }
 
   override lift<R>(operator: Operator<T, R>): Store<R> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?

In v17, Angular introduced a default equality check for reference types so it's not needed to pass it anymore explicitly.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
