### PR TITLE
fix(signals): run `onDestroy` outside of injection context

### DIFF
--- a/modules/signals/spec/signal-store.spec.ts
+++ b/modules/signals/spec/signal-store.spec.ts
@@ -268,6 +268,8 @@ describe('signalStore', () => {
       expect(message).toBe('onDestroy');
     });
 
+    // FIX: injection context will be provided for `onDestroy` in a separate PR
+    // see https://github.com/ngrx/platform/pull/4196#issuecomment-1875228588
     it('executes hooks in injection context', () => {
       const messages: string[] = [];
       const TOKEN = new InjectionToken('TOKEN', {
@@ -281,7 +283,7 @@ describe('signalStore', () => {
             messages.push('onInit');
           },
           onDestroy() {
-            inject(TOKEN);
+            // inject(TOKEN);
             messages.push('onDestroy');
           },
         })

--- a/modules/signals/spec/signal-store.spec.ts
+++ b/modules/signals/spec/signal-store.spec.ts
@@ -296,21 +296,20 @@ describe('signalStore', () => {
       expect(messages).toEqual(['onInit', 'onDestroy']);
     });
 
-    it('fails if onDestroy accesses DI', () => {
-      const TOKEN = new InjectionToken('TOKEN', {
-        providedIn: 'root',
-        factory: () => 'ngrx',
-      });
+    it('succeeds with onDestroy and providedIn: root', () => {
+      const messages: string[] = [];
       const Store = signalStore(
+        { providedIn: 'root' },
         withHooks({
           onDestroy() {
-            inject(TOKEN);
+            messages.push('ending...');
           },
         })
       );
-      const { destroy } = createLocalService(Store);
+      TestBed.inject(Store);
+      TestBed.resetTestEnvironment();
 
-      expect(() => destroy()).toThrowError('NG0203');
+      expect(messages).toEqual(['ending...']);
     });
   });
 

--- a/modules/signals/spec/signal-store.spec.ts
+++ b/modules/signals/spec/signal-store.spec.ts
@@ -295,6 +295,23 @@ describe('signalStore', () => {
       destroy();
       expect(messages).toEqual(['onInit', 'onDestroy']);
     });
+
+    it('fails if onDestroy accesses DI', () => {
+      const TOKEN = new InjectionToken('TOKEN', {
+        providedIn: 'root',
+        factory: () => 'ngrx',
+      });
+      const Store = signalStore(
+        withHooks({
+          onDestroy() {
+            inject(TOKEN);
+          },
+        })
+      );
+      const { destroy } = createLocalService(Store);
+
+      expect(() => destroy()).toThrowError('NG0203');
+    });
   });
 
   describe('composition', () => {

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -325,16 +325,14 @@ export function signalStore(
         (this as any)[key] = props[key];
       }
 
-      if (hooks.onInit) {
-        hooks.onInit();
+      const { onInit, onDestroy } = hooks;
+
+      if (onInit) {
+        onInit();
       }
 
-      if (hooks.onDestroy) {
-        const injector = inject(Injector);
-
-        inject(DestroyRef).onDestroy(() => {
-          runInInjectionContext(injector, hooks.onDestroy!);
-        });
+      if (onDestroy) {
+        inject(DestroyRef).onDestroy(onDestroy);
       }
     }
   }

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -1,21 +1,13 @@
-import {
-  DestroyRef,
-  inject,
-  Injectable,
-  Injector,
-  runInInjectionContext,
-  signal,
-  Type,
-} from '@angular/core';
+import { DestroyRef, inject, Injectable, signal, Type } from '@angular/core';
 import { STATE_SIGNAL, StateSignal } from './state-signal';
 import {
   EmptyFeatureResult,
   InnerSignalStore,
   MergeFeatureResults,
-  SignalStoreProps,
   SignalStoreConfig,
   SignalStoreFeature,
   SignalStoreFeatureResult,
+  SignalStoreProps,
 } from './signal-store-models';
 import { Prettify } from './ts-helpers';
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

The Signal Store saves the injection context upon instantiation and re-uses it in the `onDestroy` hook.

If the Store is provided in root, any test with an `onDestroy` hook fails with the error message: NG0205: Injector has already been destroyed.

This PR runs `onDestroy` outside of the injection context.

Since this will break any code which depends on the injection context in `onDestroy`, there will be follow-up (breaking change) feature which will provide the injection context before the hook is executed.

 Discussed in: https://github.com/ngrx/platform/pull/4196

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Any test with a store `providedIn: root` fails.

Closes #

## What is the new behavior?

`onDestroy` runs outside of the injection context.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

There will be a feature PR which re-enables the injection context, but in a different way.

## Other information
