### PR TITLE
fix(signals): allow using signalStore and signalState in TS libs

### DIFF
--- a/modules/signals/spec/patch-state.spec.ts
+++ b/modules/signals/spec/patch-state.spec.ts
@@ -1,5 +1,5 @@
 import { patchState, signalState, signalStore, withState } from '../src';
-import { STATE_SIGNAL } from '../src/signal-state';
+import { STATE_SIGNAL } from '../src/state-signal';
 
 describe('patchState', () => {
   const initialState = {

--- a/modules/signals/spec/signal-state.spec.ts
+++ b/modules/signals/spec/signal-state.spec.ts
@@ -1,8 +1,8 @@
-import { effect, isSignal } from '@angular/core';
 import * as angular from '@angular/core';
+import { effect, isSignal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { patchState, signalState } from '../src';
-import { STATE_SIGNAL } from '../src/signal-state';
+import { STATE_SIGNAL } from '../src/state-signal';
 
 describe('signalState', () => {
   const initialState = {

--- a/modules/signals/spec/signal-store-feature.spec.ts
+++ b/modules/signals/spec/signal-store-feature.spec.ts
@@ -7,7 +7,7 @@ import {
   withMethods,
   withState,
 } from '../src';
-import { STATE_SIGNAL } from '../src/signal-state';
+import { STATE_SIGNAL } from '../src/state-signal';
 
 describe('signalStoreFeature', () => {
   function withCustomFeature1() {

--- a/modules/signals/spec/signal-store.spec.ts
+++ b/modules/signals/spec/signal-store.spec.ts
@@ -8,7 +8,7 @@ import {
   withMethods,
   withState,
 } from '../src';
-import { STATE_SIGNAL } from '../src/signal-state';
+import { STATE_SIGNAL } from '../src/state-signal';
 import { createLocalService } from './helpers';
 
 describe('signalStore', () => {

--- a/modules/signals/spec/types/signal-store.types.spec.ts
+++ b/modules/signals/spec/types/signal-store.types.spec.ts
@@ -33,7 +33,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'Store',
-      'Type<{ foo: Signal<string>; bar: Signal<number[]>; [STATE_SIGNAL]: WritableSignal<{ foo: string; bar: number[]; }>; }>'
+      'Type<{ foo: Signal<string>; bar: Signal<number[]>; } & StateSignal<{ foo: string; bar: number[]; }>>'
     );
   });
 
@@ -63,7 +63,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ user: DeepSignal<{ age: number; details: { first: string; flags: boolean[]; }; }>; [STATE_SIGNAL]: WritableSignal<{ user: { age: number; details: { first: string; flags: boolean[]; }; }; }>; }'
+      '{ user: DeepSignal<{ age: number; details: { first: string; flags: boolean[]; }; }>; } & StateSignal<{ user: { age: number; details: { first: string; flags: boolean[]; }; }; }>'
     );
 
     expectSnippet(snippet).toInfer(
@@ -203,10 +203,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toSucceed();
 
-    expectSnippet(snippet).toInfer(
-      'Store',
-      'Type<{ [STATE_SIGNAL]: WritableSignal<{}>; }>'
-    );
+    expectSnippet(snippet).toInfer('Store', 'Type<{} & StateSignal<{}>>');
   });
 
   it('succeeds when state slices are union types', () => {
@@ -237,7 +234,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ foo: Signal<number | { s: string; }>; bar: DeepSignal<{ baz: { b: boolean; } | null; }>; x: DeepSignal<{ y: { z: number | undefined; }; }>; [STATE_SIGNAL]: WritableSignal<...>; }'
+      '{ foo: Signal<number | { s: string; }>; bar: DeepSignal<{ baz: { b: boolean; } | null; }>; x: DeepSignal<{ y: { z: number | undefined; }; }>; } & StateSignal<{ foo: number | { ...; }; bar: { ...; }; x: { ...; }; }>'
     );
 
     expectSnippet(snippet).toInfer('foo', 'Signal<number | { s: string; }>');
@@ -277,7 +274,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet1).toInfer(
       'Store',
-      'Type<{ name: DeepSignal<{ x: { y: string; }; }>; arguments: Signal<number[]>; call: Signal<boolean>; [STATE_SIGNAL]: WritableSignal<{ name: { x: { y: string; }; }; arguments: number[]; call: boolean; }>; }>'
+      'Type<{ name: DeepSignal<{ x: { y: string; }; }>; arguments: Signal<number[]>; call: Signal<boolean>; } & StateSignal<{ name: { x: { y: string; }; }; arguments: number[]; call: boolean; }>>'
     );
 
     const snippet2 = `
@@ -294,7 +291,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet2).toInfer(
       'Store',
-      ' Type<{ apply: Signal<string>; bind: DeepSignal<{ foo: string; }>; prototype: Signal<string[]>; [STATE_SIGNAL]: WritableSignal<{ apply: string; bind: { foo: string; }; prototype: string[]; }>; }>'
+      'Type<{ apply: Signal<string>; bind: DeepSignal<{ foo: string; }>; prototype: Signal<string[]>; } & StateSignal<{ apply: string; bind: { foo: string; }; prototype: string[]; }>>'
     );
 
     const snippet3 = `
@@ -310,7 +307,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet3).toInfer(
       'Store',
-      'Type<{ length: Signal<number>; caller: Signal<undefined>; [STATE_SIGNAL]: WritableSignal<{ length: number; caller: undefined; }>; }>'
+      'Type<{ length: Signal<number>; caller: Signal<undefined>; } & StateSignal<{ length: number; caller: undefined; }>>'
     );
   });
 
@@ -365,7 +362,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ bar: DeepSignal<{ baz?: number | undefined; }>; x: DeepSignal<{ y?: { z: boolean; } | undefined; }>; [STATE_SIGNAL]: WritableSignal<{ bar: { baz?: number | undefined; }; x: { y?: { ...; } | undefined; }; }>; }'
+      '{ bar: DeepSignal<{ baz?: number | undefined; }>; x: DeepSignal<{ y?: { z: boolean; } | undefined; }>; } & StateSignal<{ bar: { baz?: number | undefined; }; x: { y?: { z: boolean; } | undefined; }; }>'
     );
 
     expectSnippet(snippet).toInfer(
@@ -594,7 +591,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ ngrx: Signal<string>; x: DeepSignal<{ y: string; }>; signals: Signal<number[]>; mgmt: (arg: boolean) => number; [STATE_SIGNAL]: WritableSignal<{ ngrx: string; x: { y: string; }; }>; }'
+      '{ ngrx: Signal<string>; x: DeepSignal<{ y: string; }>; signals: Signal<number[]>; mgmt: (arg: boolean) => number; } & StateSignal<{ ngrx: string; x: { y: string; }; }>'
     );
   });
 
