### PR TITLE
perf(signals): avoid unecessary observable conversions in rxMethod

### DIFF
--- a/modules/signals/rxjs-interop/src/rx-method.ts
+++ b/modules/signals/rxjs-interop/src/rx-method.ts
@@ -1,13 +1,13 @@
 import {
   assertInInjectionContext,
   DestroyRef,
+  effect,
   inject,
   Injector,
   isSignal,
   Signal,
 } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
-import { isObservable, Observable, of, Subject, Unsubscribable } from 'rxjs';
+import { isObservable, noop, Observable, Subject, Unsubscribable } from 'rxjs';
 
 type RxMethodInput<Input> = Input | Observable<Input> | Signal<Input>;
 
@@ -30,20 +30,23 @@ export function rxMethod<Input>(
   destroyRef.onDestroy(() => sourceSub.unsubscribe());
 
   const rxMethodFn = (input: RxMethodInput<Input>) => {
-    let input$: Observable<Input>;
-
     if (isSignal(input)) {
-      input$ = toObservable(input, { injector });
-    } else if (isObservable(input)) {
-      input$ = input;
-    } else {
-      input$ = of(input);
+      const watcher = effect(() => source$.next(input()), { injector });
+      const instanceSub = { unsubscribe: () => watcher.destroy() };
+      sourceSub.add(instanceSub);
+
+      return instanceSub;
     }
 
-    const instanceSub = input$.subscribe((value) => source$.next(value));
-    sourceSub.add(instanceSub);
+    if (isObservable(input)) {
+      const instanceSub = input.subscribe((value) => source$.next(value));
+      sourceSub.add(instanceSub);
 
-    return instanceSub;
+      return instanceSub;
+    }
+
+    source$.next(input);
+    return { unsubscribe: noop };
   };
   rxMethodFn.unsubscribe = sourceSub.unsubscribe.bind(sourceSub);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Performance improvements
```

## What is the current behavior?

`rxMethod` converts signals and static inputs into observables.

## What is the new behavior?

`rxMethod` does not convert signals and static inputs into observables which reduces more than 1kB.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
