### PR TITLE
feat(signals): provide ability to use interface as state type

### DIFF
--- a/modules/signals/entities/src/with-entities.ts
+++ b/modules/signals/entities/src/with-entities.ts
@@ -1,4 +1,4 @@
-import { computed } from '@angular/core';
+import { computed, Signal } from '@angular/core';
 import {
   SignalStoreFeature,
   signalStoreFeature,
@@ -55,7 +55,7 @@ export function withEntities<Entity>(config?: {
       [entityMapKey]: {},
       [idsKey]: [],
     }),
-    withComputed((store) => ({
+    withComputed((store: Record<string, Signal<unknown>>) => ({
       [entitiesKey]: computed(() => {
         const entityMap = store[entityMapKey]() as EntityMap<Entity>;
         const ids = store[idsKey]() as EntityId[];

--- a/modules/signals/spec/get-state.spec.ts
+++ b/modules/signals/spec/get-state.spec.ts
@@ -1,12 +1,6 @@
-import { TestBed } from '@angular/core/testing';
-import {
-  getState,
-  patchState,
-  signalState,
-  signalStore,
-  withState,
-} from '../src';
 import { effect } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { getState, patchState, signalStore, withState } from '../src';
 
 describe('getState', () => {
   const initialState = {
@@ -25,6 +19,10 @@ describe('getState', () => {
       const store = new Store();
 
       expect(getState(store)).toEqual(initialState);
+
+      patchState(store, { foo: 'baz' });
+
+      expect(getState(store)).toEqual({ ...initialState, foo: 'baz' });
     });
 
     it('executes in the reactive context', () => {
@@ -47,7 +45,6 @@ describe('getState', () => {
 
       TestBed.flushEffects();
       expect(executionCount).toBe(2);
-      expect(getState(store)).toEqual({ ...initialState, foo: 'baz' });
     });
   });
 });

--- a/modules/signals/src/deep-signal.ts
+++ b/modules/signals/src/deep-signal.ts
@@ -4,26 +4,22 @@ import {
   Signal as NgSignal,
   untracked,
 } from '@angular/core';
-import { IsUnknownRecord } from './ts-helpers';
+import { IsKnownRecord } from './ts-helpers';
 
 // An extended Signal type that enables the correct typing
-// of nested signals with the `name' or `length' key.
+// of nested signals with the `name` or `length` key.
 interface Signal<T> extends NgSignal<T> {
   name: unknown;
   length: unknown;
 }
 
 export type DeepSignal<T> = Signal<T> &
-  (T extends Record<string, unknown>
-    ? IsUnknownRecord<T> extends true
-      ? unknown
-      : Readonly<{
-          [K in keyof T]: T[K] extends Record<string, unknown>
-            ? IsUnknownRecord<T[K]> extends true
-              ? Signal<T[K]>
-              : DeepSignal<T[K]>
-            : Signal<T[K]>;
-        }>
+  (IsKnownRecord<T> extends true
+    ? Readonly<{
+        [K in keyof T]: IsKnownRecord<T[K]> extends true
+          ? DeepSignal<T[K]>
+          : Signal<T[K]>;
+      }>
     : unknown);
 
 export function toDeepSignal<T>(signal: Signal<T>): DeepSignal<T> {

--- a/modules/signals/src/get-state.ts
+++ b/modules/signals/src/get-state.ts
@@ -1,6 +1,6 @@
 import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
 
-export function getState<State extends Record<string, unknown>>(
+export function getState<State extends Record<string, any>>(
   signalState: SignalStateMeta<State>
 ): State {
   return signalState[STATE_SIGNAL]();

--- a/modules/signals/src/get-state.ts
+++ b/modules/signals/src/get-state.ts
@@ -1,6 +1,6 @@
 import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
 
-export function getState<State extends Record<string, any>>(
+export function getState<State extends object>(
   signalState: SignalStateMeta<State>
 ): State {
   return signalState[STATE_SIGNAL]();

--- a/modules/signals/src/patch-state.ts
+++ b/modules/signals/src/patch-state.ts
@@ -1,10 +1,10 @@
 import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
 
-export type PartialStateUpdater<State extends Record<string, any>> = (
+export type PartialStateUpdater<State extends object> = (
   state: State
 ) => Partial<State>;
 
-export function patchState<State extends Record<string, any>>(
+export function patchState<State extends object>(
   signalState: SignalStateMeta<State>,
   ...updaters: Array<Partial<State & {}> | PartialStateUpdater<State & {}>>
 ): void {

--- a/modules/signals/src/patch-state.ts
+++ b/modules/signals/src/patch-state.ts
@@ -1,10 +1,10 @@
 import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
 
-export type PartialStateUpdater<State extends Record<string, unknown>> = (
+export type PartialStateUpdater<State extends Record<string, any>> = (
   state: State
 ) => Partial<State>;
 
-export function patchState<State extends Record<string, unknown>>(
+export function patchState<State extends Record<string, any>>(
   signalState: SignalStateMeta<State>,
   ...updaters: Array<Partial<State & {}> | PartialStateUpdater<State & {}>>
 ): void {

--- a/modules/signals/src/signal-state.ts
+++ b/modules/signals/src/signal-state.ts
@@ -3,14 +3,14 @@ import { DeepSignal, toDeepSignal } from './deep-signal';
 
 export const STATE_SIGNAL = Symbol('STATE_SIGNAL');
 
-export type SignalStateMeta<State extends Record<string, unknown>> = {
+export type SignalStateMeta<State extends Record<string, any>> = {
   [STATE_SIGNAL]: WritableSignal<State>;
 };
 
-type SignalState<State extends Record<string, unknown>> = DeepSignal<State> &
+type SignalState<State extends Record<string, any>> = DeepSignal<State> &
   SignalStateMeta<State>;
 
-export function signalState<State extends Record<string, unknown>>(
+export function signalState<State extends Record<string, any>>(
   initialState: State
 ): SignalState<State> {
   const stateSignal = signal(initialState as State);

--- a/modules/signals/src/signal-state.ts
+++ b/modules/signals/src/signal-state.ts
@@ -3,14 +3,14 @@ import { DeepSignal, toDeepSignal } from './deep-signal';
 
 export const STATE_SIGNAL = Symbol('STATE_SIGNAL');
 
-export type SignalStateMeta<State extends Record<string, any>> = {
+export type SignalStateMeta<State extends object> = {
   [STATE_SIGNAL]: WritableSignal<State>;
 };
 
-type SignalState<State extends Record<string, any>> = DeepSignal<State> &
+type SignalState<State extends object> = DeepSignal<State> &
   SignalStateMeta<State>;
 
-export function signalState<State extends Record<string, any>>(
+export function signalState<State extends object>(
   initialState: State
 ): SignalState<State> {
   const stateSignal = signal(initialState as State);

--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -1,17 +1,19 @@
 import { Signal } from '@angular/core';
 import { DeepSignal } from './deep-signal';
 import { SignalStateMeta } from './signal-state';
-import { IsUnknownRecord, Prettify } from './ts-helpers';
+import { IsKnownRecord, Prettify } from './ts-helpers';
 
 export type SignalStoreConfig = { providedIn: 'root' };
 
-export type SignalStoreSlices<State> = {
-  [Key in keyof State]: State[Key] extends Record<string, unknown>
-    ? IsUnknownRecord<State[Key]> extends true
-      ? Signal<State[Key]>
-      : DeepSignal<State[Key]>
-    : Signal<State[Key]>;
-};
+export type SignalStoreSlices<State> = IsKnownRecord<
+  Prettify<State>
+> extends true
+  ? {
+      [Key in keyof State]: IsKnownRecord<State[Key]> extends true
+        ? DeepSignal<State[Key]>
+        : Signal<State[Key]>;
+    }
+  : {};
 
 export type SignalStore<FeatureResult extends SignalStoreFeatureResult> =
   Prettify<
@@ -31,7 +33,7 @@ export type SignalStoreHooks = {
 };
 
 export type InnerSignalStore<
-  State extends Record<string, unknown> = Record<string, unknown>,
+  State extends Record<string, any> = Record<string, any>,
   Signals extends SignalsDictionary = SignalsDictionary,
   Methods extends MethodsDictionary = MethodsDictionary
 > = {
@@ -42,7 +44,7 @@ export type InnerSignalStore<
 } & SignalStateMeta<State>;
 
 export type SignalStoreFeatureResult = {
-  state: Record<string, unknown>;
+  state: Record<string, any>;
   signals: SignalsDictionary;
   methods: MethodsDictionary;
 };

--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -33,7 +33,7 @@ export type SignalStoreHooks = {
 };
 
 export type InnerSignalStore<
-  State extends Record<string, any> = Record<string, any>,
+  State extends object = object,
   Signals extends SignalsDictionary = SignalsDictionary,
   Methods extends MethodsDictionary = MethodsDictionary
 > = {
@@ -44,7 +44,7 @@ export type InnerSignalStore<
 } & SignalStateMeta<State>;
 
 export type SignalStoreFeatureResult = {
-  state: Record<string, any>;
+  state: object;
   signals: SignalsDictionary;
   methods: MethodsDictionary;
 };

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -289,7 +289,7 @@ export function signalStore(
       (this as any)[STATE_SIGNAL] = innerStore[STATE_SIGNAL];
 
       for (const key in props) {
-        (this as any)[key] = props[key];
+        (this as any)[key] = (props as Record<string, unknown>)[key];
       }
 
       if (hooks.onInit) {

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -289,7 +289,7 @@ export function signalStore(
       (this as any)[STATE_SIGNAL] = innerStore[STATE_SIGNAL];
 
       for (const key in props) {
-        (this as any)[key] = (props as Record<string, unknown>)[key];
+        (this as any)[key] = props[key];
       }
 
       if (hooks.onInit) {

--- a/modules/signals/src/ts-helpers.ts
+++ b/modules/signals/src/ts-helpers.ts
@@ -1,7 +1,25 @@
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
+export type IsRecord<T> = T extends Record<string, any>
+  ? T extends unknown[]
+    ? false
+    : T extends Set<unknown>
+    ? false
+    : T extends Map<unknown, unknown>
+    ? false
+    : T extends Function
+    ? false
+    : true
+  : false;
+
 export type IsUnknownRecord<T> = string extends keyof T
   ? true
   : number extends keyof T
   ? true
+  : false;
+
+export type IsKnownRecord<T> = IsRecord<T> extends true
+  ? IsUnknownRecord<T> extends true
+    ? false
+    : true
   : false;

--- a/modules/signals/src/ts-helpers.ts
+++ b/modules/signals/src/ts-helpers.ts
@@ -1,6 +1,6 @@
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
-export type IsRecord<T> = T extends Record<string, any>
+export type IsRecord<T> = T extends object
   ? T extends unknown[]
     ? false
     : T extends Set<unknown>

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -10,19 +10,19 @@ import {
   SignalStoreFeatureResult,
 } from './signal-store-models';
 
-export function withState<State extends Record<string, any>>(
+export function withState<State extends object>(
   stateFactory: () => State
 ): SignalStoreFeature<
   EmptyFeatureResult,
   EmptyFeatureResult & { state: State }
 >;
-export function withState<State extends Record<string, any>>(
+export function withState<State extends object>(
   state: State
 ): SignalStoreFeature<
   EmptyFeatureResult,
   EmptyFeatureResult & { state: State }
 >;
-export function withState<State extends Record<string, any>>(
+export function withState<State extends object>(
   stateOrFactory: State | (() => State)
 ): SignalStoreFeature<
   SignalStoreFeatureResult,
@@ -39,7 +39,9 @@ export function withState<State extends Record<string, any>>(
     }));
 
     const slices = stateKeys.reduce((acc, key) => {
-      const slice = computed(() => store[STATE_SIGNAL]()[key]);
+      const slice = computed(
+        () => (store[STATE_SIGNAL]() as Record<string, unknown>)[key]
+      );
       return { ...acc, [key]: toDeepSignal(slice) };
     }, {} as SignalsDictionary);
     const signals = excludeKeys(store.signals, stateKeys);

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -10,19 +10,19 @@ import {
   SignalStoreFeatureResult,
 } from './signal-store-models';
 
-export function withState<State extends Record<string, unknown>>(
-  state: State
-): SignalStoreFeature<
-  EmptyFeatureResult,
-  EmptyFeatureResult & { state: State }
->;
-export function withState<State extends Record<string, unknown>>(
+export function withState<State extends Record<string, any>>(
   stateFactory: () => State
 ): SignalStoreFeature<
   EmptyFeatureResult,
   EmptyFeatureResult & { state: State }
 >;
-export function withState<State extends Record<string, unknown>>(
+export function withState<State extends Record<string, any>>(
+  state: State
+): SignalStoreFeature<
+  EmptyFeatureResult,
+  EmptyFeatureResult & { state: State }
+>;
+export function withState<State extends Record<string, any>>(
   stateOrFactory: State | (() => State)
 ): SignalStoreFeature<
   SignalStoreFeatureResult,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4117 

## What is the new behavior?

We can use interfaces as state/nested slice types:

```ts
interface User {
  id: number;
  name: string;
}

interface State {
  user: User;
}

const state = signalState<State>({
  user: { id: 1, name: 'Marko' },
});

state.user // type: DeepSignal<User>
state.user.name // type: Signal<string>
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