@@ -622,7 +619,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ foo: Signal<number>; bar: Signal<string>; baz: (x: number) => void; [STATE_SIGNAL]: WritableSignal<{ foo: number; }>; }'
+      '{ foo: Signal<number>; bar: Signal<string>; baz: (x: number) => void; } & StateSignal<{ foo: number; }>'
     );
   });
 

--- a/modules/signals/spec/with-state.spec.ts
+++ b/modules/signals/spec/with-state.spec.ts
@@ -1,6 +1,6 @@
 import { isSignal, signal } from '@angular/core';
 import { withComputed, withMethods, withState } from '../src';
-import { STATE_SIGNAL } from '../src/signal-state';
+import { STATE_SIGNAL } from '../src/state-signal';
 import { getInitialInnerStore } from '../src/signal-store';
 
 describe('withState', () => {

--- a/modules/signals/src/deep-signal.ts
+++ b/modules/signals/src/deep-signal.ts
@@ -8,7 +8,7 @@ import { IsKnownRecord } from './ts-helpers';
 
 // An extended Signal type that enables the correct typing
 // of nested signals with the `name` or `length` key.
-interface Signal<T> extends NgSignal<T> {
+export interface Signal<T> extends NgSignal<T> {
   name: unknown;
   length: unknown;
 }

--- a/modules/signals/src/get-state.ts
+++ b/modules/signals/src/get-state.ts
@@ -1,7 +1,7 @@
-import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
+import { STATE_SIGNAL, StateSignal } from './state-signal';
 
 export function getState<State extends object>(
-  signalState: SignalStateMeta<State>
+  stateSignal: StateSignal<State>
 ): State {
-  return signalState[STATE_SIGNAL]();
+  return stateSignal[STATE_SIGNAL]();
 }

--- a/modules/signals/src/patch-state.ts
+++ b/modules/signals/src/patch-state.ts
@@ -1,14 +1,14 @@
-import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
+import { STATE_SIGNAL, StateSignal } from './state-signal';
 
 export type PartialStateUpdater<State extends object> = (
   state: State
 ) => Partial<State>;
 
 export function patchState<State extends object>(
-  signalState: SignalStateMeta<State>,
+  stateSignal: StateSignal<State>,
   ...updaters: Array<Partial<State & {}> | PartialStateUpdater<State & {}>>
 ): void {
-  signalState[STATE_SIGNAL].update((currentState) =>
+  stateSignal[STATE_SIGNAL].update((currentState) =>
     updaters.reduce(
       (nextState: State, updater) => ({
         ...nextState,

--- a/modules/signals/src/signal-state.ts
+++ b/modules/signals/src/signal-state.ts
@@ -1,14 +1,8 @@
-import { signal, WritableSignal } from '@angular/core';
+import { signal } from '@angular/core';
+import { STATE_SIGNAL, StateSignal } from './state-signal';
 import { DeepSignal, toDeepSignal } from './deep-signal';
 
-export const STATE_SIGNAL = Symbol('STATE_SIGNAL');
-
-export type SignalStateMeta<State extends object> = {
-  [STATE_SIGNAL]: WritableSignal<State>;
-};
-
-type SignalState<State extends object> = DeepSignal<State> &
-  SignalStateMeta<State>;
+type SignalState<State extends object> = DeepSignal<State> & StateSignal<State>;
 
 export function signalState<State extends object>(
   initialState: State

--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -1,6 +1,6 @@
 import { Signal } from '@angular/core';
 import { DeepSignal } from './deep-signal';
-import { SignalStateMeta } from './signal-state';
+import { StateSignal } from './state-signal';
 import { IsKnownRecord, Prettify } from './ts-helpers';
 
 export type SignalStoreConfig = { providedIn: 'root' };
@@ -15,12 +15,11 @@ export type SignalStoreSlices<State> = IsKnownRecord<
     }
   : {};
 
-export type SignalStore<FeatureResult extends SignalStoreFeatureResult> =
+export type SignalStoreProps<FeatureResult extends SignalStoreFeatureResult> =
   Prettify<
     SignalStoreSlices<FeatureResult['state']> &
       FeatureResult['signals'] &
-      FeatureResult['methods'] &
-      SignalStateMeta<Prettify<FeatureResult['state']>>
+      FeatureResult['methods']
   >;
 
 export type SignalsDictionary = Record<string, Signal<unknown>>;
@@ -41,7 +40,7 @@ export type InnerSignalStore<
   signals: Signals;
   methods: Methods;
   hooks: SignalStoreHooks;
-} & SignalStateMeta<State>;
+} & StateSignal<State>;
 
 export type SignalStoreFeatureResult = {
   state: object;
@@ -61,7 +60,7 @@ export type SignalStoreFeature<
 export type MergeFeatureResults<
   FeatureResults extends SignalStoreFeatureResult[]
 > = FeatureResults extends []
-  ? {}
+  ? EmptyFeatureResult
   : FeatureResults extends [infer First extends SignalStoreFeatureResult]
   ? First
   : FeatureResults extends [

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -7,75 +7,65 @@ import {
   signal,
   Type,
 } from '@angular/core';
-import { STATE_SIGNAL } from './signal-state';
+import { STATE_SIGNAL, StateSignal } from './state-signal';
 import {
   EmptyFeatureResult,
   InnerSignalStore,
   MergeFeatureResults,
-  SignalStore,
+  SignalStoreProps,
   SignalStoreConfig,
   SignalStoreFeature,
   SignalStoreFeatureResult,
 } from './signal-store-models';
+import { Prettify } from './ts-helpers';
 
 export function signalStore<F1 extends SignalStoreFeatureResult>(
   f1: SignalStoreFeature<EmptyFeatureResult, F1>
-): Type<SignalStore<F1>>;
-export function signalStore<
-  F1 extends SignalStoreFeatureResult,
-  F2 extends SignalStoreFeatureResult
->(
-  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
-  f2: SignalStoreFeature<{} & F1, F2>
-): Type<SignalStore<MergeFeatureResults<[F1, F2]>>>;
+): Type<SignalStoreProps<F1> & StateSignal<Prettify<F1['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
-  F3 extends SignalStoreFeatureResult
+  R extends SignalStoreFeatureResult = MergeFeatureResults<[F1, F2]>
 >(
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
-  f2: SignalStoreFeature<{} & F1, F2>,
-  f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3]>>>;
+  f2: SignalStoreFeature<{} & F1, F2>
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
   F3 extends SignalStoreFeatureResult,
-  F4 extends SignalStoreFeatureResult
+  R extends SignalStoreFeatureResult = MergeFeatureResults<[F1, F2, F3]>
 >(
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
-  f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>,
-  f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4]>>>;
+  f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
   F3 extends SignalStoreFeatureResult,
   F4 extends SignalStoreFeatureResult,
-  F5 extends SignalStoreFeatureResult
+  R extends SignalStoreFeatureResult = MergeFeatureResults<[F1, F2, F3, F4]>
 >(
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>,
-  f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>,
-  f5: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4]>, F5>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5]>>>;
+  f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
   F3 extends SignalStoreFeatureResult,
   F4 extends SignalStoreFeatureResult,
   F5 extends SignalStoreFeatureResult,
-  F6 extends SignalStoreFeatureResult
+  R extends SignalStoreFeatureResult = MergeFeatureResults<[F1, F2, F3, F4, F5]>
 >(
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>,
   f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>,
-  f5: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4]>, F5>,
-  f6: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5]>, F6>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5, F6]>>>;
+  f5: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4]>, F5>
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
@@ -83,16 +73,17 @@ export function signalStore<
   F4 extends SignalStoreFeatureResult,
   F5 extends SignalStoreFeatureResult,
   F6 extends SignalStoreFeatureResult,
-  F7 extends SignalStoreFeatureResult
+  R extends SignalStoreFeatureResult = MergeFeatureResults<
+    [F1, F2, F3, F4, F5, F6]
+  >
 >(
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>,
   f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>,
   f5: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4]>, F5>,
-  f6: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5]>, F6>,
-  f7: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5, F6]>, F7>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7]>>>;
+  f6: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5]>, F6>
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
@@ -101,7 +92,9 @@ export function signalStore<
   F5 extends SignalStoreFeatureResult,
   F6 extends SignalStoreFeatureResult,
   F7 extends SignalStoreFeatureResult,
-  F8 extends SignalStoreFeatureResult
+  R extends SignalStoreFeatureResult = MergeFeatureResults<
+    [F1, F2, F3, F4, F5, F6, F7]
+  >
 >(
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
@@ -109,9 +102,8 @@ export function signalStore<
   f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>,
   f5: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4]>, F5>,
   f6: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5]>, F6>,
