### PR TITLE
fix(signals): add `StateSignal` to the public API

### DIFF
--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -4,6 +4,7 @@ export { signalState } from './signal-state';
 export { signalStore } from './signal-store';
 export { signalStoreFeature, type } from './signal-store-feature';
 export { SignalStoreFeature } from './signal-store-models';
+export { StateSignal } from './state-signal';
 
 export { withComputed } from './with-computed';
 export { withHooks } from './with-hooks';


### PR DESCRIPTION
expose `StateSignal` store type in order to make it easier for 3rd party extensions to wrap signal store APIs, e.g. patchState with immer immutability - generic `StateSignal<State>` is difficult to obtain via `ReturnType<typeof signalStore>` or any other way.

no breaking changes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

```
[X] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

