### PR TITLE
feat(signals): add `getState` function

### DIFF
--- a/modules/signals/spec/get-state.spec.ts
+++ b/modules/signals/spec/get-state.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  getState,
+  patchState,
+  signalState,
+  signalStore,
+  withState,
+} from '../src';
+import { effect } from '@angular/core';
+
+describe('getState', () => {
+  const initialState = {
+    user: {
+      firstName: 'John',
+      lastName: 'Smith',
+    },
+    foo: 'bar',
+    numbers: [1, 2, 3],
+    ngrx: 'signals',
+  };
+
+  describe('with signalStore', () => {
+    it('returns the state object', () => {
+      const Store = signalStore(withState(initialState));
+      const store = new Store();
+
+      expect(getState(store)).toEqual(initialState);
+    });
+
+    it('executes in the reactive context', () => {
+      const Store = signalStore(withState(initialState));
+      const store = new Store();
+
+      let executionCount = 0;
+
+      TestBed.runInInjectionContext(() => {
+        effect(() => {
+          getState(store);
+          executionCount++;
+        });
+      });
+
+      TestBed.flushEffects();
+      expect(executionCount).toBe(1);
+
+      patchState(store, { foo: 'baz' });
+
+      TestBed.flushEffects();
+      expect(executionCount).toBe(2);
+      expect(getState(store)).toEqual({ ...initialState, foo: 'baz' });
+    });
+  });
+});

--- a/modules/signals/src/get-state.ts
+++ b/modules/signals/src/get-state.ts
@@ -1,0 +1,7 @@
+import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
+
+export function getState<State extends Record<string, unknown>>(
+  signalState: SignalStateMeta<State>
+): State {
+  return signalState[STATE_SIGNAL]();
+}

--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -1,3 +1,4 @@
+export { getState } from './get-state';
 export { PartialStateUpdater, patchState } from './patch-state';
 export { signalState } from './signal-state';
 export { signalStore } from './signal-store';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, it's not possible to obtain the state object as a whole, via a single signal.

Closes #4116

## What is the new behavior?

Using the `getState` function will return the whole state object,  via the state signal under the hood.

```ts
import { getState, signalState } from '@ngrx/signals';

const itemsState = signalState({
  loading: false,
  items: [] as Item[]
});

getState(itemsState);  // returns the state object
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
