### PR TITLE
build(codespaces): update dev-container to use node 18 image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
   "name": "Platform",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-16-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-18-bullseye",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {

--- a/.devcontainer/ngrx.io/devcontainer.json
+++ b/.devcontainer/ngrx.io/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
   "name": "Docs (ngrx.io)",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-16-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-18-bullseye",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {


### PR DESCRIPTION
Changes the Microsoft image used to build the codespaces container from `typescript-node:0-16-bullseye` --> `typescript-node:0-18-bullseye`

Closes #4172

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[X] Other... Please describe:
```
☝️ Other or build. Unsure what best fits this kind of change?

## What is the current behavior?
When checking out the repo via Codespaces, it crashes producing the following error:
`The engine "node" is incompatible with this module. Expected version ">=18.13.0". Got "16.20.0"`

Closes #4172

## What is the new behavior?
The container successfully builds and starts up, allowing an easy environment for new contributors.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```