-  f7: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5, F6]>, F7>,
-  f8: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7]>, F8>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7, F8]>>>;
+  f7: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5, F6]>, F7>
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
@@ -121,7 +113,32 @@ export function signalStore<
   F6 extends SignalStoreFeatureResult,
   F7 extends SignalStoreFeatureResult,
   F8 extends SignalStoreFeatureResult,
-  F9 extends SignalStoreFeatureResult
+  R extends SignalStoreFeatureResult = MergeFeatureResults<
+    [F1, F2, F3, F4, F5, F6, F7, F8]
+  >
+>(
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>,
+  f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>,
+  f5: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4]>, F5>,
+  f6: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5]>, F6>,
+  f7: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5, F6]>, F7>,
+  f8: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7]>, F8>
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  F8 extends SignalStoreFeatureResult,
+  F9 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = MergeFeatureResults<
+    [F1, F2, F3, F4, F5, F6, F7, F8, F9]
+  >
 >(
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
@@ -135,48 +152,52 @@ export function signalStore<
     MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7, F8]>,
     F9
   >
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7, F8, F9]>>>;
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 
 export function signalStore<F1 extends SignalStoreFeatureResult>(
   config: SignalStoreConfig,
   f1: SignalStoreFeature<EmptyFeatureResult, F1>
-): Type<SignalStore<F1>>;
+): Type<SignalStoreProps<F1> & StateSignal<Prettify<F1['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
-  F2 extends SignalStoreFeatureResult
+  F2 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = MergeFeatureResults<[F1, F2]>
 >(
   config: SignalStoreConfig,
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>
-): Type<SignalStore<MergeFeatureResults<[F1, F2]>>>;
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
-  F3 extends SignalStoreFeatureResult
+  F3 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = MergeFeatureResults<[F1, F2, F3]>
 >(
   config: SignalStoreConfig,
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3]>>>;
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
   F3 extends SignalStoreFeatureResult,
-  F4 extends SignalStoreFeatureResult
+  F4 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = MergeFeatureResults<[F1, F2, F3, F4]>
 >(
   config: SignalStoreConfig,
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>,
   f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4]>>>;
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
   F3 extends SignalStoreFeatureResult,
   F4 extends SignalStoreFeatureResult,
-  F5 extends SignalStoreFeatureResult
+  F5 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = MergeFeatureResults<[F1, F2, F3, F4, F5]>
 >(
   config: SignalStoreConfig,
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
@@ -184,14 +205,17 @@ export function signalStore<
   f3: SignalStoreFeature<MergeFeatureResults<[F1, F2]>, F3>,
   f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>,
   f5: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4]>, F5>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5]>>>;
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
   F3 extends SignalStoreFeatureResult,
   F4 extends SignalStoreFeatureResult,
   F5 extends SignalStoreFeatureResult,
