### PR TITLE
fix(store-devtools): replace direct with indirect `eval`

### DIFF
--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -206,7 +206,7 @@ export class DevtoolsExtension {
     // Listen for lifted actions
     const liftedActions$ = changes$.pipe(
       filter((change) => change.type === ExtensionActionTypes.DISPATCH),
-      map((change) => this.unwrapAction(change.payload)),
+      map((change) => change.payload),
       concatMap((action: any) => {
         if (action.type === IMPORT_STATE) {
           // State imports may happen in two situations:
@@ -234,7 +234,7 @@ export class DevtoolsExtension {
     // Listen for unlifted actions
     const actions$ = changes$.pipe(
       filter((change) => change.type === ExtensionActionTypes.ACTION),
-      map((change) => this.unwrapAction(change.payload))
+      map((change) => change.payload)
     );
 
     const actionsUntilStop$ = actions$.pipe(takeUntil(stop$));
@@ -244,10 +244,6 @@ export class DevtoolsExtension {
     // Only take the action sources between the start/stop events
     this.actions$ = this.start$.pipe(switchMap(() => actionsUntilStop$));
     this.liftedActions$ = this.start$.pipe(switchMap(() => liftedUntilStop$));
-  }
-
-  private unwrapAction(action: Action) {
-    return typeof action === 'string' ? eval(`(${action})`) : action;
   }
 
   private getExtensionConfig(config: StoreDevtoolsConfig) {

--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -247,7 +247,8 @@ export class DevtoolsExtension {
   }
 
   private unwrapAction(action: Action) {
-    return typeof action === 'string' ? eval(`(${action})`) : action;
+    // indirect eval according to https://esbuild.github.io/content-types/#direct-eval
+    return typeof action === 'string' ? (0, eval)(`(${action})`) : action;
   }
 
   private getExtensionConfig(config: StoreDevtoolsConfig) {

--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -206,7 +206,7 @@ export class DevtoolsExtension {
     // Listen for lifted actions
     const liftedActions$ = changes$.pipe(
       filter((change) => change.type === ExtensionActionTypes.DISPATCH),
-      map((change) => change.payload),
+      map((change) => this.unwrapAction(change.payload)),
       concatMap((action: any) => {
         if (action.type === IMPORT_STATE) {
           // State imports may happen in two situations:
@@ -234,7 +234,7 @@ export class DevtoolsExtension {
     // Listen for unlifted actions
     const actions$ = changes$.pipe(
       filter((change) => change.type === ExtensionActionTypes.ACTION),
-      map((change) => change.payload)
+      map((change) => this.unwrapAction(change.payload))
     );
 
     const actionsUntilStop$ = actions$.pipe(takeUntil(stop$));
@@ -244,6 +244,10 @@ export class DevtoolsExtension {
     // Only take the action sources between the start/stop events
     this.actions$ = this.start$.pipe(switchMap(() => actionsUntilStop$));
     this.liftedActions$ = this.start$.pipe(switchMap(() => liftedUntilStop$));
+  }
+
+  private unwrapAction(action: Action) {
+    return typeof action === 'string' ? eval(`(${action})`) : action;
   }
 
   private getExtensionConfig(config: StoreDevtoolsConfig) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

From my perspective, this removes the unnecessary `eval` method to get an action's payload.

If somebody knows why the `eval` was there in the first place (no test is failing), we could provide a safer, alternative version of `unwrapAction`.

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4213

## What is the new behavior?

The `payload` is directly used.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
