### PR TITLE
feat(operators): add `mapResponse`

### DIFF
--- a/modules/operators/spec/map-response.spec.ts
+++ b/modules/operators/spec/map-response.spec.ts
@@ -1,0 +1,79 @@
+import { noop, Observable, of, throwError } from 'rxjs';
+import { mapResponse } from '..';
+import { concatMap, finalize } from 'rxjs/operators';
+
+describe('mapResponse', () => {
+  it('should invoke next callback on next', () => {
+    const nextCallback = jest.fn<void, [number]>();
+
+    of(1, 2, 3)
+      .pipe(
+        mapResponse({
+          next: nextCallback,
+          error: noop,
+        })
+      )
+      .subscribe();
+
+    expect(nextCallback.mock.calls).toEqual([[1], [2], [3]]);
+  });
+
+  it('should invoke error callback on error', () => {
+    const errorCallback = jest.fn<void, [{ message: string }]>();
+    const error = { message: 'error' };
+
+    throwError(() => error)
+      .pipe(
+        mapResponse({
+          next: noop,
+          error: errorCallback,
+        })
+      )
+      .subscribe();
+
+    expect(errorCallback).toHaveBeenCalledWith(error);
+  });
+
+  it('should invoke error callback on the exception thrown in next', () => {
+    const errorCallback = jest.fn<void, [{ message: string }]>();
+    const error = { message: 'error' };
+
+    function producesError() {
+      throw error;
+    }
+
+    of(1)
+      .pipe(
+        mapResponse({
+          next: producesError,
+          error: errorCallback,
+        })
+      )
+      .subscribe();
+
+    expect(errorCallback).toHaveBeenCalledWith(error);
+  });
+
+  it('should not unsubscribe from outer observable on inner observable error', () => {
+    const innerCompleteCallback = jest.fn<void, []>();
+    const outerCompleteCallback = jest.fn<void, []>();
+
+    new Observable((subscriber) => subscriber.next(1))
+      .pipe(
+        concatMap(() =>
+          throwError(() => 'error').pipe(
+            mapResponse({
+              next: noop,
+              error: noop,
+            }),
+            finalize(innerCompleteCallback)
+          )
+        ),
+        finalize(outerCompleteCallback)
+      )
+      .subscribe();
+
+    expect(innerCompleteCallback).toHaveBeenCalled();
+    expect(outerCompleteCallback).not.toHaveBeenCalled();
+  });
+});

--- a/modules/operators/spec/map-response.spec.ts
+++ b/modules/operators/spec/map-response.spec.ts
@@ -20,7 +20,7 @@ describe('mapResponse', () => {
     expect(results).toEqual([2, 3, 4]);
   });
 