-  F6 extends SignalStoreFeatureResult
+  F6 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = MergeFeatureResults<
+    [F1, F2, F3, F4, F5, F6]
+  >
 >(
   config: SignalStoreConfig,
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
@@ -200,7 +224,7 @@ export function signalStore<
   f4: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3]>, F4>,
   f5: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4]>, F5>,
   f6: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5]>, F6>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5, F6]>>>;
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
@@ -208,7 +232,10 @@ export function signalStore<
   F4 extends SignalStoreFeatureResult,
   F5 extends SignalStoreFeatureResult,
   F6 extends SignalStoreFeatureResult,
-  F7 extends SignalStoreFeatureResult
+  F7 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = MergeFeatureResults<
+    [F1, F2, F3, F4, F5, F6, F7]
+  >
 >(
   config: SignalStoreConfig,
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
@@ -218,7 +245,7 @@ export function signalStore<
   f5: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4]>, F5>,
   f6: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5]>, F6>,
   f7: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5, F6]>, F7>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7]>>>;
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
@@ -227,7 +254,10 @@ export function signalStore<
   F5 extends SignalStoreFeatureResult,
   F6 extends SignalStoreFeatureResult,
   F7 extends SignalStoreFeatureResult,
-  F8 extends SignalStoreFeatureResult
+  F8 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = MergeFeatureResults<
+    [F1, F2, F3, F4, F5, F6, F7, F8]
+  >
 >(
   config: SignalStoreConfig,
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
@@ -238,7 +268,7 @@ export function signalStore<
   f6: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5]>, F6>,
   f7: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5, F6]>, F7>,
   f8: SignalStoreFeature<MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7]>, F8>
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7, F8]>>>;
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 export function signalStore<
   F1 extends SignalStoreFeatureResult,
   F2 extends SignalStoreFeatureResult,
