### PR TITLE
feat(signals): add entityConfig function

### DIFF
--- a/modules/signals/entities/spec/types/entity-config.types.spec.ts
+++ b/modules/signals/entities/spec/types/entity-config.types.spec.ts
@@ -1,0 +1,176 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './helpers';
+
+describe('entityConfig', () => {
+  const expectSnippet = expecter(
+    (code) => `
+        import { type } from '@ngrx/signals';
+        import { entityConfig, SelectEntityId } from '@ngrx/signals/entities';
+
+        type User = { key: number; name: string };
+
+        ${code}
+      `,
+    compilerOptions()
+  );
+
+  it('fails when empty object is passed', () => {
+    expectSnippet('entityConfig({})').toFail(
+      /Property 'entity' is missing in type '{}'/
+    );
+  });
+
+  it('succeeds when entity is passed', () => {
+    const snippet = `
+      const userConfig = entityConfig({ entity: type<User>() });
+    `;
+
+    expectSnippet(snippet).toSucceed();
+    expectSnippet(snippet).toInfer('userConfig', '{ entity: User; }');
+  });
+
+  it('succeeds when entity and collection are passed', () => {
+    const snippet = `
+      const userConfig = entityConfig({
+        entity: type<User>(),
+        collection: 'user',
+      });
+    `;
+
+    expectSnippet(snippet).toSucceed();
+    expectSnippet(snippet).toInfer(
+      'userConfig',
+      '{ entity: User; collection: "user"; }'
+    );
+  });
+
+  it('succeeds when entity and selectId are passed', () => {
+    const snippet = `
+      const userConfig1 = entityConfig({
+        entity: type<User>(),
+        selectId: (user) => user.key,
+      });
+
+      const selectId2 = (user: User) => user.key;
+      const userConfig2 = entityConfig({
+        entity: type<User>(),
+        selectId: selectId2,
+      });
+
+      const selectId3: SelectEntityId<User> = (user) => user.key;
+      const userConfig3 = entityConfig({
+        entity: type<User>(),
+        selectId: selectId3,
+      });
+    `;
+
+    expectSnippet(snippet).toSucceed();
+    expectSnippet(snippet).toInfer(
+      'userConfig1',
+      '{ entity: User; selectId: SelectEntityId<NoInfer<User>>; }'
+    );
+    expectSnippet(snippet).toInfer(
+      'userConfig2',
+      '{ entity: User; selectId: SelectEntityId<NoInfer<User>>; }'
+    );
+    expectSnippet(snippet).toInfer(
+      'userConfig3',
+      '{ entity: User; selectId: SelectEntityId<NoInfer<User>>; }'
+    );
+  });
+
+  it('fails when entity and wrong selectId are passed', () => {
+    expectSnippet(`
+      const userConfig = entityConfig({
+        entity: type<User>(),
+        selectId: (user) => user.id,
+      });
+    `).toFail(/Property 'id' does not exist on type 'NoInfer<User>'/);
+
+    expectSnippet(`
+      const selectId = (entity: { key: number; foo: string }) => entity.key;
+
+      const userConfig = entityConfig({
+        entity: type<User>(),
+        selectId,
+      });
+    `).toFail(/No overload matches this call/);
+
+    expectSnippet(`
+      const selectId: SelectEntityId<{ key: string }> = (entity) => entity.key;
+
+      const userConfig = entityConfig({
+        entity: type<User>(),
+        selectId,
+      });
+    `).toFail(/No overload matches this call/);
+  });
+
+  it('succeeds when entity, collection, and selectId are passed', () => {
+    const snippet = `
+      const userConfig1 = entityConfig({
+        entity: type<User>(),
+        collection: 'user',
+        selectId: (user) => user.key,
+      });
+
+      const selectId2 = (user: { key: number }) => user.key;
+      const userConfig2 = entityConfig({
+        entity: type<User>(),
+        collection: 'user',
+        selectId: selectId2,
+      });
+
+      const selectId3: SelectEntityId<User> = (user) => user.key;
+      const userConfig3 = entityConfig({
+        entity: type<User>(),
+        collection: 'user',
+        selectId: selectId3,
+      });
+    `;
+
+    expectSnippet(snippet).toSucceed();
+    expectSnippet(snippet).toInfer(
+      'userConfig1',
+      '{ entity: User; collection: "user"; selectId: SelectEntityId<NoInfer<User>>; }'
+    );
+    expectSnippet(snippet).toInfer(
+      'userConfig2',
+      '{ entity: User; collection: "user"; selectId: SelectEntityId<NoInfer<User>>; }'
+    );
+    expectSnippet(snippet).toInfer(
+      'userConfig3',
+      '{ entity: User; collection: "user"; selectId: SelectEntityId<NoInfer<User>>; }'
+    );
+  });
+
+  it('fails when entity, collection, and wrong selectId are passed', () => {
+    expectSnippet(`
+      const userConfig = entityConfig({
+        entity: type<User>(),
+        collection: 'user',
+        selectId: (user) => user.id,
+      });
+    `).toFail(/Property 'id' does not exist on type 'NoInfer<User>'/);
+
+    expectSnippet(`
+      const selectId = (entity: { key: number; foo: string }) => entity.key;
+
+      const userConfig = entityConfig({
+        entity: type<User>(),
+        collection: 'user',
+        selectId,
+      });
+    `).toFail(/No overload matches this call/);
+
+    expectSnippet(`
+      const selectId: SelectEntityId<{ key: string }> = (entity) => entity.key;
+
+      const userConfig = entityConfig({
+        entity: type<User>(),
+        collection: 'user',
+        selectId,
+      });
+    `).toFail(/No overload matches this call/);
+  });
+});

