### PR TITLE
Remove outdated component-store/tapResponse docs

### DIFF
--- a/projects/ngrx.io/content/guide/component-store/effect.md
+++ b/projects/ngrx.io/content/guide/component-store/effect.md
@@ -72,47 +72,6 @@ export class MovieComponent {
 }
 </code-example>
 
-## tapResponse
-
-An easy way to handle the response in ComponentStore effects in a safe way, without additional boilerplate is to use the `tapResponse` operator. It enforces that the error case is handled and that the effect would still be running should an error occur. It is essentially a simple wrapper around two operators:
-
-- `tap` that handles success and error cases.
-- `catchError(() => EMPTY)` that ensures that the effect continues to run after the error.
-
-<code-example header="movies.store.ts">
-  readonly getMovie = this.effect((movieId$: Observable&lt;string&gt;) => {
-    return movieId$.pipe(
-      // 👇 Handle race condition with the proper choice of the flattening operator.
-      switchMap((id) => this.moviesService.fetchMovie(id).pipe(
-        //👇 Act on the result within inner pipe.
-        tapResponse(
-          (movie) => this.addMovie(movie),
-          (error: HttpErrorResponse) => this.logError(error),
-        ),
-      )),
-    );
-  });
-</code-example>
-
-There is also another signature of the `tapResponse` operator that accepts the observer object as an input argument. In addition to the `next` and `error` callbacks, it provides the ability to pass `complete` and/or `finalize` callbacks:
-
-<code-example header="movies.store.ts">
-  readonly getMoviesByQuery = this.effect&lt;string&gt;((query$) => {
-    return query$.pipe(
-      tap(() => this.patchState({ loading: true }),
-      switchMap((query) =>
-        this.moviesService.fetchMoviesByQuery(query).pipe(
-          tapResponse({
-            next: (movies) => this.patchState({ movies }),
-            error: (error: HttpErrorResponse) => this.logError(error),
-            finalize: () => this.patchState({ loading: false }),
-          })
-        )
-      )
-    );
-  });
-</code-example>
-
 ## Calling an `effect` without parameters
 
 A common use case is to call the `effect` method without any parameters. 

--- a/projects/ngrx.io/content/guide/operators/operators.md
+++ b/projects/ngrx.io/content/guide/operators/operators.md
@@ -91,6 +91,8 @@ There is also another signature of the `tapResponse` operator that accepts the o
   });
 </code-example>
 
+This documentation about the `tapResponse` operator has been moved from its previous location in the NgRx ComponentStore documentation (versions prior to 18) to provide a more centralized explanation of operators. You can find the old documentation at [NgRx ComponentStore - effect (v17)](https://v17.ngrx.io/guide/component-store/effect#tapresponse)
+
 ## mapResponse
 
 The `mapResponse` operator is particularly useful in scenarios where you need to transform data and handle potential errors with minimal boilerplate.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The NgRx documentation for the `tapResponse` operator appears to be duplicated across two pages.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4357

## What is the new behavior?

The NgRx documentation for the `tapResponse` operator within the component store has been removed.
Also, adds a note on the new page referencing the pre-18 documentation.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is my first pull request on this project. Please let me know if you have any feedback.