@@ -248,7 +278,10 @@ export function signalStore<
   F6 extends SignalStoreFeatureResult,
   F7 extends SignalStoreFeatureResult,
   F8 extends SignalStoreFeatureResult,
-  F9 extends SignalStoreFeatureResult
+  F9 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = MergeFeatureResults<
+    [F1, F2, F3, F4, F5, F6, F7, F8, F9]
+  >
 >(
   config: SignalStoreConfig,
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
@@ -263,11 +296,11 @@ export function signalStore<
     MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7, F8]>,
     F9
   >
-): Type<SignalStore<MergeFeatureResults<[F1, F2, F3, F4, F5, F6, F7, F8, F9]>>>;
+): Type<SignalStoreProps<R> & StateSignal<Prettify<R['state']>>>;
 
 export function signalStore(
   ...args: [SignalStoreConfig, ...SignalStoreFeature[]] | SignalStoreFeature[]
-): Type<SignalStore<any>> {
+): Type<SignalStoreProps<any>> {
   const signalStoreArgs = [...args];
 
   const config: Partial<SignalStoreConfig> =

--- a/modules/signals/src/state-signal.ts
+++ b/modules/signals/src/state-signal.ts
@@ -1,0 +1,7 @@
+import { WritableSignal } from '@angular/core';
+
+export const STATE_SIGNAL = Symbol('STATE_SIGNAL');
+
+export type StateSignal<State extends object> = {
+  [STATE_SIGNAL]: WritableSignal<State>;
+};

--- a/modules/signals/src/with-hooks.ts
+++ b/modules/signals/src/with-hooks.ts
@@ -1,9 +1,9 @@
-import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
+import { STATE_SIGNAL, StateSignal } from './state-signal';
 import {
   EmptyFeatureResult,
   SignalStoreFeature,
-  SignalStoreSlices,
   SignalStoreFeatureResult,
+  SignalStoreSlices,
 } from './signal-store-models';
 import { Prettify } from './ts-helpers';
 
@@ -12,7 +12,7 @@ type HooksFactory<Input extends SignalStoreFeatureResult> = (
     SignalStoreSlices<Input['state']> &
       Input['signals'] &
       Input['methods'] &
-      SignalStateMeta<Prettify<Input['state']>>
+      StateSignal<Prettify<Input['state']>>
   >
 ) => void;
 

--- a/modules/signals/src/with-methods.ts
+++ b/modules/signals/src/with-methods.ts
@@ -1,5 +1,5 @@
 import { excludeKeys } from './helpers';
-import { STATE_SIGNAL, SignalStateMeta } from './signal-state';
+import { STATE_SIGNAL, StateSignal } from './state-signal';
 import {
   EmptyFeatureResult,
   InnerSignalStore,
@@ -20,7 +20,7 @@ export function withMethods<
       SignalStoreSlices<Input['state']> &
         Input['signals'] &
         Input['methods'] &
-        SignalStateMeta<Prettify<Input['state']>>
+        StateSignal<Prettify<Input['state']>>
     >
   ) => Methods
 ): SignalStoreFeature<Input, EmptyFeatureResult & { methods: Methods }> {

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -1,7 +1,7 @@
 import { computed } from '@angular/core';
 import { toDeepSignal } from './deep-signal';
 import { excludeKeys } from './helpers';
-import { STATE_SIGNAL } from './signal-state';
+import { STATE_SIGNAL } from './state-signal';
 import {
   EmptyFeatureResult,
   InnerSignalStore,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4151 

## What is the new behavior?

`signalStore` and `signalState` can be used/exported in projects that have `tsconfig` with `"declaration": true`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is a workaround for the following TS bug: https://github.com/microsoft/TypeScript/issues/37888