--- a/modules/signals/entities/spec/types/helpers.ts
+++ b/modules/signals/entities/spec/types/helpers.ts
@@ -1,0 +1,12 @@
+export const compilerOptions = () => ({
+  moduleResolution: 'node',
+  target: 'ES2022',
+  baseUrl: '.',
+  experimentalDecorators: true,
+  strict: true,
+  noImplicitAny: true,
+  paths: {
+    '@ngrx/signals': ['./modules/signals'],
+    '@ngrx/signals/entities': ['./modules/signals/entities'],
+  },
+});

--- a/modules/signals/entities/spec/updaters/add-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/add-entities.spec.ts
@@ -1,5 +1,5 @@
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { addEntities, withEntities } from '../../src';
+import { addEntities, entityConfig, withEntities } from '../../src';
 import { Todo, todo1, todo2, todo3, User, user1, user2, user3 } from '../mocks';
 import { selectTodoId as selectId } from '../helpers';
 
@@ -205,18 +205,18 @@ describe('addEntities', () => {
   });
 
   it('does not add entities with a custom id to the specified collection if they already exist', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       collection: 'todo',
       selectId,
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(todoMeta));
+    const Store = signalStore(withEntities(todoConfig));
     const store = new Store();
 
     patchState(
       store,
-      addEntities([todo2, { ...todo2, text: 'NgRx' }, todo3, todo2], todoMeta)
+      addEntities([todo2, { ...todo2, text: 'NgRx' }, todo3, todo2], todoConfig)
     );
 
     const todoEntityMap = store.todoEntityMap();
