### PR TITLE
feat: make signalStore entries starting with _ not available outside of the store (interface, first level)

### DIFF
--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -1,7 +1,11 @@
 import { Signal } from '@angular/core';
 import { DeepSignal } from './deep-signal';
 import { StateSignal } from './state-signal';
-import { IsKnownRecord, Prettify } from './ts-helpers';
+import {
+  IsKnownRecord,
+  Prettify,
+  PrettifyWithoutUnderscores,
+} from './ts-helpers';
 
 export type SignalStoreConfig = { providedIn: 'root' };
 
@@ -16,7 +20,7 @@ export type SignalStoreSlices<State> = IsKnownRecord<
   : {};
 
 export type SignalStoreProps<FeatureResult extends SignalStoreFeatureResult> =
-  Prettify<
+  PrettifyWithoutUnderscores<
     SignalStoreSlices<FeatureResult['state']> &
       FeatureResult['signals'] &
       FeatureResult['methods']

--- a/modules/signals/src/ts-helpers.ts
+++ b/modules/signals/src/ts-helpers.ts
@@ -1,5 +1,10 @@
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
+export type RemoveUnderscore<K> = K extends `_${string}` ? never : K;
+export type PrettifyWithoutUnderscores<T> = {
+  [K in keyof T as RemoveUnderscore<K>]: T[K];
+} & {};
+
 export type IsRecord<T> = T extends object
   ? T extends unknown[]
     ? false


### PR DESCRIPTION
## Summary
As (more or less) mentioned in https://github.com/ngrx/platform/issues/4283 and https://github.com/ngrx/platform/pull/4210, providers returned by the factory `signalStore` are currently lacking some sort on encapsulation. 

As I see it, there are 2 problems: 
1.  there is no way to declare that some slices of the state / computeds / methods are private, meaning that they are not meant to be used by consumers, 
2. `patchState` and `getState` are defined as utilities applicable on both objects returned by `signalStore` and `signalState`. This is good for reusability, but it comes with the undesired side effect of making a signalStore patchable anywhere (like in components consuming it). Considering the store mental model, `patchState` and `getState` should probably be available only in methods / hooks. 

The goal of this PR is targeting point 1, following (hopefully) the suggestion in https://github.com/ngrx/platform/pull/4210#issuecomment-1966810494. Here is a use case where the feature would come in handy (there are many others): 
``` typescript
/**
 * Modified example at https://ngrx.io/guide/signals/signal-store#putting-it-all-together
 * where the store is defined as a global provider.
 *
 * In this case, you probably don't want to have loadByQuery callable from consumers
 * because you don't want to have more than one subscription.
 */
const BooksStore = signalStore(
  { providedIn: 'root' },
  withState({/* ... */ filter: { query: '', order: 'asc' } }),
  // ...
  withMethods((store, booksService = inject(BooksService)) => ({
      // not callable from components injecting BooksStore
      _loadByQuery: rxMethod<string>(/* ... */),
    }),
  ),
  withHooks({
    onInit(store): void {
      store._loadByQuery(store.filter.query);
    },
  }),
);
```
With this PR, prefixing any root slice of the state / computed / method by `_` should make it unavailable (ts interface) in the returned `signalStore` provider. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Providers returned by the factory `signalStore` are currently lacking encapsulation

Partially address https://github.com/ngrx/platform/issues/4283 and https://github.com/ngrx/platform/pull/4210

## What is the new behavior?
Prefixing any root slice of the state / computed / method by `_` should make it unavailable (ts interface) in the returned `signalStore` provider. 
## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
