### PR TITLE
feat(signals): add storage subpackage

### DIFF
--- a/modules/signals/project.json
+++ b/modules/signals/project.json
@@ -39,7 +39,9 @@
           "modules/signals/entities/**/*.ts",
           "modules/signals/entities/**/*.html",
           "modules/signals/rxjs-interop/**/*.ts",
-          "modules/signals/rxjs-interop/**/*.html"
+          "modules/signals/rxjs-interop/**/*.html",
+          "modules/signals/storage/**/*.ts",
+          "modules/signals/storage/**/*.html"
         ]
       },
       "outputs": ["{options.outputFile}"]

--- a/modules/signals/storage/index.ts
+++ b/modules/signals/storage/index.ts
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/modules/signals/storage/ng-package.json
+++ b/modules/signals/storage/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/modules/signals/storage/spec/with-storage-sync.spec.ts
+++ b/modules/signals/storage/spec/with-storage-sync.spec.ts
@@ -1,0 +1,239 @@
+import { patchState, signalStore, withState } from '@ngrx/signals';
+import { withStorageSync } from '../src';
+import { TestBed } from '@angular/core/testing';
+import { getInitialInnerStore } from '../../src/signal-store';
+import { STATE_SIGNAL } from '../../src/state-signal';
+
+interface StateObject {
+  foo: string;
+  age: number;
+}
+const initialState: StateObject = {
+  foo: 'bar',
+  age: 18,
+};
+const key = 'FooBar';
+const initialStore = getInitialInnerStore();
+
+describe('withStorageSync', () => {
+  beforeEach(() => {
+    // make sure to start with a clean storage
+    localStorage.removeItem(key);
+  });
+
+  it('adds methods for storage access to the store', () => {
+    TestBed.runInInjectionContext(() => {
+      const store = withStorageSync(key)(initialStore);
+
+      expect(Object.keys(store.methods)).toEqual([
+        'clearStorage',
+        'readFromStorage',
+        'writeToStorage',
+      ]);
+    });
+  });
+
+  it('offers manual sync using provided methods', () => {
+    TestBed.runInInjectionContext(() => {
+      // prefill storage
+      localStorage.setItem(
+        key,
+        JSON.stringify({
+          foo: 'baz',
+          age: 99,
+        } as StateObject)
+      );
+
+      const Store = signalStore(withStorageSync({ key, autoSync: false }));
+      const store = new Store();
+      expect(store[STATE_SIGNAL]()).toEqual({});
+
+      store.readFromStorage();
+      expect(store[STATE_SIGNAL]()).toEqual({
+        foo: 'baz',
+        age: 99,
+      });
+
+      patchState(store, { ...initialState });
+      TestBed.flushEffects();
+
+      let storeItem = JSON.parse(localStorage.getItem(key) || '{}');
+      expect(storeItem).toEqual({
+        foo: 'baz',
+        age: 99,
+      });
+
+      store.writeToStorage();
+      storeItem = JSON.parse(localStorage.getItem(key) || '{}');
+      expect(storeItem).toEqual({
+        ...initialState,
+      });
+
+      store.clearStorage();
+      storeItem = localStorage.getItem(key);
+      expect(storeItem).toEqual(null);
+    });
+  });
+
+  describe('autoSync', () => {
+    it('inits from storage and write to storage on changes when set to `true`', () => {
+      TestBed.runInInjectionContext(() => {
+        // prefill storage
+        localStorage.setItem(
+          key,
+          JSON.stringify({
+            foo: 'baz',
+            age: 99,
+          } as StateObject)
+        );
+
+        const Store = signalStore(withStorageSync(key));
+        const store = new Store();
+        expect(store[STATE_SIGNAL]()).toEqual({
+          foo: 'baz',
+          age: 99,
+        });
+
+        patchState(store, { ...initialState });
+        TestBed.flushEffects();
+
+        expect(store[STATE_SIGNAL]()).toEqual({
+          ...initialState,
+        });
+        const storeItem = JSON.parse(localStorage.getItem(key) || '{}');
+        expect(storeItem).toEqual({
+          ...initialState,
+        });
+      });
+    });
+
+    it('does not init from storage and does write to storage on changes when set to `false`', () => {
+      TestBed.runInInjectionContext(() => {
+        // prefill storage
+        localStorage.setItem(
+          key,
+          JSON.stringify({
+            foo: 'baz',
+            age: 99,
+          } as StateObject)
+        );
+
+        const Store = signalStore(withStorageSync({ key, autoSync: false }));
+        const store = new Store();
+        expect(store[STATE_SIGNAL]()).toEqual({});
+
+        patchState(store, { ...initialState });
+        const storeItem = JSON.parse(localStorage.getItem(key) || '{}');
+        expect(storeItem).toEqual({
+          foo: 'baz',
+          age: 99,
+        });
+      });
+    });
+  });
+
+  describe('select', () => {
+    it('syncs the whole state by default', () => {
+      TestBed.runInInjectionContext(() => {
+        const Store = signalStore(withStorageSync(key));
+        const store = new Store();
+
+        patchState(store, { ...initialState });
+        TestBed.flushEffects();
+
+        const storeItem = JSON.parse(localStorage.getItem(key) || '{}');
+        expect(storeItem).toEqual({
+          ...initialState,
+        });
+      });
+    });
+
+    it('syncs selected slices when specified', () => {
+      TestBed.runInInjectionContext(() => {
+        const Store = signalStore(
+          withState(initialState),
+          withStorageSync({ key, select: ({ foo }) => ({ foo }) })
+        );
+        const store = new Store();
+
+        patchState(store, { foo: 'baz' });
+        TestBed.flushEffects();
+
+        const storeItem = JSON.parse(localStorage.getItem(key) || '{}');
+        expect(storeItem).toEqual({
+          foo: 'baz',
+        });
+      });
+    });
+  });
+
+  describe('parse/stringify', () => {
+    it('uses custom parsing/stringification when specified', () => {
+      const parse = (stateString: string) => {
+        const [foo, age] = stateString.split('_');
+        return {
+          foo,
+          age: +age,
+        };
+      };
+
+      TestBed.runInInjectionContext(() => {
+        const Store = signalStore(
+          withState(initialState),
+          withStorageSync({
+            key,
+            parse,
+            stringify: (state) => `${state.foo}_${state.age}`,
+          })
+        );
+        const store = new Store();
+
+        patchState(store, { foo: 'baz' });
+        TestBed.flushEffects();
+
+        const storeItem = parse(localStorage.getItem(key) || '');
+        expect(storeItem).toEqual({
+          ...initialState,
+          foo: 'baz',
+        });
+      });
+    });
+  });
+
+  describe('storage factory', () => {
+    it('uses specified storage', () => {
+      TestBed.runInInjectionContext(() => {
+        // prefill storage
+        sessionStorage.setItem(
+          key,
+          JSON.stringify({
+            foo: 'baz',
+            age: 99,
+          } as StateObject)
+        );
+
+        const Store = signalStore(
+          withStorageSync({ key, storage: () => sessionStorage })
+        );
+        const store = new Store();
+        expect(store[STATE_SIGNAL]()).toEqual({
+          foo: 'baz',
+          age: 99,
+        });
+
+        patchState(store, { ...initialState });
+        TestBed.flushEffects();
+
+        expect(store[STATE_SIGNAL]()).toEqual({
+          ...initialState,
+        });
+        const storeItem = JSON.parse(sessionStorage.getItem(key) || '{}');
+        expect(storeItem).toEqual({
+          ...initialState,
+        });
+
+        store.clearStorage();
+      });
+    });
+  });
+});

