### PR TITLE
perf(signals): avoid creating unnecessary objects in excludeKeys

### DIFF
--- a/modules/signals/src/helpers.ts
+++ b/modules/signals/src/helpers.ts
@@ -2,8 +2,10 @@ export function excludeKeys<
   Obj extends Record<string, unknown>,
   Keys extends string[]
 >(obj: Obj, keys: Keys): Omit<Obj, Keys[number]> {
-  return Object.keys(obj).reduce(
-    (acc, key) => (keys.includes(key) ? acc : { ...acc, [key]: obj[key] }),
-    {}
-  ) as Omit<Obj, Keys[number]>;
+  return Object.keys(obj).reduce<Record<string, unknown>>((acc, key) => {
+    if (!keys.includes(key)) {
+      acc[key] = obj[key];
+    }
+    return acc;
+  }, {}) as Omit<Obj, Keys[number]>;
 }


### PR DESCRIPTION
Make the `excludeKeys` create only one object as it's enough for the function to work correctly. Currently the `excludeKeys` helper function creates a new object on every iteration of the non-removed keys. It's unnecessary as - before the function returns the result outside, nothing can have the reference to the newly created object. It's safe to mutate the temporarily created result.

no breaking changes, fixes #4238

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

Closes #4238

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
