### PR TITLE
docs: Add link to migration path for selector props deprecation notice

### DIFF
--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -29,7 +29,7 @@ export interface MemoizedSelector<
 }
 
 /**
- * @deprecated Selectors with props are deprecated, for more info see {@link https://github.com/ngrx/platform/issues/2980 Github Issue}
+ * @deprecated Selectors with props are deprecated, for more info see {@link https://github.com/ngrx/platform/issues/2980 Github Issue} or {@link https://ngrx.io/guide/migration/v12#ngrxstore suggested migration}
  */
 export interface MemoizedSelectorWithProps<
   State,

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -29,7 +29,7 @@ export interface MemoizedSelector<
 }
 
 /**
- * @deprecated Selectors with props are deprecated, for more info see {@link https://github.com/ngrx/platform/issues/2980 Github Issue} or {@link https://ngrx.io/guide/migration/v12#ngrxstore suggested migration}
+ * @deprecated Selectors with props are deprecated, for more info see the {@link https://ngrx.io/guide/migration/v12#ngrxstore migration guide}
  */
 export interface MemoizedSelectorWithProps<
   State,


### PR DESCRIPTION
Principle of least surprise.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

People stumble on this notice and they have to read a long issue, rather than the actual solution

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This issue on selector props deprecation, may be quite controversial. But it seems like the dust is settled, except for this little notice. I want to ensure that I use the tools the way they are intended to be used. So I go and follow this link and read on some of it. Just to find out the solution is quite simple.

I program on many different platforms, and I really don't keep up with all this little issues. Please don't waste my bandwidth is it's easily avoidable.