### PR TITLE
fix(effects): allow effects providers to be registered outside of the root injector

### DIFF
--- a/modules/effects/src/actions.ts
+++ b/modules/effects/src/actions.ts
@@ -8,7 +8,7 @@ import {
 import { Observable, OperatorFunction, Operator } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class Actions<V = Action> extends Observable<V> {
   constructor(@Inject(ScannedActionsSubject) source?: Observable<V>) {
     super();

--- a/modules/effects/src/effect_sources.ts
+++ b/modules/effects/src/effect_sources.ts
@@ -29,7 +29,7 @@ import {
   ObservableNotification,
 } from './utils';
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class EffectSources extends Subject<any> {
   constructor(
     private errorHandler: ErrorHandler,

--- a/modules/effects/src/effects_root_module.ts
+++ b/modules/effects/src/effects_root_module.ts
@@ -2,10 +2,26 @@ import { NgModule, Inject, Optional } from '@angular/core';
 import { Store, StoreRootModule, StoreFeatureModule } from '@ngrx/store';
 import { EffectsRunner } from './effects_runner';
 import { EffectSources } from './effect_sources';
-import { _ROOT_EFFECTS_GUARD, _ROOT_EFFECTS_INSTANCES } from './tokens';
+import {
+  EFFECTS_ERROR_HANDLER,
+  _ROOT_EFFECTS_GUARD,
+  _ROOT_EFFECTS_INSTANCES,
+} from './tokens';
 import { ROOT_EFFECTS_INIT } from './effects_actions';
+import { defaultEffectsErrorHandler } from './effects_error_handler';
+import { Actions } from './actions';
 
-@NgModule({})
+@NgModule({
+  providers: [
+    EffectSources,
+    EffectsRunner,
+    Actions,
+    {
+      provide: EFFECTS_ERROR_HANDLER,
+      useFactory: () => defaultEffectsErrorHandler,
+    },
+  ],
+})
 export class EffectsRootModule {
   constructor(
     private sources: EffectSources,

--- a/modules/effects/src/effects_runner.ts
+++ b/modules/effects/src/effects_runner.ts
@@ -4,7 +4,7 @@ import { Subscription } from 'rxjs';
 
 import { EffectSources } from './effect_sources';
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class EffectsRunner implements OnDestroy {
   private effectsSubscription: Subscription | null = null;
 

--- a/modules/effects/src/provide_effects.ts
+++ b/modules/effects/src/provide_effects.ts
@@ -15,6 +15,9 @@ import { EffectSources } from './effect_sources';
 import { rootEffectsInit as effectsInit } from './effects_actions';
 import { FunctionalEffect } from './models';
 import { getClasses, isClass } from './utils';
+import { EFFECTS_ERROR_HANDLER } from './tokens';
+import { defaultEffectsErrorHandler } from './effects_error_handler';
+import { Actions } from './actions';
 
 /**
  * Runs the provided effects.
@@ -66,6 +69,13 @@ export function provideEffects(
 
   return makeEnvironmentProviders([
     effectsClasses,
+    EffectSources,
+    EffectsRunner,
+    Actions,
+    {
+      provide: EFFECTS_ERROR_HANDLER,
+      useFactory: () => defaultEffectsErrorHandler,
+    },
     {
       provide: ENVIRONMENT_INITIALIZER,
       multi: true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Effects classes are registered using `providedIn: 'root'`. This doesn't allow effects to be used in a remote application when used with Module Federation unless the Store/Effects are registered within the host AppModule.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes https://github.com/ngrx/platform/issues/3700

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
