### PR TITLE
fix(effects): fix bugs in migration script to v18

### DIFF
--- a/modules/effects/migrations/18_0_0-beta/index.spec.ts
+++ b/modules/effects/migrations/18_0_0-beta/index.spec.ts
@@ -185,7 +185,7 @@ class SomeEffects {}
     expect(actualMainTwo).toBe(outputMainTwo);
   });
 
-  it('should report a warning on multiple imports of concatLatestFrom', async () => {
+  it('should report an info on multiple imports of concatLatestFrom', async () => {
     const input = tags.stripIndent`
 import { concatLatestFrom } from '@ngrx/effects';
 import { concatLatestFrom, createEffect, ofType } from '@ngrx/effects';
@@ -206,7 +206,7 @@ class SomeEffects {}
     expect(logEntries[0]).toMatchObject({
       message:
         '[@ngrx/effects] Skipping because of multiple `concatLatestFrom` imports',
-      level: 'warn',
+      level: 'info',
     });
   });
 

--- a/modules/effects/migrations/18_0_0-beta/index.ts
+++ b/modules/effects/migrations/18_0_0-beta/index.ts
@@ -14,7 +14,6 @@ import {
   visitTSSourceFiles,
 } from '../../schematics-core';
 import { createRemoveChange } from '../../schematics-core/utility/change';
-import * as os from 'node:os';
 
 export function migrateConcatLatestFromImport(): Rule {
   return (tree: Tree, ctx: SchematicContext) => {
@@ -48,7 +47,7 @@ export function migrateConcatLatestFromImport(): Rule {
       if (effectsImportsAndDeclarations.length === 0) {
         return;
       } else if (effectsImportsAndDeclarations.length > 1) {
-        ctx.logger.warn(
+        ctx.logger.info(
           '[@ngrx/effects] Skipping because of multiple `concatLatestFrom` imports'
         );
         return;
@@ -126,7 +125,7 @@ export function migrateConcatLatestFromImport(): Rule {
           new InsertChange(
             sourceFile.fileName,
             effectsImportDeclaration.getEnd() + 1,
-            `${newOperatorsImport}${os.EOL}`
+            `${newOperatorsImport}\n` // not os-independent for snapshot tests
           )
         );
       }


### PR DESCRIPTION
ChangeLog:
- Update 17.6: Remove `os.EOL`.

This commit fixes one major bug and some edge cases in the migration script.

- Reset the changes array with every file.
- Fix an issue when a file has multiple import declarations to `@ngrx/effects`.
- Print out a warning if `concatLatestFrom` is imported multiple times.

The same problem exists for the component store's migration script. I will provide a PR for that as well.

I'm afraid a new patch release is necessary. Apologies, I'm very sorry!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[] Other... Please describe:
```

Closes #4397

## Does this PR introduce a breaking change?

```
[] Yes
[x] No
```



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
