### PR TITLE
feat(effects): remove concatLatestFrom operator

### DIFF
--- a/modules/effects/spec/provide_effects.spec.ts
+++ b/modules/effects/spec/provide_effects.spec.ts
@@ -10,9 +10,9 @@ import {
   provideStore,
   Store,
 } from '@ngrx/store';
+import { concatLatestFrom } from '@ngrx/operators';
 import {
   Actions,
-  concatLatestFrom,
   createEffect,
   EffectsRunner,
   ofType,

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -1,5 +1,3 @@
-import * as operators from '@ngrx/operators';
-
 export { createEffect } from './effect_creator';
 export { EffectConfig } from './models';
 export { getEffectsMetadata } from './effects_metadata';
@@ -30,8 +28,3 @@ export {
 } from './lifecycle_hooks';
 export { USER_PROVIDED_EFFECTS } from './tokens';
 export { provideEffects } from './provide_effects';
-
-/**
- * @deprecated Use `concatLatestFrom` from `@ngrx/operators` instead.
- */
-export const concatLatestFrom = operators.concatLatestFrom;

--- a/projects/example-app/src/app/core/effects/router.effects.ts
+++ b/projects/example-app/src/app/core/effects/router.effects.ts
@@ -3,7 +3,8 @@ import { Title } from '@angular/platform-browser';
 
 import { map, tap } from 'rxjs/operators';
 
-import { Actions, concatLatestFrom, createEffect, ofType } from '@ngrx/effects';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { concatLatestFrom } from '@ngrx/operators';
 import { Store } from '@ngrx/store';
 import { routerNavigatedAction } from '@ngrx/router-store';
 

--- a/projects/ngrx.io/content/guide/eslint-plugin/rules/prefer-concat-latest-from.md
+++ b/projects/ngrx.io/content/guide/eslint-plugin/rules/prefer-concat-latest-from.md
@@ -75,5 +75,5 @@ To report only needed uses of `withLatestFrom` use:
 
 ## Further reading
 
-- [`concatLatestFrom` API](api/effects/concatLatestFrom)
+- [`concatLatestFrom` API](api/operators/concatLatestFrom)
 - [Incorporating State](guide/effects#incorporating-state)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGES:

The `concatLatestFrom` operator has been removed from `@ngrx/effects` in favor of the `@ngrx/operators` package.

BEFORE:

import { concatLatestFrom } from '@ngrx/effects';

AFTER:

import { concatLatestFrom } from '@ngrx/operators';