-  it('should map the thrown error using the error callback', () => {
+  it('should map the thrown error using the error callback', (done) => {
     throwError(() => 'error')
       .pipe(
         mapResponse({
@@ -30,10 +30,11 @@ describe('mapResponse', () => {
       )
       .subscribe((result) => {
         expect(result).toBe('mapped error');
+        done();
       });
   });
 
-  it('should map the error thrown in next callback using error callback', () => {
+  it('should map the error thrown in next callback using error callback', (done) => {
     function producesError() {
       throw 'error';
     }
@@ -47,6 +48,7 @@ describe('mapResponse', () => {
       )
       .subscribe((result) => {
         expect(result).toBe('mapped error');
+        done();
       });
   });
 

--- a/modules/operators/src/index.ts
+++ b/modules/operators/src/index.ts
@@ -1,2 +1,3 @@
 export { concatLatestFrom } from './concat_latest_from';
+export { mapResponse } from './map-response';
 export { tapResponse } from './tap-response';

--- a/modules/operators/src/map-response.ts
+++ b/modules/operators/src/map-response.ts
@@ -1,14 +1,14 @@
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-type MapResponseObserver<T, E, R1, R2> = {
-  next: (value: T) => R1;
-  error: (error: E) => R2;
+type MapResponseObserver<T, S, E> = {
+  next: (value: T) => S;
+  error: (error: unknown) => E;
 };
 
-export function mapResponse<T, E, R1, R2>(
-  observer: MapResponseObserver<T, E, R1, R2>
-): (source$: Observable<T>) => Observable<R1 | R2> {
+export function mapResponse<T, S, E>(
+  observer: MapResponseObserver<T, S, E>
+): (source$: Observable<T>) => Observable<S | E> {
   return (source$) =>
     source$.pipe(
       map((value) => observer.next(value)),

--- a/modules/operators/src/map-response.ts
+++ b/modules/operators/src/map-response.ts
@@ -1,14 +1,14 @@
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-type MapResponseObserver<T, S, E> = {
-  next: (value: T) => S;
-  error: (error: unknown) => E;
+type MapResponseObserver<T, E, R1, R2> = {
+  next: (value: T) => R1;
+  error: (error: E) => R2;
 };
 
-export function mapResponse<T, S, E>(
-  observer: MapResponseObserver<T, S, E>
-): (source$: Observable<T>) => Observable<S | E> {
+export function mapResponse<T, E, R1, R2>(
+  observer: MapResponseObserver<T, E, R1, R2>
+): (source$: Observable<T>) => Observable<R1 | R2> {
   return (source$) =>
     source$.pipe(
       map((value) => observer.next(value)),

--- a/modules/operators/src/map-response.ts
+++ b/modules/operators/src/map-response.ts
@@ -1,0 +1,17 @@
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+export function mapResponse<T, E, R1, R2>(observerOrNext: {
+  next: (value: T) => R1;
+  error: (error: E) => R2;
+}): (source$: Observable<T>) => Observable<R1 | R2> {
+  return (source$) =>
+    source$.pipe(
+      map((value) => {
+        return observerOrNext.next(value);
+      }),
+      catchError((error) => {
+        return of(observerOrNext.error(error));
+      })
+    );
+}

--- a/modules/operators/src/map-response.ts
+++ b/modules/operators/src/map-response.ts
@@ -11,11 +11,7 @@ export function mapResponse<T, E, R1, R2>(
 ): (source$: Observable<T>) => Observable<R1 | R2> {
   return (source$) =>
     source$.pipe(
-      map((value) => {
-        return observer.next(value);
-      }),
-      catchError((error) => {
-        return of(observer.error(error));
-      })
+      map((value) => observer.next(value)),
+      catchError((error) => of(observer.error(error)))
     );
 }

--- a/modules/operators/src/map-response.ts
+++ b/modules/operators/src/map-response.ts
@@ -1,17 +1,21 @@
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-export function mapResponse<T, E, R1, R2>(observerOrNext: {
+type MapResponseObserver<T, E, R1, R2> = {
   next: (value: T) => R1;
   error: (error: E) => R2;
-}): (source$: Observable<T>) => Observable<R1 | R2> {
+};
+
+export function mapResponse<T, E, R1, R2>(
+  observer: MapResponseObserver<T, E, R1, R2>
+): (source$: Observable<T>) => Observable<R1 | R2> {
   return (source$) =>
     source$.pipe(
       map((value) => {
-        return observerOrNext.next(value);
+        return observer.next(value);
       }),
       catchError((error) => {
-        return of(observerOrNext.error(error));
+        return of(observer.error(error));
       })
     );
 }

--- a/projects/ngrx.io/content/guide/operators/operators.md
+++ b/projects/ngrx.io/content/guide/operators/operators.md
@@ -90,3 +90,25 @@ There is also another signature of the `tapResponse` operator that accepts the o
     );
   });
 </code-example>
+
+## mapResponse
+
+The `mapResponse` operator is particularly useful in scenarios where you need to transform data and handle potential errors with minimal boilerplate.
+
+In the example below, we use `mapResponse` within an NgRx effect to handle loading movies from an API. It demonstrates how to map successful API responses to an action indicating success, and how to handle errors by dispatching an error action.
+
+<code-example header="movies.effects.ts">
+  loadMovies$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType('[Movies Page] Load Movies'),
+      exhaustMap(() => this.moviesService.getAll()
+        .pipe(
+          mapResponse({
+            next: (movies) => ({ type: '[Movies API] Movies Loaded Success', payload: movies }),
+            error: () => of({ type: '[Movies API] Movies Loaded Error' })
+          })
+        )
+      )
+    )
+  );
+</code-example>

--- a/projects/ngrx.io/content/guide/operators/operators.md
+++ b/projects/ngrx.io/content/guide/operators/operators.md
@@ -98,17 +98,21 @@ The `mapResponse` operator is particularly useful in scenarios where you need to
 In the example below, we use `mapResponse` within an NgRx effect to handle loading movies from an API. It demonstrates how to map successful API responses to an action indicating success, and how to handle errors by dispatching an error action.
 
 <code-example header="movies.effects.ts">
-  loadMovies$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType('[Movies Page] Load Movies'),
-      exhaustMap(() => this.moviesService.getAll()
-        .pipe(
-          mapResponse({
-            next: (movies) => ({ type: '[Movies API] Movies Loaded Success', payload: movies }),
-            error: () => of({ type: '[Movies API] Movies Loaded Error' })
-          })
+  export const loadMovies = createEffect(
+    (actions$ = inject(Actions), moviesService = inject(MoviesService)) => {
+      return actions$.pipe(
+        ofType(MoviesPageActions.opened),
+        exhaustMap(() =>
+          moviesService.getAll().pipe(
+            mapResponse({
+              next: (movies) => MoviesApiActions.moviesLoadedSuccess({ movies }),
+              error: (error: { message: string }) =>
+                MoviesApiActions.moviesLoadedFailure({ errorMsg: error.message }),
+            })
+          )
         )
-      )
-    )
+      );
+    },
+    { functional: true }
   );
 </code-example>


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

```ts
export const loadAllUsers = createEffect((
  actions$ = inject(Actions),
  usersService = inject(UsersService)
) => {
  return actions$.pipe(
    ofType(UsersPageActions.opened),
    exhaustMap(() => {
      return usersService.getAll().pipe(
        map((users) => UsersApiActions.usersLoadedSuccess({ users })),
        catchError((error) =>
          of(UsersApiActions.usersLoadedFailure({ error }))
        )
      );
    })
  );
});
```

Closes #4230 

## What is the new behavior?

```ts
import { mapResponse } from '@ngrx/operators';

export const loadAllUsers = createEffect((
  actions$ = inject(Actions),
  usersService = inject(UsersService)
) => {
  return actions$.pipe(
    ofType(UsersPageActions.opened),
    exhaustMap(() => {
      return usersService.getAll().pipe(
        mapResponse({
          next: (users) => UsersApiActions.usersLoadedSuccess({ users }),
          error: (error) => UsersApiActions.usersLoadedFailure({ error }),
        })
      );
    })
  );
});
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

I am not 100% sure if I correctly understood the expected behavior of `mapResponse`, as @markostanimirovic suggested in #4230.

Please feel free to give me feedback. 

Thanks.