### PR TITLE
fix(signals): remove state checks for better DX

### DIFF
--- a/modules/signals/entities/src/with-entities.ts
+++ b/modules/signals/entities/src/with-entities.ts
@@ -54,7 +54,7 @@ export function withEntities<Entity>(config?: {
     withState({
       [entityMapKey]: {},
       [idsKey]: [],
-    } as any),
+    }),
     withComputed((store) => ({
       [entitiesKey]: computed(() => {
         const entityMap = store[entityMapKey]() as EntityMap<Entity>;

--- a/modules/signals/spec/signal-state.spec.ts
+++ b/modules/signals/spec/signal-state.spec.ts
@@ -1,8 +1,8 @@
 import { effect, isSignal } from '@angular/core';
 import * as angular from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { patchState, signalState } from '../src';
 import { STATE_SIGNAL } from '../src/signal-state';
-import { TestBed } from '@angular/core/testing';
 
 describe('signalState', () => {
   const initialState = {
@@ -85,6 +85,25 @@ describe('signalState', () => {
     expect((state[STATE_SIGNAL] as any).ngrx).toBe(undefined);
   });
 
+  it('overrides Function properties if state keys have the same name', () => {
+    const initialState = { name: { length: { length: 'ngrx' }, name: 20 } };
+    const state = signalState(initialState);
+
+    expect(state()).toBe(initialState);
+
+    expect(state.name()).toBe(initialState.name);
+    expect(isSignal(state.name)).toBe(true);
+
+    expect(state.name.name()).toBe(20);
+    expect(isSignal(state.name.name)).toBe(true);
+
+    expect(state.name.length()).toBe(initialState.name.length);
+    expect(isSignal(state.name.length)).toBe(true);
+
+    expect(state.name.length.length()).toBe('ngrx');
+    expect(isSignal(state.name.length.length)).toBe(true);
+  });
+
   it('emits new values only for affected signals', () => {
     TestBed.runInInjectionContext(() => {
       const state = signalState(initialState);
@@ -144,7 +163,7 @@ describe('signalState', () => {
     });
   });
 
-  it('should not emit if there was no change', () =>
+  it('does not emit if there was no change', () =>
     TestBed.runInInjectionContext(() => {
       let stateCounter = 0;
       let userCounter = 0;

--- a/modules/signals/spec/types/signal-state.types.spec.ts
+++ b/modules/signals/spec/types/signal-state.types.spec.ts
@@ -169,7 +169,7 @@ describe('signalState', () => {
 
     expectSnippet(snippet).toInfer(
       'state1Keys',
-      'unique symbol | unique symbol'
+      'unique symbol | keyof Signal<{ [key: string]: number; }>'
     );
 
     expectSnippet(snippet).toInfer(
@@ -179,7 +179,7 @@ describe('signalState', () => {
 
     expectSnippet(snippet).toInfer(
       'state2Keys',
-      'unique symbol | unique symbol'
+      'unique symbol | keyof Signal<{ [key: number]: { foo: string; }; }>'
     );
 
     expectSnippet(snippet).toInfer(
@@ -189,7 +189,7 @@ describe('signalState', () => {
 
     expectSnippet(snippet).toInfer(
       'state3Keys',
-      'unique symbol | unique symbol'
+      'unique symbol | keyof Signal<Record<string, { bar: number; }>>'
     );
 
     expectSnippet(snippet).toInfer(
@@ -270,50 +270,26 @@ describe('signalState', () => {
     expectSnippet(snippet).toInfer('z', 'Signal<boolean | undefined>');
   });
 
-  it('fails when state contains Function properties', () => {
-    expectSnippet(`const state = signalState({ name: '' })`).toFail(
-      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
-    );
+  it('succeeds when state contains Function properties', () => {
+    const snippet = `
+      const state1 = signalState({ name: 0 });
+      const state2 = signalState({ foo: { length: [] as boolean[] } });
+      const state3 = signalState({ name: { length: '' } });
 
-    expectSnippet(
-      `const state = signalState({ foo: { arguments: [] } })`
-    ).toFail(
-      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
-    );
+      const name = state1.name;
+      const length1 = state2.foo.length;
+      const name2 = state3.name;
+      const length2 = state3.name.length;
+    `;
 
-    expectSnippet(`
-      type State = { foo: { bar: { call?: boolean }; baz: number } };
-      const state = signalState<State>({ foo: { bar: {}, baz: 1 } });
-    `).toFail(
-      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
+    expectSnippet(snippet).toSucceed();
+    expectSnippet(snippet).toInfer('name', 'Signal<number>');
+    expectSnippet(snippet).toInfer('length1', 'Signal<boolean[]>');
+    expectSnippet(snippet).toInfer(
+      'name2',
+      'Signal<{ length: string; }> & Readonly<{ length: Signal<string>; }>'
     );
-
-    expectSnippet(
-      `const state = signalState({ foo: { apply: 'apply', bar: true } })`
-    ).toFail(
-      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
-    );
-
-    expectSnippet(`
-      type State = { bind?: { foo: string } };
-      const state = signalState<State>({ bind: { foo: 'bar' } });
-    `).toFail(
-      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
-    );
-
-    expectSnippet(
-      `const state = signalState({ foo: { bar: { prototype: [] }; baz: 1 } })`
-    ).toFail(
-      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
-    );
-
-    expectSnippet(`const state = signalState({ foo: { length: 10 } })`).toFail(
-      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
-    );
-
-    expectSnippet(`const state = signalState({ caller: '' })`).toFail(
-      /@ngrx\/signals: signal state cannot contain `Function` property or method names/
-    );
+    expectSnippet(snippet).toInfer('length2', 'Signal<string>');
   });
 
   it('fails when state is not an object', () => {

--- a/modules/signals/src/deep-signal.ts
+++ b/modules/signals/src/deep-signal.ts
@@ -1,5 +1,17 @@
-import { computed, Signal, untracked } from '@angular/core';
+import {
+  computed,
+  isSignal,
+  Signal as NgSignal,
+  untracked,
+} from '@angular/core';
 import { IsUnknownRecord } from './ts-helpers';
+
+// An extended Signal type that enables the correct typing
+// of nested signals with the `name' or `length' key.
+interface Signal<T> extends NgSignal<T> {
+  name: unknown;
+  length: unknown;
+}
 
 export type DeepSignal<T> = Signal<T> &
   (T extends Record<string, unknown>
@@ -26,8 +38,10 @@ export function toDeepSignal<T>(signal: Signal<T>): DeepSignal<T> {
         return target[prop];
       }
 
-      if (!target[prop]) {
-        target[prop] = computed(() => target()[prop]);
+      if (!isSignal(target[prop])) {
+        Object.defineProperty(target, prop, {
+          value: computed(() => target()[prop]),
+        });
       }
 
       return toDeepSignal(target[prop]);

--- a/modules/signals/src/signal-state.ts
+++ b/modules/signals/src/signal-state.ts
@@ -1,6 +1,5 @@
 import { signal, WritableSignal } from '@angular/core';
 import { DeepSignal, toDeepSignal } from './deep-signal';
-import { HasFunctionKeys } from './ts-helpers';
 
 export const STATE_SIGNAL = Symbol('STATE_SIGNAL');
 
@@ -8,15 +7,11 @@ export type SignalStateMeta<State extends Record<string, unknown>> = {
   [STATE_SIGNAL]: WritableSignal<State>;
 };
 
-type SignalStateCheck<State> = HasFunctionKeys<State> extends false | undefined
-  ? unknown
-  : '@ngrx/signals: signal state cannot contain `Function` property or method names';
-
 type SignalState<State extends Record<string, unknown>> = DeepSignal<State> &
   SignalStateMeta<State>;
 
 export function signalState<State extends Record<string, unknown>>(
-  initialState: State & SignalStateCheck<State>
+  initialState: State
 ): SignalState<State> {
   const stateSignal = signal(initialState as State);
   const deepSignal = toDeepSignal(stateSignal.asReadonly());

--- a/modules/signals/src/ts-helpers.ts
+++ b/modules/signals/src/ts-helpers.ts
@@ -5,15 +5,3 @@ export type IsUnknownRecord<T> = string extends keyof T
   : number extends keyof T
   ? true
   : false;
-
-export type HasOptionalProps<T> = T extends Required<T> ? false : true;
-
-export type HasFunctionKeys<T> = T extends Record<string, unknown>
-  ? {
-      [K in keyof T]: K extends keyof Function ? true : HasFunctionKeys<T[K]>;
-    }[keyof T]
-  : false;
-
-export type HasNestedFunctionKeys<T> = {
-  [K in keyof T]: HasFunctionKeys<T[K]>;
-}[keyof T];

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -9,28 +9,15 @@ import {
   SignalStoreFeature,
   SignalStoreFeatureResult,
 } from './signal-store-models';
-import {
-  HasNestedFunctionKeys,
-  HasOptionalProps,
-  IsUnknownRecord,
-} from './ts-helpers';
-
-type WithStateCheck<State> = IsUnknownRecord<State> extends true
-  ? '@ngrx/signals: root state keys must be string literals'
-  : HasOptionalProps<State> extends true
-  ? '@ngrx/signals: root state slices cannot be optional'
-  : HasNestedFunctionKeys<State> extends false | undefined
-  ? unknown
-  : '@ngrx/signals: nested state slices cannot contain `Function` property or method names';
 
 export function withState<State extends Record<string, unknown>>(
-  state: State & WithStateCheck<State>
+  state: State
 ): SignalStoreFeature<
   EmptyFeatureResult,
   EmptyFeatureResult & { state: State }
 >;
 export function withState<State extends Record<string, unknown>>(
-  stateFactory: () => State & WithStateCheck<State>
+  stateFactory: () => State
 ): SignalStoreFeature<
   EmptyFeatureResult,
   EmptyFeatureResult & { state: State }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

After some research, we realized that compilation errors that prevent creating deep signals with keys `name` or `length` (overriding Signal/Function properties) can be hard to debug, especially when migrating existing stores to the SignalStore.

```ts
// compilation error - it's not allowed to override `name` which is a property of `state` Signal
const state = signalState({ name: 'Marko' });
```

## What is the new behavior?

We're able to override Signal/Function properties and create strongly typed deep signals with keys `name` or `length`. We can also pass optional properties or unknown records as state type, which is not recommended, but everything will be still properly typed.

There is more flexibility but also more responsibility on the user side when defining state.

```ts
const state = signalState({ name: 'Marko' });
const name = state.name; // type: Signal<string> ✅ 
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