@@ -225,8 +225,8 @@ describe('addEntities', () => {
 
     patchState(
       store,
-      addEntities([] as Todo[], todoMeta),
-      addEntities([todo3, todo2, { ...todo3, text: 'NgRx' }], todoMeta)
+      addEntities([] as Todo[], todoConfig),
+      addEntities([todo3, todo2, { ...todo3, text: 'NgRx' }], todoConfig)
     );
 
     expect(store.todoEntityMap()).toBe(todoEntityMap);
@@ -238,8 +238,8 @@ describe('addEntities', () => {
 
     patchState(
       store,
-      addEntities([todo1, todo2, todo3], todoMeta),
-      addEntities([todo2, todo3, todo1], todoMeta)
+      addEntities([todo1, todo2, todo3], todoConfig),
+      addEntities([todo2, todo3, todo1], todoConfig)
     );
 
     expect(store.todoEntityMap()).toEqual({ y: todo2, z: todo3, x: todo1 });

--- a/modules/signals/entities/spec/updaters/add-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/add-entity.spec.ts
@@ -1,5 +1,5 @@
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { addEntity, withEntities } from '../../src';
+import { addEntity, entityConfig, withEntities } from '../../src';
 import { Todo, todo1, todo2, User, user1, user2 } from '../mocks';
 import { selectTodoId as selectId } from '../helpers';
 
@@ -167,16 +167,20 @@ describe('addEntity', () => {
   });
 
   it('does not add entity with a custom id to the specified collection if it already exists', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       collection: 'todo',
       selectId,
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(todoMeta));
+    const Store = signalStore(withEntities(todoConfig));
     const store = new Store();
 
-    patchState(store, addEntity(todo1, todoMeta), addEntity(todo2, todoMeta));
+    patchState(
+      store,
+      addEntity(todo1, todoConfig),
+      addEntity(todo2, todoConfig)
+    );
 
     const todoEntityMap = store.todoEntityMap();
     const todoIds = store.todoIds();
@@ -184,10 +188,10 @@ describe('addEntity', () => {
 
     patchState(
       store,
-      addEntity(todo1, todoMeta),
-      addEntity({ ...todo1, text: 'NgRx' }, todoMeta),
-      addEntity(todo2, todoMeta),
-      addEntity(todo1, todoMeta)
+      addEntity(todo1, todoConfig),
+      addEntity({ ...todo1, text: 'NgRx' }, todoConfig),
+      addEntity(todo2, todoConfig),
+      addEntity(todo1, todoConfig)
     );
 
     expect(store.todoEntityMap()).toBe(todoEntityMap);

--- a/modules/signals/entities/spec/updaters/remove-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/remove-entities.spec.ts
@@ -1,5 +1,10 @@
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { addEntities, removeEntities, withEntities } from '../../src';
+import {
+  addEntities,
+  entityConfig,
+  removeEntities,
+  withEntities,
+} from '../../src';
 import { Todo, todo1, todo2, todo3, User, user1, user2, user3 } from '../mocks';
 import { selectTodoId } from '../helpers';
 
@@ -60,16 +65,16 @@ describe('removeEntities', () => {
   });
 
   it('removes entities by ids from specified collection', () => {
-    const userMeta = {
+    const userConfig = entityConfig({
       entity: type<User>(),
       collection: 'users',
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(userMeta));
+    const Store = signalStore(withEntities(userConfig));
     const store = new Store();
 
-    patchState(store, addEntities([user1, user2, user3], userMeta));
-    patchState(store, removeEntities([user1.id, user2.id], userMeta));
+    patchState(store, addEntities([user1, user2, user3], userConfig));
+    patchState(store, removeEntities([user1.id, user2.id], userConfig));
 
     expect(store.usersEntityMap()).toEqual({ 3: user3 });
     expect(store.usersIds()).toEqual([3]);
@@ -77,18 +82,18 @@ describe('removeEntities', () => {
   });
 
   it('removes entities by predicate from specified collection', () => {
-    const userMeta = {
+    const userConfig = entityConfig({
       entity: type<User>(),
       collection: 'users',
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(userMeta));
+    const Store = signalStore(withEntities(userConfig));
     const store = new Store();
 
     patchState(
       store,
-      addEntities([user1, user2, user3], userMeta),
-      removeEntities((user) => user.lastName.startsWith('J'), userMeta)
+      addEntities([user1, user2, user3], userConfig),
+      removeEntities((user) => user.lastName.startsWith('J'), userConfig)
     );
 
     expect(store.usersEntityMap()).toEqual({ 1: user1, 2: user2 });
@@ -97,16 +102,16 @@ describe('removeEntities', () => {
   });
 
   it('does not modify entity state if entities do not exist in specified collection', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       collection: 'todo',
       selectId: selectTodoId,
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(todoMeta));
+    const Store = signalStore(withEntities(todoConfig));
     const store = new Store();
 
-    patchState(store, addEntities([todo1, todo2, todo3], todoMeta));
+    patchState(store, addEntities([todo1, todo2, todo3], todoConfig));
 
     const todoEntityMap = store.todoEntityMap();
     const todoIds = store.todoIds();
@@ -114,8 +119,8 @@ describe('removeEntities', () => {
 
     patchState(
       store,
-      removeEntities(['a', 'b'], todoMeta),
-      removeEntities((todo) => todo.text === 'NgRx', todoMeta)
+      removeEntities(['a', 'b'], todoConfig),
+      removeEntities((todo) => todo.text === 'NgRx', todoConfig)
     );
 
     expect(store.todoEntityMap()).toBe(todoEntityMap);

--- a/modules/signals/entities/spec/updaters/remove-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/remove-entity.spec.ts
@@ -1,5 +1,10 @@
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { addEntities, removeEntity, withEntities } from '../../src';
+import {
+  addEntities,
+  entityConfig,
+  removeEntity,
+  withEntities,
+} from '../../src';
 import { Todo, todo1, todo2, todo3, User, user1, user2 } from '../mocks';
 import { selectTodoId } from '../helpers';
 
@@ -37,26 +42,26 @@ describe('removeEntity', () => {
   });
 
   it('removes entity from specified collection', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       collection: 'todo',
       selectId: selectTodoId,
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(todoMeta));
+    const Store = signalStore(withEntities(todoConfig));
     const store = new Store();
 
     patchState(
       store,
-      addEntities([todo1, todo2, todo3], todoMeta),
-      removeEntity(todo1._id, todoMeta)
+      addEntities([todo1, todo2, todo3], todoConfig),
+      removeEntity(todo1._id, todoConfig)
     );
 
     expect(store.todoEntityMap()).toEqual({ y: todo2, z: todo3 });
     expect(store.todoIds()).toEqual(['y', 'z']);
     expect(store.todoEntities()).toEqual([todo2, todo3]);
 
-    patchState(store, removeEntity(todo2._id, todoMeta));
+    patchState(store, removeEntity(todo2._id, todoConfig));
 
     expect(store.todoEntityMap()).toEqual({ z: todo3 });
     expect(store.todoIds()).toEqual(['z']);

--- a/modules/signals/entities/spec/updaters/set-all-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/set-all-entities.spec.ts
@@ -1,5 +1,5 @@
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { setAllEntities, withEntities } from '../../src';
+import { entityConfig, setAllEntities, withEntities } from '../../src';
 import { Todo, todo1, todo2, todo3, User, user1, user2, user3 } from '../mocks';
 import { selectTodoId as selectId } from '../helpers';
 
@@ -82,28 +82,28 @@ describe('setAllEntities', () => {
   });
 
   it('replaces specified entity collection with provided entities with a custom id', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       collection: 'todo',
       selectId,
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(todoMeta));
+    const Store = signalStore(withEntities(todoConfig));
     const store = new Store();
 
-    patchState(store, setAllEntities([todo1, todo3], todoMeta));
+    patchState(store, setAllEntities([todo1, todo3], todoConfig));
 
     expect(store.todoEntityMap()).toEqual({ x: todo1, z: todo3 });
     expect(store.todoIds()).toEqual(['x', 'z']);
     expect(store.todoEntities()).toEqual([todo1, todo3]);
 
-    patchState(store, setAllEntities([todo3, todo2, todo1], todoMeta));
+    patchState(store, setAllEntities([todo3, todo2, todo1], todoConfig));
 
     expect(store.todoEntityMap()).toEqual({ z: todo3, y: todo2, x: todo1 });
     expect(store.todoIds()).toEqual(['z', 'y', 'x']);
     expect(store.todoEntities()).toEqual([todo3, todo2, todo1]);
 
-    patchState(store, setAllEntities([] as Todo[], todoMeta));
+    patchState(store, setAllEntities([] as Todo[], todoConfig));
 
     expect(store.todoEntityMap()).toEqual({});
     expect(store.todoIds()).toEqual([]);

--- a/modules/signals/entities/spec/updaters/set-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/set-entities.spec.ts
@@ -1,5 +1,5 @@
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { setEntities, withEntities } from '../../src';
+import { entityConfig, setEntities, withEntities } from '../../src';
 import { Todo, todo1, todo2, todo3, User, user1, user2, user3 } from '../mocks';
 import { selectTodoId as selectId } from '../helpers';
 
@@ -202,20 +202,23 @@ describe('setEntities', () => {
   });
 
   it('replaces entities with a custom id to the specified collection if they already exist', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       collection: 'todo',
       selectId,
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(todoMeta));
+    const Store = signalStore(withEntities(todoConfig));
     const store = new Store();
 
     patchState(
       store,
-      setEntities([todo2, { ...todo2, text: 'NgRx' }, todo3, todo2], todoMeta),
-      setEntities([] as Todo[], todoMeta),
-      setEntities([todo3, { ...todo3, text: 'NgRx' }, todo1], todoMeta)
+      setEntities(
+        [todo2, { ...todo2, text: 'NgRx' }, todo3, todo2],
+        todoConfig
+      ),
+      setEntities([] as Todo[], todoConfig),
+      setEntities([todo3, { ...todo3, text: 'NgRx' }, todo1], todoConfig)
     );
 
     expect(store.todoEntityMap()).toEqual({

--- a/modules/signals/entities/spec/updaters/set-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/set-entity.spec.ts
@@ -1,5 +1,5 @@
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { setEntity, withEntities } from '../../src';
+import { entityConfig, setEntity, withEntities } from '../../src';
 import { Todo, todo1, todo2, User, user1, user2, user3 } from '../mocks';
 import { selectTodoId as selectId } from '../helpers';
 
@@ -146,22 +146,26 @@ describe('setEntity', () => {
   });
 
   it('replaces entity with a custom id to the specified collection if it already exists', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       collection: 'todo',
       selectId,
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(todoMeta));
+    const Store = signalStore(withEntities(todoConfig));
     const store = new Store();
 
-    patchState(store, setEntity(todo1, todoMeta), setEntity(todo2, todoMeta));
     patchState(
       store,
-      setEntity({ ...todo2, text: 'Signals' }, todoMeta),
-      setEntity(todo1, todoMeta),
-      setEntity({ ...todo1, text: 'NgRx' }, todoMeta),
-      setEntity(todo2, todoMeta)
+      setEntity(todo1, todoConfig),
+      setEntity(todo2, todoConfig)
+    );
+    patchState(
+      store,
+      setEntity({ ...todo2, text: 'Signals' }, todoConfig),
+      setEntity(todo1, todoConfig),
+      setEntity({ ...todo1, text: 'NgRx' }, todoConfig),
+      setEntity(todo2, todoConfig)
     );
 
     expect(store.todoEntityMap()).toEqual({

--- a/modules/signals/entities/spec/updaters/update-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/update-entities.spec.ts
@@ -1,5 +1,10 @@
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { addEntities, updateEntities, withEntities } from '../../src';
+import {
+  addEntities,
+  entityConfig,
+  updateEntities,
+  withEntities,
+} from '../../src';
 import { Todo, todo1, todo2, todo3, User, user1, user2, user3 } from '../mocks';
 import { selectTodoId } from '../helpers';
 
@@ -100,15 +105,15 @@ describe('updateEntities', () => {
   });
 
   it('updates entities by ids from specified collection', () => {
-    const userMeta = {
+    const userConfig = entityConfig({
       entity: type<User>(),
       collection: 'users',
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(userMeta));
+    const Store = signalStore(withEntities(userConfig));
     const store = new Store();
 
-    patchState(store, addEntities([user1, user2, user3], userMeta));
+    patchState(store, addEntities([user1, user2, user3], userConfig));
     patchState(
       store,
       updateEntities(
@@ -116,14 +121,14 @@ describe('updateEntities', () => {
           ids: [user1.id, user2.id, 20, 30],
           changes: { lastName: 'Hendrix' },
         },
-        userMeta
+        userConfig
       ),
       updateEntities(
         {
           ids: [user1.id, user3.id],
           changes: ({ id }) => ({ firstName: `Jimmy${id}` }),
         },
-        userMeta
+        userConfig
       )
     );
 
@@ -141,30 +146,30 @@ describe('updateEntities', () => {
   });
 
   it('updates entities by predicate from specified collection', () => {
-    const userMeta = {
+    const userConfig = entityConfig({
       entity: type<User>(),
       collection: 'users',
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(userMeta));
+    const Store = signalStore(withEntities(userConfig));
     const store = new Store();
 
     patchState(
       store,
-      addEntities([user1, user2, user3], userMeta),
+      addEntities([user1, user2, user3], userConfig),
       updateEntities(
         {
           predicate: ({ id }) => id < 3,
           changes: { lastName: 'Hendrix' },
         },
-        userMeta
+        userConfig
       ),
       updateEntities(
         {
           predicate: ({ id }) => id > 2,
           changes: ({ id }) => ({ firstName: `Jimmy${id}` }),
         },
-        userMeta
+        userConfig
       )
     );
 
@@ -182,16 +187,16 @@ describe('updateEntities', () => {
   });
 
   it('does not modify entity state if entities do not exist in specified collection', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       collection: 'todo',
-      selectId: selectTodoId,
-    } as const;
+      selectId: (todo) => todo._id,
+    });
 
-    const Store = signalStore(withEntities(todoMeta));
+    const Store = signalStore(withEntities(todoConfig));
     const store = new Store();
 
-    patchState(store, addEntities([todo1, todo2, todo3], todoMeta));
+    patchState(store, addEntities([todo1, todo2, todo3], todoConfig));
 
     const todoEntityMap = store.todoEntityMap();
     const todoIds = store.todoIds();
@@ -204,14 +209,14 @@ describe('updateEntities', () => {
           ids: ['a', 'b'],
           changes: { completed: false },
         },
-        todoMeta
+        todoConfig
       ),
       updateEntities(
         {
           predicate: (todo) => todo.text === 'NgRx',
           changes: ({ text }) => ({ text: `Don't ${text}` }),
         },
-        todoMeta
+        todoConfig
       )
     );
 

--- a/modules/signals/entities/spec/updaters/update-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/update-entity.spec.ts
@@ -1,5 +1,10 @@
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { addEntities, updateEntity, withEntities } from '../../src';
+import {
+  addEntities,
+  entityConfig,
+  updateEntity,
+  withEntities,
+} from '../../src';
 import { Todo, todo1, todo2, todo3, User, user1, user2, user3 } from '../mocks';
 import { selectTodoId } from '../helpers';
 
@@ -55,15 +60,15 @@ describe('updateEntity', () => {
   });
 
   it('does not modify entity state if entity do not exist', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       selectId: selectTodoId,
-    } as const;
+    });
 
-    const Store = signalStore(withEntities(todoMeta));
+    const Store = signalStore(withEntities(todoConfig));
     const store = new Store();
 
-    patchState(store, addEntities([todo2, todo3], todoMeta));
+    patchState(store, addEntities([todo2, todo3], todoConfig));
 
     const entityMap = store.entityMap();
     const ids = store.ids();
@@ -132,15 +137,16 @@ describe('updateEntity', () => {
   });
 
   it('does not modify entity state if entity do not exist in specified collection', () => {
-    const userMeta = {
+    const userConfig = entityConfig({
       entity: type<User>(),
       collection: 'user',
-    } as const;
+      selectId: (user) => user.id,
+    });
 
-    const Store = signalStore(withEntities(userMeta));
+    const Store = signalStore(withEntities(userConfig));
     const store = new Store();
 
-    patchState(store, addEntities([user1, user2, user3], userMeta));
+    patchState(store, addEntities([user1, user2, user3], userConfig));
 
     const userEntityMap = store.userEntityMap();
     const userEntities = store.userEntities();
@@ -148,13 +154,13 @@ describe('updateEntity', () => {
 
     patchState(
       store,
-      updateEntity({ id: 10, changes: { firstName: '' } }, userMeta),
+      updateEntity({ id: 10, changes: { firstName: '' } }, userConfig),
       updateEntity(
         {
           id: 100,
           changes: ({ id, lastName }) => ({ lastName: `${lastName}${id}` }),
         },
-        userMeta
+        userConfig
       )
     );
 

--- a/modules/signals/entities/spec/with-entities.spec.ts
+++ b/modules/signals/entities/spec/with-entities.spec.ts
@@ -1,6 +1,6 @@
 import { isSignal } from '@angular/core';
 import { patchState, signalStore, type } from '@ngrx/signals';
-import { addEntities, withEntities } from '../src';
+import { addEntities, entityConfig, withEntities } from '../src';
 import { Todo, todo2, todo3, User, user1, user2 } from './mocks';
 import { selectTodoId } from './helpers';
 
@@ -48,13 +48,13 @@ describe('withEntities', () => {
   });
 
   it('combines multiple entity features', () => {
-    const todoMeta = {
+    const todoConfig = entityConfig({
       entity: type<Todo>(),
       collection: 'todo',
       selectId: selectTodoId,
-    } as const;
+    });
 
-    const Store = signalStore(withEntities<User>(), withEntities(todoMeta));
+    const Store = signalStore(withEntities<User>(), withEntities(todoConfig));
     const store = new Store();
 
     expect(isSignal(store.entityMap)).toBe(true);
@@ -75,7 +75,7 @@ describe('withEntities', () => {
     patchState(
       store,
       addEntities([user2, user1]),
-      addEntities([todo2, todo3], todoMeta)
+      addEntities([todo2, todo3], todoConfig)
     );
 
     expect(store.entityMap()).toEqual({ 2: user2, 1: user1 });

--- a/modules/signals/entities/src/entity-config.ts
+++ b/modules/signals/entities/src/entity-config.ts
@@ -1,0 +1,23 @@
+import { SelectEntityId } from './models';
+
+export function entityConfig<Entity, Collection extends string>(config: {
+  entity: Entity;
+  collection: Collection;
+  selectId: SelectEntityId<NoInfer<Entity>>;
+}): typeof config;
+export function entityConfig<Entity>(config: {
+  entity: Entity;
+  selectId: SelectEntityId<NoInfer<Entity>>;
+}): typeof config;
+export function entityConfig<Entity, Collection extends string>(config: {
+  entity: Entity;
+  collection: Collection;
+}): typeof config;
+export function entityConfig<Entity>(config: { entity: Entity }): typeof config;
+export function entityConfig<Entity>(config: {
+  entity: Entity;
+  collection?: string;
+  selectId?: SelectEntityId<Entity>;
+}): typeof config {
+  return config;
+}

--- a/modules/signals/entities/src/index.ts
+++ b/modules/signals/entities/src/index.ts
@@ -10,6 +10,7 @@ export { updateEntity } from './updaters/update-entity';
 export { updateEntities } from './updaters/update-entities';
 export { updateAllEntities } from './updaters/update-all-entities';
 
+export { entityConfig } from './entity-config';
 export {
   EntityId,
   EntityMap,

--- a/projects/ngrx.io/content/guide/signals/signal-store/entity-management.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/entity-management.md
@@ -340,6 +340,36 @@ const Store = signalStore(
 
 Try to avoid multiple entity types in one store. It is better to have multiple stores, each with a single entity type.
 
+---
+
+To avoid repetitive code, it's recommended to use the `entityConfig` function when defining a custom entity configuration:
+
+```typescript
+const todoConfig = entityConfig({
+  entity: type<Todo>(),
+  collection: 'todo',
+  selectId: (todo) => todo.key,
+});
+
+const userConfig = entityConfig({
+  entity: type<User>(),
+  collection: 'user',
+});
+
+const Store = signalStore(
+  withEntities(todoConfig),
+  withEntities(userConfig),
+  withMethods((store) => ({
+    addTodo(todo: Todo): void {
+      patchState(store, addEntity(todo, todoConfig));
+    },
+    addUser(user: User): void {
+      patchState(store, addEntity(user, userConfig));
+    },
+  }))
+);
+```
+
 ## Extending and Integrating
 
 You will usually want to persist your entities to a backend. Therefore, you must additionally implement `withMethods` and add the necessary methods.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```ts
const selectId: SelectEntityId<Todo> = (todo) => todo.key;

const Store = signalStore(
  withEntities({ entity: type<Todo>(), collection: 'todo' }),
  withEntities({ entity: type<User>(), collection: 'user' }),
  withMethods((store) => ({
    addTodo(todo: Todo): void {
      patchState(store, addEntity(todo, { collection: 'todo', selectId }));
    },
    addUser(user: User): void {
      patchState(store, addEntity(user, { collection: 'user' }));
    },
  }))
);
```

Closes #4393 

## What is the new behavior?

```ts
const todoConfig = entityConfig({
  entity: type<Todo>(),
  collection: 'todo',
  selectId: (todo) => todo.key,
});

const userConfig = entityConfig({
  entity: type<User>(),
  collection: 'user',
});

const Store = signalStore(
  withEntities(todoConfig),
  withEntities(userConfig),
  withMethods((store) => ({
    addTodo(todo: Todo): void {
      patchState(store, addEntity(todo, todoConfig));
    },
    addUser(user: User): void {
      patchState(store, addEntity(user, userConfig));
    },
  }))
);
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
