### PR TITLE
fix(router-store): include string[] as return type for selectQueryParam

### DIFF
--- a/modules/router-store/spec/types/router_selectors.types.spec.ts
+++ b/modules/router-store/spec/types/router_selectors.types.spec.ts
@@ -53,7 +53,7 @@ describe('getRouterSelectors', () => {
     );
   });
 
-  it('selectQueryParam should return string', () => {
+  it('selectQueryParam should return string or string[]', () => {
     expectSnippet(`
       export const selectIdFromRoute = selectQueryParam('id')
       export const selector = createSelector(
@@ -62,7 +62,7 @@ describe('getRouterSelectors', () => {
       );
     `).toInfer(
       'selector',
-      'MemoizedSelector<State, string, (s1: string) => string>'
+      'MemoizedSelector<State, string | string[], (s1: string | string[]) => string | string[]>'
     );
   });
 

--- a/modules/router-store/src/models.ts
+++ b/modules/router-store/src/models.ts
@@ -5,7 +5,9 @@ export type RouterStateSelectors<V> = {
   selectCurrentRoute: MemoizedSelector<V, any>;
   selectFragment: MemoizedSelector<V, string | undefined>;
   selectQueryParams: MemoizedSelector<V, Params>;
-  selectQueryParam: (param: string) => MemoizedSelector<V, string | undefined>;
+  selectQueryParam: (
+    param: string
+  ) => MemoizedSelector<V, string | string[] | undefined>;
   selectRouteParams: MemoizedSelector<V, Params>;
   selectRouteParam: (param: string) => MemoizedSelector<V, string | undefined>;
   selectRouteData: MemoizedSelector<V, Data>;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4286 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

```
BREAKING CHANGE:

BEFORE:
The return type of `selectQueryParam` is `MemoizedSelector<V, string | undefined>`.

AFTER:
The return type of `selectQueryParam` now includes `string[]`, making the return type `MemoizedSelector<V, string | string[] | undefined>`.
```

## Other information
