### PR TITLE
Entity: Strengthen typing of getInitialState

### DIFF
--- a/modules/entity/src/entity_state.ts
+++ b/modules/entity/src/entity_state.ts
@@ -9,9 +9,9 @@ export function getInitialEntityState<V>(): EntityState<V> {
 
 export function createInitialStateFactory<V>() {
   function getInitialState(): EntityState<V>;
-  function getInitialState<S extends object>(
-    additionalState: S
-  ): EntityState<V> & S;
+  function getInitialState<S extends EntityState<V>>(
+    additionalState: Omit<S, keyof EntityState<V>>
+  ): S;
   function getInitialState(additionalState: any = {}): any {
     return Object.assign(getInitialEntityState(), additionalState);
   }

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -110,7 +110,9 @@ export interface EntityAdapter<T> extends EntityStateAdapter<T> {
   selectId: IdSelector<T>;
   sortComparer: false | Comparer<T>;
   getInitialState(): EntityState<T>;
-  getInitialState<S extends object>(state: S): EntityState<T> & S;
+  getInitialState<S extends EntityState<T>>(
+    state: Omit<S, keyof EntityState<T>>
+  ): S;
   getSelectors(): EntitySelectors<T, EntityState<T>>;
   getSelectors<V>(
     selectState: (state: V) => EntityState<T>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When initializing an `EntityAdapter<T>` and subsequently setting the `initialState` using `...adapter.getInitialState({ <additional state here>})`, it is possible, given the current interface, to introduce unknown variables that do not conform to the user's specified state. This could result in bugs related to mistyped variable names, resulting in confusing user error scenarios.

Closes #4422

## What is the new behavior?

This small change modifies the interface to require that the input state `S` extends `EntityState<T>`, requires that the additionalState `state` argument conforms to an Omit version of this `S` type, which removes the 'id' and 'entities' properties by way of `keyof EntityState<T>`, and then finally, since the argument now already extends `EntityState<T>`, we can now simply return `S`.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

I have answered "Yes", but realistically, if a user of the Entity package has entered in correct code already, there will be no breaking changes. Any breaking changes should be in the form of a user now being aware of incompatible property types in their additional state, or if their State interface does not contain `extends EntityState<T>`.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This change has helped my place of employment from unknown state properties quite nicely, but I must say this is my very first community/open source pull request. I would be happy to take any constructive criticism or guidance on anything that I could do better here. Very excited to be contributing and hope this is of help. 

Thank you, -Gavyn Holt
