### PR TITLE
feat(store): merge Action and TypedAction intefaces

### DIFF
--- a/modules/effects/spec/types/effect_creator.spec.ts
+++ b/modules/effects/spec/types/effect_creator.spec.ts
@@ -22,7 +22,7 @@ describe('createEffect()', () => {
       expectSnippet(`
         const effect = createEffect(() => of({ foo: 'a' }));
       `).toFail(
-        /Type 'Observable<{ foo: string; }>' is not assignable to type 'EffectResult<Action>'./
+        /Type 'Observable<{ foo: string; }>' is not assignable to type 'EffectResult<Action<string>>'./
       );
     });
 
@@ -50,7 +50,7 @@ describe('createEffect()', () => {
       expectSnippet(`
         const effect = createEffect(() => of({ foo: 'a' }), { dispatch: true });
       `).toFail(
-        /Type 'Observable<{ foo: string; }>' is not assignable to type 'EffectResult<Action>'./
+        /Type 'Observable<{ foo: string; }>' is not assignable to type 'EffectResult<Action<string>>'./
       );
     });
 
@@ -176,7 +176,7 @@ describe('createEffect()', () => {
         );
       `).toInfer(
         'effect',
-        'FunctionalEffect<() => Observable<ActionCreator<"a", () => TypedAction<"a">>>>'
+        'FunctionalEffect<() => Observable<ActionCreator<"a", () => Action<"a">>>>'
       );
     });
 

--- a/modules/effects/spec/types/of_type.spec.ts
+++ b/modules/effects/spec/types/of_type.spec.ts
@@ -19,27 +19,21 @@ describe('ofType()', () => {
       expectSnippet(`
         const actionA = createAction('Action A');
         const effect = actions$.pipe(ofType(actionA))
-      `).toInfer('effect', 'Observable<TypedAction<"Action A">>');
+      `).toInfer('effect', 'Observable<Action<"Action A">>');
     });
 
     it('should infer correctly with props', () => {
       expectSnippet(`
         const actionA = createAction('Action A', props<{ foo: string }>());
         const effect = actions$.pipe(ofType(actionA))
-      `).toInfer(
-        'effect',
-        'Observable<{ foo: string; } & TypedAction<"Action A">>'
-      );
+      `).toInfer('effect', 'Observable<{ foo: string; } & Action<"Action A">>');
     });
 
     it('should infer correctly with function', () => {
       expectSnippet(`
         const actionA = createAction('Action A', (foo: string) => ({ foo }));
         const effect = actions$.pipe(ofType(actionA))
-      `).toInfer(
-        'effect',
-        'Observable<{ foo: string; } & TypedAction<"Action A">>'
-      );
+      `).toInfer('effect', 'Observable<{ foo: string; } & Action<"Action A">>');
     });
 
     it('should infer correctly with multiple actions (with over 5 actions)', () => {
@@ -55,7 +49,7 @@ describe('ofType()', () => {
         const effect = actions$.pipe(ofType(actionA, actionB, actionC, actionD, actionE, actionF, actionG))
       `).toInfer(
         'effect',
-        'Observable<TypedAction<"Action A"> | TypedAction<"Action B"> | TypedAction<"Action C"> | TypedAction<"Action D"> | TypedAction<"Action E"> | TypedAction<...> | TypedAction<...>>'
+        'Observable<Action<"Action A"> | Action<"Action B"> | Action<"Action C"> | Action<"Action D"> | Action<"Action E"> | Action<"Action F"> | Action<...>>'
       );
     });
   });
@@ -106,7 +100,7 @@ describe('ofType()', () => {
       expectSnippet(`
         const actions$ = {} as Actions<ActionA | ActionB | ActionC | ActionD | ActionE | ActionF>;
         const effect = actions$.pipe(ofType(ACTION_A, ACTION_B, ACTION_C, ACTION_D, ACTION_E, ACTION_F))
-      `).toInfer('effect', 'Observable<Action>');
+      `).toInfer('effect', 'Observable<Action<string>>');
     });
 
     it('should infer to never when the action is not in Actions', () => {

--- a/modules/store/spec/types/action_group_creator.spec.ts
+++ b/modules/store/spec/types/action_group_creator.spec.ts
@@ -32,7 +32,7 @@ describe('createActionGroup', () => {
         `ActionCreator<
           "[Auth API] Login Success",
           (props: { userId: number; token: string; }) =>
-            { userId: number; token: string; } & TypedAction<"[Auth API] Login Success">
+            { userId: number; token: string; } & Action<"[Auth API] Login Success">
         >`
       );
       snippet.toInfer(
@@ -40,22 +40,22 @@ describe('createActionGroup', () => {
         `ActionCreator<
           "[Auth API] Login Failure",
           (props: { error: string; }) =>
-            { error: string; } & TypedAction<"[Auth API] Login Failure">
+            { error: string; } & Action<"[Auth API] Login Failure">
         >`
       );
       snippet.toInfer(
         'logoutSuccess',
         `ActionCreator<
           "[Auth API] Logout Success",
-          () => TypedAction<"[Auth API] Logout Success">
+          () => Action<"[Auth API] Logout Success">
         >`
       );
       snippet.toInfer(
         'logoutFailure',
         `FunctionWithParametersType<
           [error: Error],
-          { error: Error; } & TypedAction<"[Auth API] Logout Failure">
-        > & TypedAction<"[Auth API] Logout Failure">`
+          { error: Error; } & Action<"[Auth API] Logout Failure">
+        > & Action<"[Auth API] Logout Failure">`
       );
     });
 
@@ -115,14 +115,14 @@ describe('createActionGroup', () => {
           'loadBooksSuccess',
           `ActionCreator<
             "[Books API]  Load BOOKS  suCCess  ",
-            () => TypedAction<"[Books API]  Load BOOKS  suCCess  ">
+            () => Action<"[Books API]  Load BOOKS  suCCess  ">
           >`
         );
         snippet.toInfer(
           'loadBooksFailure',
           `ActionCreator<
             "[Books API] loadBooksFailure",
-            () => TypedAction<"[Books API] loadBooksFailure">
+            () => Action<"[Books API] loadBooksFailure">
           >`
         );
       });
@@ -164,7 +164,7 @@ describe('createActionGroup', () => {
           let loadBooksSuccess: typeof booksApiActions.loadBooksSuccess;
         `).toInfer(
           'loadBooksSuccess',
-          'ActionCreator<"[Books API] Load Books Success", (props: { books: string[]; total: number; } | { books: symbol[]; }) => ({ books: string[]; total: number; } | { books: symbol[]; }) & TypedAction<"[Books API] Load Books Success">>'
+          'ActionCreator<"[Books API] Load Books Success", (props: { books: string[]; total: number; } | { books: symbol[]; }) => ({ books: string[]; total: number; } | { books: symbol[]; }) & Action<"[Books API] Load Books Success">>'
         );
       });
 
@@ -180,7 +180,7 @@ describe('createActionGroup', () => {
           let loadBooksSuccess: typeof booksApiActions.loadBooksSuccess;
         `).toInfer(
           'loadBooksSuccess',
-          'ActionCreator<"[Books API] Load Books Success", (props: { books: string[]; } & { total: number; }) => { books: string[]; } & { total: number; } & TypedAction<"[Books API] Load Books Success">>'
+          'ActionCreator<"[Books API] Load Books Success", (props: { books: string[]; } & { total: number; }) => { books: string[]; } & { total: number; } & Action<"[Books API] Load Books Success">>'
         );
       });
 

--- a/modules/store/spec/types/feature_creator.spec.ts
+++ b/modules/store/spec/types/feature_creator.spec.ts
@@ -67,7 +67,7 @@ describe('createFeature()', () => {
     `);
 
     snippet.toInfer('name', '"products"');
-    snippet.toInfer('reducer', 'ActionReducer<State, Action>');
+    snippet.toInfer('reducer', 'ActionReducer<State, Action<string>>');
     snippet.toInfer(
       'selectProductsState',
       'MemoizedSelector<Record<string, any>, State, (featureState: State) => State>'
@@ -103,7 +103,10 @@ describe('createFeature()', () => {
     `);
 
     snippet.toInfer('name', '"counter"');
-    snippet.toInfer('reducer', 'ActionReducer<{ count: number; }, Action>');
+    snippet.toInfer(
+      'reducer',
+      'ActionReducer<{ count: number; }, Action<string>>'
+    );
     snippet.toInfer(
       'selectCounterState',
       'MemoizedSelector<Record<string, any>, { count: number; }, (featureState: { count: number; }) => { count: number; }>'
@@ -260,7 +263,7 @@ describe('createFeature()', () => {
       `);
 
       snippet.toInfer('name', '"counter"');
-      snippet.toInfer('reducer', 'ActionReducer<State, Action>');
+      snippet.toInfer('reducer', 'ActionReducer<State, Action<string>>');
       snippet.toInfer(
         'selectCounterState',
         'MemoizedSelector<Record<string, any>, State, (featureState: State) => State>'
@@ -314,7 +317,10 @@ describe('createFeature()', () => {
       `);
 
       snippet.toInfer('name', '"counter"');
-      snippet.toInfer('reducer', 'ActionReducer<{ count: number; }, Action>');
+      snippet.toInfer(
+        'reducer',
+        'ActionReducer<{ count: number; }, Action<string>>'
+      );
       snippet.toInfer(
         'selectCounterState',
         'MemoizedSelector<Record<string, any>, { count: number; }, (featureState: { count: number; }) => { count: number; }>'

--- a/modules/store/spec/types/reducer_creator.spec.ts
+++ b/modules/store/spec/types/reducer_creator.spec.ts
@@ -25,7 +25,7 @@ describe('createReducer()', () => {
           on(setAction, (_, { value }) => value),
           on(resetAction, () => initialState),
         );
-      `).toInfer('reducer', 'ActionReducer<State, Action>');
+      `).toInfer('reducer', 'ActionReducer<State, Action<string>>');
     });
 
     it('should support arrays', () => {
@@ -40,7 +40,7 @@ describe('createReducer()', () => {
           on(setAction, (_, { value }) => value),
           on(resetAction, () => initialState),
         );
-      `).toInfer('reducer', 'ActionReducer<string[], Action>');
+      `).toInfer('reducer', 'ActionReducer<string[], Action<string>>');
     });
 
     it('should support primitive types', () => {
@@ -55,7 +55,7 @@ describe('createReducer()', () => {
           on(setAction, (_, { value }) => value),
           on(resetAction, () => initialState),
         );
-      `).toInfer('reducer', 'ActionReducer<number, Action>');
+      `).toInfer('reducer', 'ActionReducer<number, Action<string>>');
     });
 
     it('should support a generic reducer factory', () => {
@@ -105,7 +105,7 @@ describe('createReducer()', () => {
         foo: string;
     }) => {
         foo: string;
-    } & TypedAction<"FOO">>]>
+    } & Action<"FOO">>]>
     `
       );
     });
@@ -120,7 +120,7 @@ describe('createReducer()', () => {
         `
       ReducerTypes<{
         name: string;
-    }, [ActionCreator<"FOO", () => TypedAction<"FOO">>]>
+    }, [ActionCreator<"FOO", () => Action<"FOO">>]>
     `
       );
     });

--- a/modules/store/src/action_creator.ts
+++ b/modules/store/src/action_creator.ts
@@ -1,7 +1,7 @@
 import {
   Creator,
   ActionCreator,
-  TypedAction,
+  Action,
   FunctionWithParametersType,
   NotAllowedCheck,
   ActionCreatorProps,
@@ -14,11 +14,11 @@ import { REGISTERED_ACTION_TYPES } from './globals';
 
 export function createAction<T extends string>(
   type: T
-): ActionCreator<T, () => TypedAction<T>>;
+): ActionCreator<T, () => Action<T>>;
 export function createAction<T extends string, P extends object>(
   type: T,
   config: ActionCreatorProps<P> & NotAllowedCheck<P>
-): ActionCreator<T, (props: P & NotAllowedCheck<P>) => P & TypedAction<T>>;
+): ActionCreator<T, (props: P & NotAllowedCheck<P>) => P & Action<T>>;
 export function createAction<
   T extends string,
   P extends any[],
@@ -26,7 +26,7 @@ export function createAction<
 >(
   type: T,
   creator: Creator<P, R & NotAllowedCheck<R>>
-): FunctionWithParametersType<P, R & TypedAction<T>> & TypedAction<T>;
+): FunctionWithParametersType<P, R & Action<T>> & Action<T>;
 /**
  * @description
  * Creates a configured `Creator` function that, when called, returns an object in the shape of the `Action` interface.

--- a/modules/store/src/action_group_creator.ts
+++ b/modules/store/src/action_group_creator.ts
@@ -5,7 +5,7 @@ import {
   Creator,
   FunctionWithParametersType,
   NotAllowedCheck,
-  TypedAction,
+  Action,
 } from './models';
 import { capitalize, uncapitalize } from './helpers';
 
@@ -48,19 +48,17 @@ type EventCreator<
   Type extends string
 > = PropsCreator extends ActionCreatorProps<infer Props>
   ? void extends Props
-    ? ActionCreator<Type, () => TypedAction<Type>>
+    ? ActionCreator<Type, () => Action<Type>>
     : ActionCreator<
         Type,
-        (
-          props: Props & NotAllowedCheck<Props & object>
-        ) => Props & TypedAction<Type>
+        (props: Props & NotAllowedCheck<Props & object>) => Props & Action<Type>
       >
   : PropsCreator extends Creator<infer Props, infer Result>
   ? FunctionWithParametersType<
       Props,
-      Result & NotAllowedCheck<Result> & TypedAction<Type>
+      Result & NotAllowedCheck<Result> & Action<Type>
     > &
-      TypedAction<Type>
+      Action<Type>
   : never;
 
 type ActionName<EventName extends string> = Uncapitalize<

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -1,12 +1,7 @@
 import { type ValueEqualityFn } from '@angular/core';
 
-export interface Action {
-  type: string;
-}
-
-// declare to make it property-renaming safe
-export declare interface TypedAction<T extends string> extends Action {
-  readonly type: T;
+export interface Action<Type extends string = string> {
+  type: Type;
 }
 
 export type ActionType<A> = A extends ActionCreator<infer T, infer C>
@@ -132,7 +127,7 @@ export type NotAllowedInPropsCheck<T> = T extends object
 export type ActionCreator<
   T extends string = string,
   C extends Creator = Creator
-> = C & TypedAction<T>;
+> = C & Action<T>;
 
 export interface ActionCreatorProps<T> {
   _as: 'props';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4136
Closes #4183

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

```
BREAKING CHANGE:

The Action and TypedAction interfaces are merged into one interface.

BEFORE:

There was a separation between the Action and TypedAction interfaces.

AFTER:

The Action interface accepts a generic type parameter that represents the payload type (defaults to string).
The TypedAction interface is removed.
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

