### PR TITLE
fix(signals): allow modifying entity id on update

### DIFF
--- a/modules/signals/entities/spec/updaters/update-all-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/update-all-entities.spec.ts
@@ -51,8 +51,10 @@ describe('updateAllEntities', () => {
 
     patchState(
       store,
-      updateAllEntities({ text: '' }),
-      updateAllEntities((todo) => ({ completed: !todo.completed }))
+      updateAllEntities({ text: '' }, { selectId: (todo) => todo._id }),
+      updateAllEntities((todo) => ({ completed: !todo.completed }), {
+        selectId: (todo) => todo._id,
+      })
     );
 
     expect(store.entityMap()).toBe(entityMap);
@@ -79,7 +81,13 @@ describe('updateAllEntities', () => {
         collection: 'todo',
         selectId: selectTodoId,
       }),
-      updateAllEntities({ completed: false }, { collection: 'todo' })
+      updateAllEntities(
+        { completed: false },
+        {
+          collection: 'todo',
+          selectId: (todo) => todo._id,
+        }
+      )
     );
 
     expect(store.todoEntityMap()).toEqual({
@@ -98,6 +106,7 @@ describe('updateAllEntities', () => {
       store,
       updateAllEntities(({ completed }) => ({ completed: !completed }), {
         collection: 'todo',
+        selectId: (todo) => todo._id,
       })
     );
 

--- a/modules/signals/entities/spec/updaters/update-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/update-entities.spec.ts
@@ -50,14 +50,20 @@ describe('updateEntities', () => {
 
     patchState(
       store,
-      updateEntities({
-        predicate: (todo) => todo.text.startsWith('Buy'),
-        changes: { completed: false },
-      }),
-      updateEntities({
-        predicate: ({ completed }) => !completed,
-        changes: ({ text }) => ({ text: `Don't ${text}` }),
-      })
+      updateEntities(
+        {
+          predicate: (todo) => todo.text.startsWith('Buy'),
+          changes: { completed: false },
+        },
+        { selectId: (todo) => todo._id }
+      ),
+      updateEntities(
+        {
+          predicate: ({ completed }) => !completed,
+          changes: ({ text }) => ({ text: `Don't ${text}` }),
+        },
+        { selectId: (todo) => todo._id }
+      )
     );
 
     expect(store.entityMap()).toEqual({
@@ -227,5 +233,230 @@ describe('updateEntities', () => {
     expect(store.todoEntityMap()).toEqual({ x: todo1, y: todo2, z: todo3 });
     expect(store.todoIds()).toEqual(['x', 'y', 'z']);
     expect(store.todoEntities()).toEqual([todo1, todo2, todo3]);
+  });
+
+  it('updates entity ids', () => {
+    const Store = signalStore(withEntities<User>());
+    const store = new Store();
+
+    patchState(
+      store,
+      addEntities([user1, user2, user3]),
+      updateEntities({
+        ids: [user1.id, user2.id],
+        changes: ({ id }) => ({ id: id + 10, firstName: `Jimmy${id}` }),
+      }),
+      updateEntities({
+        ids: [user3.id],
+        changes: { id: 303, lastName: 'Hendrix' },
+      })
+    );
+
+    expect(store.entityMap()).toEqual({
+      11: { ...user1, id: 11, firstName: 'Jimmy1' },
+      12: { ...user2, id: 12, firstName: 'Jimmy2' },
+      303: { ...user3, id: 303, lastName: 'Hendrix' },
+    });
+    expect(store.ids()).toEqual([11, 12, 303]);
+
+    patchState(
+      store,
+      updateEntities({
+        predicate: ({ id }) => id > 300,
+        changes: ({ id }) => ({ id: id - 300 }),
+      }),
+      updateEntities({
+        predicate: ({ firstName }) => firstName === 'Jimmy1',
+        changes: { id: 1, firstName: 'Jimmy' },
+      })
+    );
+
+    expect(store.entityMap()).toEqual({
+      1: { ...user1, id: 1, firstName: 'Jimmy' },
+      12: { ...user2, id: 12, firstName: 'Jimmy2' },
+      3: { ...user3, id: 3, lastName: 'Hendrix' },
+    });
+    expect(store.ids()).toEqual([1, 12, 3]);
+  });
+
+  it('updates custom entity ids', () => {
+    const Store = signalStore(withEntities<Todo>());
+    const store = new Store();
+
+    patchState(
+      store,
+      addEntities([todo1, todo2, todo3], { selectId: (todo) => todo._id }),
+      updateEntities(
+        {
+          ids: [todo1._id, todo2._id],
+          changes: ({ _id }) => ({ _id: _id + 10, text: `Todo ${_id}` }),
+        },
+        { selectId: (todo) => todo._id }
+      ),
+      updateEntities(
+        {
+          ids: [todo3._id],
+          changes: { _id: 'z30' },
+        },
+        { selectId: (todo) => todo._id }
+      )
+    );
+
+    expect(store.entityMap()).toEqual({
+      x10: { ...todo1, _id: 'x10', text: 'Todo x' },
+      y10: { ...todo2, _id: 'y10', text: 'Todo y' },
+      z30: { ...todo3, _id: 'z30' },
+    });
+    expect(store.ids()).toEqual(['x10', 'y10', 'z30']);
+
+    patchState(
+      store,
+      updateEntities(
+        {
+          predicate: ({ text }) => text.startsWith('Todo '),
+          changes: ({ _id }) => ({ _id: `${_id}0` }),
+        },
+        { selectId: (todo) => todo._id }
+      ),
+      updateEntities(
+        {
+          predicate: ({ _id }) => _id === 'z30',
+          changes: { _id: 'z' },
+        },
+        { selectId: (todo) => todo._id }
+      )
+    );
+
+    expect(store.entityMap()).toEqual({
+      x100: { ...todo1, _id: 'x100', text: 'Todo x' },
+      y100: { ...todo2, _id: 'y100', text: 'Todo y' },
+      z: { ...todo3, _id: 'z' },
+    });
+    expect(store.ids()).toEqual(['x100', 'y100', 'z']);
+  });
+
+  it('updates entity ids from specified collection', () => {
+    const Store = signalStore(
+      withEntities({
+        entity: type<User>(),
+        collection: 'user',
+      })
+    );
+    const store = new Store();
+
+    patchState(
+      store,
+      addEntities([user1, user2, user3], { collection: 'user' }),
+      updateEntities(
+        {
+          ids: [user1.id, user2.id],
+          changes: ({ id }) => ({ id: id + 100, firstName: `Jimmy${id}` }),
+        },
+        { collection: 'user' }
+      ),
+      updateEntities(
+        {
+          ids: [user3.id],
+          changes: { id: 303, lastName: 'Hendrix' },
+        },
+        { collection: 'user' }
+      )
+    );
+
+    expect(store.userEntityMap()).toEqual({
+      101: { ...user1, id: 101, firstName: 'Jimmy1' },
+      102: { ...user2, id: 102, firstName: 'Jimmy2' },
+      303: { ...user3, id: 303, lastName: 'Hendrix' },
+    });
+    expect(store.userIds()).toEqual([101, 102, 303]);
+
+    patchState(
+      store,
+      updateEntities(
+        {
+          predicate: ({ id }) => id > 300,
+          changes: ({ id }) => ({ id: id - 300 }),
+        },
+        { collection: 'user' }
+      ),
+      updateEntities(
+        {
+          predicate: ({ firstName }) => firstName === 'Jimmy1',
+          changes: { id: 1, firstName: 'Jimmy' },
+        },
+        { collection: 'user' }
+      )
+    );
+
+    expect(store.userEntityMap()).toEqual({
+      1: { ...user1, id: 1, firstName: 'Jimmy' },
+      102: { ...user2, id: 102, firstName: 'Jimmy2' },
+      3: { ...user3, id: 3, lastName: 'Hendrix' },
+    });
+    expect(store.userIds()).toEqual([1, 102, 3]);
+  });
+
+  it('updates custom entity ids from specified collection', () => {
+    const Store = signalStore(
+      withEntities({
+        entity: type<Todo>(),
+        collection: 'todo',
+      })
+    );
+    const store = new Store();
+
+    patchState(
+      store,
+      addEntities([todo1, todo2, todo3], {
+        collection: 'todo',
+        selectId: (todo) => todo._id,
+      }),
+      updateEntities(
+        {
+          ids: [todo1._id, todo2._id],
+          changes: ({ _id }) => ({ _id: _id + 10, text: `Todo ${_id}` }),
+        },
+        { collection: 'todo', selectId: (todo) => todo._id }
+      ),
+      updateEntities(
+        {
+          ids: [todo3._id],
+          changes: { _id: 'z30' },
+        },
+        { collection: 'todo', selectId: (todo) => todo._id }
+      )
+    );
+
+    expect(store.todoEntityMap()).toEqual({
+      x10: { ...todo1, _id: 'x10', text: 'Todo x' },
+      y10: { ...todo2, _id: 'y10', text: 'Todo y' },
+      z30: { ...todo3, _id: 'z30' },
+    });
+    expect(store.todoIds()).toEqual(['x10', 'y10', 'z30']);
+
+    patchState(
+      store,
+      updateEntities(
+        {
+          predicate: ({ text }) => text.startsWith('Todo '),
+          changes: ({ _id }) => ({ _id: `${_id}0` }),
+        },
+        { collection: 'todo', selectId: (todo) => todo._id }
+      ),
+      updateEntities(
+        {
+          predicate: ({ _id }) => _id === 'z30',
+          changes: { _id: 'z' },
+        },
+        { collection: 'todo', selectId: (todo) => todo._id }
+      )
+    );
+
+    expect(store.todoEntityMap()).toEqual({
+      x100: { ...todo1, _id: 'x100', text: 'Todo x' },
+      y100: { ...todo2, _id: 'y100', text: 'Todo y' },
+      z: { ...todo3, _id: 'z' },
+    });
+    expect(store.todoIds()).toEqual(['x100', 'y100', 'z']);
   });
 });

--- a/modules/signals/entities/src/updaters/update-all-entities.ts
+++ b/modules/signals/entities/src/updaters/update-all-entities.ts
@@ -1,27 +1,55 @@
 import { PartialStateUpdater } from '@ngrx/signals';
-import { EntityChanges, EntityState, NamedEntityState } from '../models';
+import {
+  EntityChanges,
+  EntityId,
+  EntityState,
+  NamedEntityState,
+  SelectEntityId,
+} from '../models';
 import {
   cloneEntityState,
+  getEntityIdSelector,
   getEntityStateKeys,
   getEntityUpdaterResult,
   updateEntitiesMutably,
 } from '../helpers';
 
-export function updateAllEntities<Entity>(
-  changes: EntityChanges<Entity & {}>
-): PartialStateUpdater<EntityState<Entity>>;
 export function updateAllEntities<
   Collection extends string,
   State extends NamedEntityState<any, Collection>,
   Entity = State extends NamedEntityState<infer E, Collection> ? E : never
 >(
-  changes: EntityChanges<Entity & {}>,
+  changes: EntityChanges<NoInfer<Entity>>,
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>>;
+  }
+): PartialStateUpdater<State>;
+export function updateAllEntities<
+  Collection extends string,
+  State extends NamedEntityState<any, Collection>,
+  Entity = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection
+  >
+    ? E
+    : never
+>(
+  changes: EntityChanges<NoInfer<Entity>>,
   config: { collection: Collection }
 ): PartialStateUpdater<State>;
+export function updateAllEntities<Entity>(
+  changes: EntityChanges<NoInfer<Entity>>,
+  config: { selectId: SelectEntityId<NoInfer<Entity>> }
+): PartialStateUpdater<EntityState<Entity>>;
+export function updateAllEntities<Entity extends { id: EntityId }>(
+  changes: EntityChanges<NoInfer<Entity>>
+): PartialStateUpdater<EntityState<Entity>>;
 export function updateAllEntities(
   changes: EntityChanges<any>,
-  config?: { collection?: string }
+  config?: { collection?: string; selectId?: SelectEntityId<any> }
 ): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
 
   return (state) => {
@@ -29,7 +57,8 @@ export function updateAllEntities(
     const didMutate = updateEntitiesMutably(
       clonedState,
       (state as Record<string, any>)[stateKeys.idsKey],
-      changes
+      changes,
+      selectId
     );
 
     return getEntityUpdaterResult(clonedState, stateKeys, didMutate);

--- a/modules/signals/entities/src/updaters/update-entities.ts
+++ b/modules/signals/entities/src/updaters/update-entities.ts
@@ -5,22 +5,16 @@ import {
   EntityPredicate,
   EntityState,
   NamedEntityState,
+  SelectEntityId,
 } from '../models';
 import {
   cloneEntityState,
+  getEntityIdSelector,
   getEntityStateKeys,
   getEntityUpdaterResult,
   updateEntitiesMutably,
 } from '../helpers';
 
-export function updateEntities<Entity>(update: {
-  ids: EntityId[];
-  changes: EntityChanges<Entity & {}>;
-}): PartialStateUpdater<EntityState<Entity>>;
-export function updateEntities<Entity>(update: {
-  predicate: EntityPredicate<Entity>;
-  changes: EntityChanges<Entity & {}>;
-}): PartialStateUpdater<EntityState<Entity>>;
 export function updateEntities<
   Collection extends string,
   State extends NamedEntityState<any, Collection>,
@@ -28,9 +22,12 @@ export function updateEntities<
 >(
   update: {
     ids: EntityId[];
-    changes: EntityChanges<Entity & {}>;
+    changes: EntityChanges<NoInfer<Entity>>;
   },
-  config: { collection: Collection }
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>>;
+  }
 ): PartialStateUpdater<State>;
 export function updateEntities<
   Collection extends string,
@@ -39,16 +36,74 @@ export function updateEntities<
 >(
   update: {
     predicate: EntityPredicate<Entity>;
-    changes: EntityChanges<Entity & {}>;
+    changes: EntityChanges<NoInfer<Entity>>;
+  },
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>>;
+  }
+): PartialStateUpdater<State>;
+export function updateEntities<
+  Collection extends string,
+  State extends NamedEntityState<any, Collection>,
+  Entity = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection
+  >
+    ? E
+    : never
+>(
+  update: {
+    ids: EntityId[];
+    changes: EntityChanges<NoInfer<Entity>>;
   },
   config: { collection: Collection }
 ): PartialStateUpdater<State>;
+export function updateEntities<
+  Collection extends string,
+  State extends NamedEntityState<any, Collection>,
+  Entity = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection
+  >
+    ? E
+    : never
+>(
+  update: {
+    predicate: EntityPredicate<Entity>;
+    changes: EntityChanges<NoInfer<Entity>>;
+  },
+  config: { collection: Collection }
+): PartialStateUpdater<State>;
+export function updateEntities<Entity>(
+  update: {
+    ids: EntityId[];
+    changes: EntityChanges<NoInfer<Entity>>;
+  },
+  config: { selectId: SelectEntityId<NoInfer<Entity>> }
+): PartialStateUpdater<EntityState<Entity>>;
+export function updateEntities<Entity>(
+  update: {
+    predicate: EntityPredicate<Entity>;
+    changes: EntityChanges<NoInfer<Entity>>;
+  },
+  config: { selectId: SelectEntityId<NoInfer<Entity>> }
+): PartialStateUpdater<EntityState<Entity>>;
+export function updateEntities<Entity extends { id: EntityId }>(update: {
+  ids: EntityId[];
+  changes: EntityChanges<NoInfer<Entity>>;
+}): PartialStateUpdater<EntityState<Entity>>;
+export function updateEntities<Entity extends { id: EntityId }>(update: {
+  predicate: EntityPredicate<Entity>;
+  changes: EntityChanges<NoInfer<Entity>>;
+}): PartialStateUpdater<EntityState<Entity>>;
 export function updateEntities(
   update: ({ ids: EntityId[] } | { predicate: EntityPredicate<any> }) & {
     changes: EntityChanges<any>;
   },
-  config?: { collection?: string }
+  config?: { collection?: string; selectId?: SelectEntityId<any> }
 ): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
   const idsOrPredicate = 'ids' in update ? update.ids : update.predicate;
 
@@ -57,7 +112,8 @@ export function updateEntities(
     const didMutate = updateEntitiesMutably(
       clonedState,
       idsOrPredicate,
-      update.changes
+      update.changes,
+      selectId
     );
 
     return getEntityUpdaterResult(clonedState, stateKeys, didMutate);

--- a/modules/signals/entities/src/updaters/update-entity.ts
+++ b/modules/signals/entities/src/updaters/update-entity.ts
@@ -4,18 +4,16 @@ import {
   EntityId,
   EntityState,
   NamedEntityState,
+  SelectEntityId,
 } from '../models';
 import {
   cloneEntityState,
+  getEntityIdSelector,
   getEntityStateKeys,
   getEntityUpdaterResult,
   updateEntitiesMutably,
 } from '../helpers';
 
-export function updateEntity<Entity>(update: {
-  id: EntityId;
-  changes: EntityChanges<Entity & {}>;
-}): PartialStateUpdater<EntityState<Entity>>;
 export function updateEntity<
   Collection extends string,
   State extends NamedEntityState<any, Collection>,
@@ -23,17 +21,48 @@ export function updateEntity<
 >(
   update: {
     id: EntityId;
-    changes: EntityChanges<Entity & {}>;
+    changes: EntityChanges<NoInfer<Entity>>;
+  },
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>>;
+  }
+): PartialStateUpdater<State>;
+export function updateEntity<
+  Collection extends string,
+  State extends NamedEntityState<any, Collection>,
+  Entity = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection
+  >
+    ? E
+    : never
+>(
+  update: {
+    id: EntityId;
+    changes: EntityChanges<NoInfer<Entity>>;
   },
   config: { collection: Collection }
 ): PartialStateUpdater<State>;
+export function updateEntity<Entity>(
+  update: {
+    id: EntityId;
+    changes: EntityChanges<NoInfer<Entity>>;
+  },
+  config: { selectId: SelectEntityId<NoInfer<Entity>> }
+): PartialStateUpdater<EntityState<Entity>>;
+export function updateEntity<Entity extends { id: EntityId }>(update: {
+  id: EntityId;
+  changes: EntityChanges<NoInfer<Entity>>;
+}): PartialStateUpdater<EntityState<Entity>>;
 export function updateEntity(
   update: {
     id: EntityId;
     changes: EntityChanges<any>;
   },
-  config?: { collection?: string }
+  config?: { collection?: string; selectId?: SelectEntityId<any> }
 ): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
 
   return (state) => {
@@ -41,7 +70,8 @@ export function updateEntity(
     const didMutate = updateEntitiesMutably(
       clonedState,
       [update.id],
-      update.changes
+      update.changes,
+      selectId
     );
 
     return getEntityUpdaterResult(clonedState, stateKeys, didMutate);

--- a/projects/ngrx.io/content/guide/signals/signal-store/entity-management.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/entity-management.md
@@ -217,9 +217,9 @@ patchState(this.todoStore, removeEntities([2, 4]));
 
 The default property name for an identifier is `id` and is of type `string` or `number`.
 
-It is possible to specify a custom ID selector, but the return type must still be a `string` or `number`. Custom ID selectors should be provided when adding or setting an entity. It is not possible to define it via `withEntities`.
+It is possible to specify a custom ID selector, but the return type must still be a `string` or `number`. Custom ID selectors should be provided when adding, setting, or updating an entity. It is not possible to define it via `withEntities`.
 
-Therefore, all variations of the `add*` and `set*` functions have an optional (last) parameter, which is an object literal that allows to specify the `selectId` function.
+Therefore, all variations of the `add*`, `set*`, and `update*` functions have an optional (last) parameter, which is a config object that allows to specify the `selectId` function.
 
 For example:
 
@@ -244,9 +244,11 @@ patchState(
 );
 
 patchState(this.todoStore, setEntity({ key: 4, name: 'Dog Feeding', finished: false }, { selectId }));
+
+patchState(this.todoStore, updateAllEntities({ finished: true }, { selectId }));
 ```
 
-The `update*` and `remove*` methods, which expect an id value, automatically pick the right one. That is possible because every entity belongs to a map with its id as the key.
+The `remove*` methods, which expect an id value, automatically pick the right one. That is possible because every entity belongs to a map with its id as the key.
 
 Theoretically, adding the same entity twice with different id names would be possible. For obvious reasons, we discourage you from doing that.
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It's not possible to modify entity ID via `update*` functions. Instead, it's necessary to remove the existing one and add a new entity with an updated ID:

```ts
const myEntity = { ...entityMap()['tmp_id'], id: 'real_id' };

patchState(store, removeEntity('tmp_id'), addEntity(myEntity));
```

Closes #4235 

## What is the new behavior?

The `update*` updaters can be used to modify entity ID:

```ts
patchState(store, updateEntity({ id: 'tmp_id', changes: { id: 'real_id' } }));
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

After this change, it's necessary to provide `selectId` to all `update*` updaters if an entity has a custom ID.

```diff
type Todo = { _id: string; text: string };

+const selectId: SelectEntityId<Todo> = (todo) => todo._id;

const TodosStore = signalStore(
  withEntities<Todo>(),
  withMethods((store) => ({
    updateTodo(id: string, changes: Partial<Todo>): void {
-      patchState(store, updateEntity({ id, changes }));
+      patchState(store, updateEntity({ id, changes }, { selectId }));
    },
  }))
);
```

This is not considered as a breaking change because the `@ngrx/signals` package is in developer preview.
