### PR TITLE
docs: bring back orange color for code snippets

### DIFF
--- a/projects/ngrx.io/src/styles/2-modules/code/_code-theme.scss
+++ b/projects/ngrx.io/src/styles/2-modules/code/_code-theme.scss
@@ -129,7 +129,7 @@
       color: if($is-dark-theme, $code-lightgreen, #800);
     } /* string content */
     .kwd {
-      color: if($is-dark-theme, $code-lightteal, #00f);
+      color: if($is-dark-theme, $code-lightteal, #D86703);
     } /* a keyword */
     .com {
       color: if($is-dark-theme, $code-grey, #060);
@@ -138,7 +138,7 @@
       color: if($is-dark-theme, $code-lightred, purple);
     } /* a type name */
     .lit {
-      color: if($is-dark-theme, $code-lightpurple, mat.get-color-from-palette(ngrx.$gold, 900));
+      color: if($is-dark-theme, $code-lightpurple, #D86703);
     } /* a literal value */
     /* punctuation, lisp open bracket, lisp close bracket */
     .pun,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

I have bring back the orange color for code snippets at light mode

<img width="803" alt="image" src="https://github.com/ngrx/platform/assets/67691339/529dcd73-cdfe-4f4c-9e7b-a6b7bda8ec06">
