### PR TITLE
feat(component-store): remove tapResponse operator

### DIFF
--- a/modules/component-store/src/index.ts
+++ b/modules/component-store/src/index.ts
@@ -1,13 +1,6 @@
-import * as operators from '@ngrx/operators';
-
 export * from './component-store';
 export {
   provideComponentStore,
   OnStateInit,
   OnStoreInit,
 } from './lifecycle_hooks';
-
-/**
- * @deprecated Use `tapResponse` from `@ngrx/operators` instead.
- */
-export const tapResponse = operators.tapResponse;

--- a/modules/operators/spec/types/tap-response.types.spec.ts
+++ b/modules/operators/spec/types/tap-response.types.spec.ts
@@ -3,7 +3,7 @@ import { compilerOptions } from './utils';
 
 describe('tapResponse types', () => {
   const snippetFactory = (code: string): string => `
-    import { tapResponse } from '@ngrx/component-store';
+    import { tapResponse } from '@ngrx/operators';
     import { noop, of } from 'rxjs';
 
     ${code}

--- a/modules/operators/spec/types/utils.ts
+++ b/modules/operators/spec/types/utils.ts
@@ -1,0 +1,9 @@
+export const compilerOptions = () => ({
+  moduleResolution: 'node',
+  target: 'ES2022',
+  baseUrl: '.',
+  experimentalDecorators: true,
+  paths: {
+    '@ngrx/operators': ['./modules/operators'],
+  },
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGES:

The `tapResponse` operator has been removed from `@ngrx/component-store` in favor of the `@ngrx/operators` package.

BEFORE:

import { tapResponse } from '@ngrx/component-store';

AFTER:

import { tapResponse } from '@ngrx/operators';
