### PR TITLE
fix(signals): destroy hook doesn't run in injection context.

### DIFF
--- a/modules/signals/spec/helpers.ts
+++ b/modules/signals/spec/helpers.ts
@@ -2,7 +2,8 @@ import { Component, inject, Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 export function createLocalService<Service extends Type<unknown>>(
-  serviceToken: Service
+  serviceToken: Service,
+  provideLocally = true
 ): {
   service: InstanceType<Service>;
   flushEffects: () => void;
@@ -11,7 +12,7 @@ export function createLocalService<Service extends Type<unknown>>(
   @Component({
     standalone: true,
     template: '',
-    providers: [serviceToken],
+    providers: provideLocally ? [serviceToken] : [],
   })
   class TestComponent {
     service = inject(serviceToken);

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -331,10 +331,9 @@ export function signalStore(
 
       if (hooks.onDestroy) {
         const injector = inject(Injector);
+        const { onDestroy } = hooks;
 
-        inject(DestroyRef).onDestroy(() => {
-          runInInjectionContext(injector, hooks.onDestroy!);
-        });
+        inject(DestroyRef).onDestroy(onDestroy);
       }
     }
   }

--- a/modules/signals/src/with-hooks.ts
+++ b/modules/signals/src/with-hooks.ts
@@ -16,13 +16,24 @@ type HooksFactory<Input extends SignalStoreFeatureResult> = (
   >
 ) => void;
 
-export function withHooks<Input extends SignalStoreFeatureResult>(hooks: {
+type HooksSupplier<Input extends SignalStoreFeatureResult> = () => {
   onInit?: HooksFactory<Input>;
   onDestroy?: HooksFactory<Input>;
-}): SignalStoreFeature<Input, EmptyFeatureResult> {
+};
+
+export function withHooks<Input extends SignalStoreFeatureResult>(
+  hooks:
+    | {
+        onInit?: HooksFactory<Input>;
+        onDestroy?: HooksFactory<Input>;
+      }
+    | HooksSupplier<Input>
+): SignalStoreFeature<Input, EmptyFeatureResult> {
   return (store) => {
-    const createHook = (name: keyof typeof hooks) => {
-      const hook = hooks[name];
+    const _hooks = typeof hooks === 'function' ? hooks() : hooks;
+
+    const createHook = (name: keyof typeof _hooks) => {
+      const hook = _hooks[name];
       const currentHook = store.hooks[name];
 
       return hook


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

It fixes a testing issues when a store, which is provided in root, has an onDestroy hook.

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The Signal Store saves the injection context upon instantiation and re-uses it in the `onDestroy` hook.

If the Store is provided in `root`, any test with an `onDestroy` hook fails with the error message: `NG0205: Injector has already been destroyed`.

This commit requires `withHook` to access the DI outside of `onDestroy`.

With the main branch, it is very easily to test. Just run the following test:

```typescript
it('should fail', () => {
  const Store = signalStore(
    { providedIn: 'root' },
    withState({ name: 'Coffee' }),
    withHooks({
      onDestroy() {
        console.log('will throw...');
      },
    })
  );

  TestBed.inject(Store);
});
```

## What is the new behavior?

`onDestroy` runs outside of the injection context.

I would like to add, that this PR makes `withHooks` in its usage fully compatible with `withMethods`, `withComputed` and are similar extensions that provide access to the DI.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

We add a note the changelog, describe the reasons and that's it. Signal Store is, as far as I know, still in developer preview.

## Other information

I left the old notation of `withHooks`. If that PR would be accepted, I'd suggest to remove that one as well, so that `withHooks` accepts only a `HookSupplier` as argument.