--- a/modules/signals/storage/src/index.ts
+++ b/modules/signals/storage/src/index.ts
@@ -1,0 +1,1 @@
+export { withStorageSync } from './with-storage-sync';

--- a/modules/signals/storage/src/with-storage-sync.ts
+++ b/modules/signals/storage/src/with-storage-sync.ts
@@ -1,0 +1,166 @@
+import { isPlatformServer } from '@angular/common';
+import { PLATFORM_ID, effect, inject } from '@angular/core';
+import {
+  SignalStoreFeature,
+  getState,
+  patchState,
+  signalStoreFeature,
+  withHooks,
+  withMethods,
+} from '@ngrx/signals';
+
+type SignalStoreFeatureInput<State> = Pick<
+  Parameters<SignalStoreFeature>[0],
+  'signals' | 'methods'
+> & {
+  state: State;
+};
+
+type SyncConfig<State> = {
+  /**
+   * The key which is used to access the storage.
+   */
+  key: string;
+  /**
+   * Flag indicating if the store should read from storage on init and write to storage on every state change.
+   *
+   * `true` by default
+   */
+  autoSync?: boolean;
+  /**
+   * Function to select that portion of the state which should be stored.
+   *
+   * Returns the whole state object by default
+   */
+  select?: (state: State) => Partial<State>;
+  /**
+   * Function used to parse the state coming from storage.
+   *
+   * `JSON.parse()` by default
+   */
+  parse?: (stateString: string) => State;
+  /**
+   * Function used to tranform the state into a string representation.
+   *
+   * `JSON.stringify()` by default
+   */
+  stringify?: (state: State) => string;
+  /**
+   * Factory function used to select the storage.
+   *
+   * `localstorage` by default
+   */
+  storage?: () => Storage;
+};
+
+/**
+ * Enables store synchronization with storage.
+ *
+ * Only works on browser platform.
+ */
+export function withStorageSync<
+  State extends object,
+  Input extends SignalStoreFeatureInput<State>
+>(
+  key: string
+): SignalStoreFeature<
+  Input,
+  {
+    state: {};
+    signals: {};
+    methods: {
+      clearStorage(): void;
+      readFromStorage(): void;
+      writeToStorage(): void;
+    };
+  }
+>;
+export function withStorageSync<
+  State extends object,
+  Input extends SignalStoreFeatureInput<State>
+>(
+  config: SyncConfig<Input['state']>
+): SignalStoreFeature<
+  Input,
+  {
+    state: {};
+    signals: {};
+    methods: {
+      clearStorage(): void;
+      readFromStorage(): void;
+      writeToStorage(): void;
+    };
+  }
+>;
+export function withStorageSync<
+  State extends object,
+  Input extends SignalStoreFeatureInput<State>
+>(
+  configOrKey: SyncConfig<Input['state']> | string
+): SignalStoreFeature<
+  Input,
+  {
+    state: {};
+    signals: {};
+    methods: {
+      clearStorage(): void;
+      readFromStorage(): void;
+      writeToStorage(): void;
+    };
+  }
+> {
+  const {
+    key,
+    autoSync = true,
+    select = (state: State) => state,
+    parse = JSON.parse,
+    stringify = JSON.stringify,
+    storage: storageFactory = () => localStorage,
+  } = typeof configOrKey === 'string' ? { key: configOrKey } : configOrKey;
+
+  return signalStoreFeature(
+    withMethods((store) => {
+      const storage = storageFactory();
+
+      return {
+        /**
+         * Removes the item stored in storage.
+         */
+        clearStorage(): void {
+          storage.removeItem(key);
+        },
+        /**
+         * Reads item from storage and patches the state.
+         */
+        readFromStorage(): void {
+          const stateString = storage.getItem(key);
+          if (stateString) {
+            patchState(store, parse(stateString));
+          }
+        },
+        /**
+         * Writes selected portion to storage.
+         */
+        writeToStorage(): void {
+          const slicedState = select(getState(store) as State);
+          storage.setItem(key, stringify(slicedState));
+        },
+      };
+    }),
+    withHooks({
+      onInit(store, platformId = inject(PLATFORM_ID)) {
+        if (isPlatformServer(platformId)) {
+          return;
+        }
+
+        if (autoSync) {
+          store.readFromStorage();
+
+          effect(() => {
+            store.writeToStorage();
+          });
+        }
+      },
+    })
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,6 +47,7 @@
       "@ngrx/signals/entities": ["./modules/signals/entities"],
       "@ngrx/signals/rxjs-interop": ["./modules/signals/rxjs-interop"],
       "@ngrx/signals/schematics-core": ["./modules/signals/schematics-core"],
+      "@ngrx/signals/storage": ["./modules/signals/storage"],
       "@ngrx/store": ["./modules/store"],
       "@ngrx/store-devtools": ["./modules/store-devtools"],
       "@ngrx/store-devtools/schematics-core": [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #3997 

## What is the new behavior?

1. Adding storage (`localstorage`/`sessionstorage`) synchronization to the store:
```ts
const SyncStore = signalStore(
  withStorageSync('synced'),
);
```
2. Adding methods for manual synchronization
```ts
const SyncStore = signalStore(
  withStorageSync('synced'),
);

const syncStore = inject(SyncStore);

syncStore.clearStorage(); // clears the stores item in storage
syncStore.readFromStorage(); // reads the stores item from storage and patches the state
syncStore.writeToStorage(); // writes the current state to storage
```
3. Offering customization options
```ts
const SyncStore = signalStore(
  withStorageSync<User>({
    key: 'synced',
    autoSync: false, // read from storage on init and write on state changes - `true` by default
    select: (state: User) => Partial<User>, // projection to keep specific slices in sync
    parse: (stateString: string) => State, // custom parsing from storage - `JSON.parse` by default
    stringify: (state: User) => string, // custom stringification - `JSON.stringify` by default
    storage: () => sessionstorage, // factory to select storage to sync with
  }),
);
```

👏 A huge shoutout to @markostanimirovic for his preliminary work with his `ngrx-signal-store-playground` - integration into the signals package was all I've done.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

