### PR TITLE
fix(eslint-plugin): do not report non-array returns in no-multiple-actions-in-effects

### DIFF
--- a/modules/eslint-plugin/spec/rules/effects/no-multiple-actions-in-effects.spec.ts
+++ b/modules/eslint-plugin/spec/rules/effects/no-multiple-actions-in-effects.spec.ts
@@ -94,6 +94,24 @@ export const saveSearchCriteria$ = createEffect(
   { functional: true }
 );
   `,
+  `
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { createAction, props } from '@ngrx/store';
+import { of, switchMap } from 'rxjs';
+const foo = createAction('foo', props<{ payload: string }>());
+const bar = createAction('bar');
+const baz = createAction('baz');
+
+@Injectable()
+export class Effects {
+  constructor(private actions$: Actions) {}
+  effect$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(foo),
+            switchMap(({ payload }: { payload: string }) => (payload === 'value' ? of(bar()) : of(baz()))),
+        ),
+    );
+}`,
 ];
 
 const invalid: () => RunTests['invalid'] = () => [

--- a/modules/eslint-plugin/src/rules/effects/no-multiple-actions-in-effects.ts
+++ b/modules/eslint-plugin/src/rules/effects/no-multiple-actions-in-effects.ts
@@ -58,7 +58,7 @@ export default createRule<Options, MessageIds>({
           });
         } else if (
           type.isUnion() &&
-          type.types.some((ut) => !typeChecker.isArrayType(ut))
+          type.types.some((ut) => typeChecker.isArrayType(ut))
         ) {
           context.report({
             node: nodeToReport,


### PR DESCRIPTION
…tions-in-effects

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Eslint rules incorrectly reports an error for the rule no-multiple-actions-in-effects for the following code:
```typescript
import { Actions, createEffect, ofType } from '@ngrx/effects';
import { createAction, props } from '@ngrx/store';
import { of, switchMap } from 'rxjs';

const foo = createAction('foo', props<{ payload: string }>());
const bar = createAction('bar');
const baz = createAction('baz');

@Injectable()
export class Effects {
  constructor(private actions$: Actions) {}
  effect$ = createEffect(() =>
      this.actions$.pipe(
          ofType(foo),
          switchMap(({ payload }: { payload: string }) => (payload === 'value' ? of(bar()) : of(baz()))),
      ),
  );
}

```

Closes #

## What is the new behavior?
The eslint rule does not report an error on the valid code.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
