### PR TITLE
fix(component-store): resolve issues in migration script to v18

### DIFF
--- a/modules/component-store/migrations/18_0_0-beta/index.spec.ts
+++ b/modules/component-store/migrations/18_0_0-beta/index.spec.ts
@@ -5,6 +5,7 @@ import {
 import { createWorkspace } from '@ngrx/schematics-core/testing';
 import { tags } from '@angular-devkit/core';
 import * as path from 'path';
+import { LogEntry } from '@angular-devkit/core/src/logger';
 
 describe('ComponentStore Migration to 18.0.0-beta', () => {
   const collectionPath = path.join(__dirname, '../migration.json');
@@ -114,6 +115,100 @@ export class MyStore extends ComponentStore {
 }
       `;
       await verifySchematic(input, output);
+    });
+  });
+
+  it('should work with prior import from same namespace', async () => {
+    const input = tags.stripIndent`
+import { ComponentStore, provideComponentStore } from '@ngrx/component-store';
+import { tapResponse } from '@ngrx/component-store';
+
+export class MyStore extends ComponentStore {}
+      `;
+    const output = tags.stripIndent`
+import { ComponentStore, provideComponentStore } from '@ngrx/component-store';
+import { tapResponse } from '@ngrx/operators';
+
+export class MyStore extends ComponentStore {}
+      `;
+    await verifySchematic(input, output);
+  });
+
+  it('should operate on multiple files', async () => {
+    const inputMainOne = tags.stripIndent`
+import { ComponentStore, tapResponse } from '@ngrx/component-store';
+import { concatLatestFrom } from '@ngrx/operators';
+
+@Injectable()
+export class MyStore extends ComponentStore {
+
+}
+`;
+
+    const outputMainOne = tags.stripIndent`
+import { ComponentStore } from '@ngrx/component-store';
+import { concatLatestFrom, tapResponse } from '@ngrx/operators';
+
+@Injectable()
+export class MyStore extends ComponentStore {
+
+}
+`;
+
+    const inputMainTwo = tags.stripIndent`
+import { tapResponse } from "@ngrx/component-store";
+
+@Injectable()
+export class MyStore extends ComponentStore {
+
+}
+      `;
+    const outputMainTwo = tags.stripIndent`
+import { tapResponse } from '@ngrx/operators';
+
+@Injectable()
+export class MyStore extends ComponentStore {
+
+}
+`;
+    appTree.create('mainOne.ts', inputMainOne);
+    appTree.create('mainTwo.ts', inputMainTwo);
+
+    const tree = await schematicRunner.runSchematic(
+      `ngrx-component-store-migration-18-beta`,
+      {},
+      appTree
+    );
+
+    const actualMainOne = tree.readContent('mainOne.ts');
+    const actualMainTwo = tree.readContent('mainTwo.ts');
+
+    expect(actualMainOne).toBe(outputMainOne);
+    expect(actualMainTwo).toBe(outputMainTwo);
+  });
+
+  it('should report a warning on multiple imports of tapResponse', async () => {
+    const input = tags.stripIndent`
+import { tapResponse } from '@ngrx/component-store';
+import { tapResponse, ComponentStore } from '@ngrx/component-store';
+
+class SomeEffects {}
+      `;
+
+    appTree.create('main.ts', input);
+    const logEntries: LogEntry[] = [];
+    schematicRunner.logger.subscribe((logEntry) => logEntries.push(logEntry));
+    await schematicRunner.runSchematic(
+      `ngrx-component-store-migration-18-beta`,
+      {},
+      appTree
+    );
+
+    expect(logEntries).toHaveLength(1);
+    expect(logEntries[0]).toMatchObject({
+      message:
+        '[@ngrx/component-store] Skipping because of multiple `tapResponse` imports',
+      level: 'warn',
     });
   });
 

--- a/modules/component-store/migrations/18_0_0-beta/index.spec.ts
+++ b/modules/component-store/migrations/18_0_0-beta/index.spec.ts
@@ -208,7 +208,7 @@ class SomeEffects {}
     expect(logEntries[0]).toMatchObject({
       message:
         '[@ngrx/component-store] Skipping because of multiple `tapResponse` imports',
-      level: 'warn',
+      level: 'info',
     });
   });
 

--- a/modules/component-store/migrations/18_0_0-beta/index.ts
+++ b/modules/component-store/migrations/18_0_0-beta/index.ts
@@ -14,7 +14,6 @@ import {
   visitTSSourceFiles,
 } from '../../schematics-core';
 import { createRemoveChange } from '../../schematics-core/utility/change';
-import * as os from 'node:os';
 
 export function migrateTapResponseImport(): Rule {
   return (tree: Tree, ctx: SchematicContext) => {
@@ -47,7 +46,7 @@ export function migrateTapResponseImport(): Rule {
       if (componentStoreImportsAndDeclarations.length === 0) {
         return;
       } else if (componentStoreImportsAndDeclarations.length > 1) {
-        ctx.logger.warn(
+        ctx.logger.info(
           '[@ngrx/component-store] Skipping because of multiple `tapResponse` imports'
         );
         return;
@@ -125,7 +124,7 @@ export function migrateTapResponseImport(): Rule {
           new InsertChange(
             sourceFile.fileName,
             componentStoreImportDeclaration.getEnd() + 1,
-            `${newOperatorsImport}${os.EOL}`
+            `${newOperatorsImport}\n` // not os-independent for snapshot tests
           )
         );
       }


### PR DESCRIPTION
ChangeLog
 - 17.5.2024: Remove `os.EOL`

Fixes the migration script for `tapResponse` in v18. It is exactly the same as in #4402:

- Reset the `changes` array for each file.
- Correct handling of files with multiple import declarations to `@ngrx/component-store`.
- Add a warning when `tapResponse` is imported multiple times.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Closes: No Issues have been reported yet


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
