### PR TITLE
[WIP] fix(signals): `getState` now returns computed signals too

### DIFF
--- a/modules/signals/spec/get-state.spec.ts
+++ b/modules/signals/spec/get-state.spec.ts
@@ -1,6 +1,12 @@
-import { effect } from '@angular/core';
+import { computed, effect } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { getState, patchState, signalStore, withState } from '../src';
+import {
+  getState,
+  patchState,
+  signalStore,
+  withComputed,
+  withState,
+} from '../src';
 
 describe('getState', () => {
   const initialState = {
@@ -45,6 +51,36 @@ describe('getState', () => {
 
       TestBed.flushEffects();
       expect(executionCount).toBe(2);
+    });
+
+    it('outputs the values of computed signals', () => {
+      const Store = signalStore(
+        withState(initialState),
+        withComputed((store) => ({
+          fullName: computed(
+            () => `${store.user.firstName()} ${store.user.lastName()}`
+          ),
+        }))
+      );
+      const store = new Store();
+
+      expect(getState(store)).toEqual({
+        ...initialState,
+        fullName: 'John Smith',
+      });
+
+      patchState(store, { user: { firstName: 'Jane', lastName: 'Doe' } });
+
+      console.log(getState(store));
+
+      expect(getState(store)).toEqual({
+        ...initialState,
+        user: {
+          firstName: 'Jane',
+          lastName: 'Doe',
+        },
+        fullName: 'Jane Doe',
+      });
     });
   });
 });

--- a/modules/signals/src/get-state.ts
+++ b/modules/signals/src/get-state.ts
@@ -1,7 +1,24 @@
+import { SIGNAL } from '@angular/core/primitives/signals';
+import { SignalsDictionary } from './signal-store-models';
 import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
+import { Prettify } from './ts-helpers';
 
-export function getState<State extends object>(
-  signalState: SignalStateMeta<State>
-): State {
-  return signalState[STATE_SIGNAL]();
+export function getState<State extends Record<string, unknown>>(
+  store: Prettify<SignalStateMeta<State> & SignalsDictionary>
+): Record<string, unknown> {
+  const state: Record<string, unknown> = store[STATE_SIGNAL]();
+
+  return Object.keys(store).reduce((acc, key) => {
+    // Ignore values already existing from the initial state
+    if (key in state) {
+      return acc;
+    }
+
+    const value = store[key];
+    if (SIGNAL in value) {
+      acc[key] = value();
+    }
+
+    return acc;
+  }, state);
 }


### PR DESCRIPTION
An attempted approach at fixing #4143, with a couple of flaws:

1. I'm using a potentially internal const — `SIGNAL` — from `'@angular/core/primitives/signals'`, which may not be ideal!
2. The test doesn't actually pass — it's not receiving the updated computed value in the final assertion in the test (I'm not sure why — it could be something to do with flushing effects, but adding `TestBed.flushEffects();` didn't help.

Pausing this here for any feedback before I continue.

---
_**I'll fill this in if/when this PR get accepted as a solution, before a proper review**_

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4143

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
