### PR TITLE
feat(signals): limit external SignalStore state updates

### DIFF
--- a/modules/signals/entities/spec/updaters/add-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/add-entities.spec.ts
@@ -5,7 +5,7 @@ import { selectTodoId as selectId } from '../helpers';
 
 describe('addEntities', () => {
   it('adds entities if they do not exist', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, addEntities([user1]));
@@ -22,7 +22,7 @@ describe('addEntities', () => {
   });
 
   it('does not add entities if they already exist', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, addEntities([user1, user2]));
@@ -54,6 +54,7 @@ describe('addEntities', () => {
 
   it('adds entities to the specified collection if they do not exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -74,6 +75,7 @@ describe('addEntities', () => {
 
   it('does not add entities to the specified collection if they already exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -117,7 +119,7 @@ describe('addEntities', () => {
   });
 
   it('adds entities with a custom id if they do not exist', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(store, addEntities([todo2, todo3], { selectId }));
@@ -138,7 +140,7 @@ describe('addEntities', () => {
   });
 
   it('does not add entities with a custom id if they already exist', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(
@@ -174,6 +176,7 @@ describe('addEntities', () => {
 
   it('adds entities with a custom id to the specified collection if they do not exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<Todo>(),
         collection: 'todo',
@@ -211,7 +214,10 @@ describe('addEntities', () => {
       selectId,
     });
 
-    const Store = signalStore(withEntities(todoConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(todoConfig)
+    );
     const store = new Store();
 
     patchState(

--- a/modules/signals/entities/spec/updaters/add-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/add-entity.spec.ts
@@ -5,7 +5,7 @@ import { selectTodoId as selectId } from '../helpers';
 
 describe('addEntity', () => {
   it('adds entity if it does not exist', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, addEntity(user1));
@@ -22,7 +22,7 @@ describe('addEntity', () => {
   });
 
   it('does not add entity if it already exists', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, addEntity(user1));
@@ -45,6 +45,7 @@ describe('addEntity', () => {
 
   it('adds entity to the specified collection if it does not exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -65,6 +66,7 @@ describe('addEntity', () => {
 
   it('does not add entity to the specified collection if it already exists', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -98,7 +100,7 @@ describe('addEntity', () => {
   });
 
   it('adds entity with a custom id if it does not exist', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(store, addEntity(todo1, { selectId }));
@@ -115,7 +117,7 @@ describe('addEntity', () => {
   });
 
   it('does not add entity with a custom id if it already exists', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(
@@ -146,6 +148,7 @@ describe('addEntity', () => {
 
   it('adds entity with a custom id to the specified collection if it does not exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<Todo>(),
         collection: 'todo',
@@ -173,7 +176,10 @@ describe('addEntity', () => {
       selectId,
     });
 
-    const Store = signalStore(withEntities(todoConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(todoConfig)
+    );
     const store = new Store();
 
     patchState(

--- a/modules/signals/entities/spec/updaters/remove-all-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/remove-all-entities.spec.ts
@@ -5,7 +5,7 @@ import { selectTodoId } from '../helpers';
 
 describe('removeAllEntities', () => {
   it('removes all entities', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, setAllEntities([user1, user2]), removeAllEntities());
@@ -17,6 +17,7 @@ describe('removeAllEntities', () => {
 
   it('removes all entities from specified entity collection', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<Todo>(),
         collection: 'todo',

--- a/modules/signals/entities/spec/updaters/remove-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/remove-entities.spec.ts
@@ -10,7 +10,7 @@ import { selectTodoId } from '../helpers';
 
 describe('removeEntities', () => {
   it('removes entities by ids', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(
@@ -25,7 +25,7 @@ describe('removeEntities', () => {
   });
 
   it('removes entities by predicate', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(
@@ -40,7 +40,7 @@ describe('removeEntities', () => {
   });
 
   it('does not modify entity state if entities do not exist', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, addEntities([user1, user2, user3]));
@@ -70,7 +70,10 @@ describe('removeEntities', () => {
       collection: 'users',
     });
 
-    const Store = signalStore(withEntities(userConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(userConfig)
+    );
     const store = new Store();
 
     patchState(store, addEntities([user1, user2, user3], userConfig));
@@ -87,7 +90,10 @@ describe('removeEntities', () => {
       collection: 'users',
     });
 
-    const Store = signalStore(withEntities(userConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(userConfig)
+    );
     const store = new Store();
 
     patchState(
@@ -108,7 +114,10 @@ describe('removeEntities', () => {
       selectId: selectTodoId,
     });
 
-    const Store = signalStore(withEntities(todoConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(todoConfig)
+    );
     const store = new Store();
 
     patchState(store, addEntities([todo1, todo2, todo3], todoConfig));

--- a/modules/signals/entities/spec/updaters/remove-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/remove-entity.spec.ts
@@ -10,7 +10,7 @@ import { selectTodoId } from '../helpers';
 
 describe('removeEntity', () => {
   it('removes entity', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, addEntities([user1, user2]), removeEntity(user1.id));
@@ -21,7 +21,7 @@ describe('removeEntity', () => {
   });
 
   it('does not modify entity state if entity does not exist', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(store, addEntities([todo2, todo3], { selectId: selectTodoId }));
@@ -48,7 +48,10 @@ describe('removeEntity', () => {
       selectId: selectTodoId,
     });
 
-    const Store = signalStore(withEntities(todoConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(todoConfig)
+    );
     const store = new Store();
 
     patchState(
@@ -70,6 +73,7 @@ describe('removeEntity', () => {
 
   it('does not modify entity state if entity does not exist in specified collection', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',

--- a/modules/signals/entities/spec/updaters/set-all-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/set-all-entities.spec.ts
@@ -5,7 +5,7 @@ import { selectTodoId as selectId } from '../helpers';
 
 describe('setAllEntities', () => {
   it('replaces entity collection with provided entities', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, setAllEntities([user1, user2]));
@@ -29,6 +29,7 @@ describe('setAllEntities', () => {
 
   it('replaces specified entity collection with provided entities', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -59,7 +60,7 @@ describe('setAllEntities', () => {
   });
 
   it('replaces entity collection with provided entities with a custom id', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(store, setAllEntities([todo2, todo3], { selectId }));
@@ -88,7 +89,10 @@ describe('setAllEntities', () => {
       selectId,
     });
 
-    const Store = signalStore(withEntities(todoConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(todoConfig)
+    );
     const store = new Store();
 
     patchState(store, setAllEntities([todo1, todo3], todoConfig));

--- a/modules/signals/entities/spec/updaters/set-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/set-entities.spec.ts
@@ -5,7 +5,7 @@ import { selectTodoId as selectId } from '../helpers';
 
 describe('setEntities', () => {
   it('adds entities if they do not exist', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, setEntities([user1]));
@@ -22,7 +22,7 @@ describe('setEntities', () => {
   });
 
   it('replaces entities if they already exist', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(
@@ -61,6 +61,7 @@ describe('setEntities', () => {
 
   it('adds entities to the specified collection if they do not exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -81,6 +82,7 @@ describe('setEntities', () => {
 
   it('replaces entities to the specified collection if they already exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -117,7 +119,7 @@ describe('setEntities', () => {
   });
 
   it('adds entities with a custom id if they do not exist', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(store, setEntities([todo2, todo3], { selectId }));
@@ -138,7 +140,7 @@ describe('setEntities', () => {
   });
 
   it('replaces entities with a custom id if they already exist', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(
@@ -171,6 +173,7 @@ describe('setEntities', () => {
 
   it('adds entities with a custom id to the specified collection if they do not exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<Todo>(),
         collection: 'todo',
@@ -208,7 +211,10 @@ describe('setEntities', () => {
       selectId,
     });
 
-    const Store = signalStore(withEntities(todoConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(todoConfig)
+    );
     const store = new Store();
 
     patchState(

--- a/modules/signals/entities/spec/updaters/set-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/set-entity.spec.ts
@@ -5,7 +5,7 @@ import { selectTodoId as selectId } from '../helpers';
 
 describe('setEntity', () => {
   it('adds entity if it does not exist', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, setEntity(user1));
@@ -22,7 +22,7 @@ describe('setEntity', () => {
   });
 
   it('replaces entity if it already exists', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, setEntity(user1), setEntity(user2));
@@ -38,6 +38,7 @@ describe('setEntity', () => {
 
   it('adds entity to the specified collection if it does not exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -58,6 +59,7 @@ describe('setEntity', () => {
 
   it('replaces entity to the specified collection if it already exists', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -88,7 +90,7 @@ describe('setEntity', () => {
   });
 
   it('adds entity with a custom id if it does not exist', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(store, setEntity(todo1, { selectId }));
@@ -105,7 +107,7 @@ describe('setEntity', () => {
   });
 
   it('replaces entity with a custom id if it already exists', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(
@@ -125,6 +127,7 @@ describe('setEntity', () => {
 
   it('adds entity with a custom id to the specified collection if it does not exist', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<Todo>(),
         collection: 'todo',
@@ -152,7 +155,10 @@ describe('setEntity', () => {
       selectId,
     });
 
-    const Store = signalStore(withEntities(todoConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(todoConfig)
+    );
     const store = new Store();
 
     patchState(

--- a/modules/signals/entities/spec/updaters/update-all-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/update-all-entities.spec.ts
@@ -5,7 +5,7 @@ import { selectTodoId } from '../helpers';
 
 describe('updateAllEntities', () => {
   it('updates all entities', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(
@@ -42,7 +42,7 @@ describe('updateAllEntities', () => {
   });
 
   it('does not modify entity state if entities do not exist', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     const entityMap = store.entityMap();
@@ -68,6 +68,7 @@ describe('updateAllEntities', () => {
 
   it('updates all entities from specified entity collection', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<Todo>(),
         collection: 'todo',
@@ -125,6 +126,7 @@ describe('updateAllEntities', () => {
 
   it('does not modify entity state if entities do not exist in specified collection', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',

--- a/modules/signals/entities/spec/updaters/update-entities.spec.ts
+++ b/modules/signals/entities/spec/updaters/update-entities.spec.ts
@@ -10,7 +10,7 @@ import { selectTodoId } from '../helpers';
 
 describe('updateEntities', () => {
   it('updates entities by ids', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(
@@ -40,7 +40,7 @@ describe('updateEntities', () => {
   });
 
   it('updates entities by predicate', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(
@@ -80,7 +80,7 @@ describe('updateEntities', () => {
   });
 
   it('does not modify entity state if entities do not exist', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(store, addEntities([user1, user2, user3]));
@@ -116,7 +116,10 @@ describe('updateEntities', () => {
       collection: 'users',
     });
 
-    const Store = signalStore(withEntities(userConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(userConfig)
+    );
     const store = new Store();
 
     patchState(store, addEntities([user1, user2, user3], userConfig));
@@ -157,7 +160,10 @@ describe('updateEntities', () => {
       collection: 'users',
     });
 
-    const Store = signalStore(withEntities(userConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(userConfig)
+    );
     const store = new Store();
 
     patchState(
@@ -199,7 +205,10 @@ describe('updateEntities', () => {
       selectId: (todo) => todo._id,
     });
 
-    const Store = signalStore(withEntities(todoConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(todoConfig)
+    );
     const store = new Store();
 
     patchState(store, addEntities([todo1, todo2, todo3], todoConfig));
@@ -236,7 +245,7 @@ describe('updateEntities', () => {
   });
 
   it('updates entity ids', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(
@@ -280,7 +289,7 @@ describe('updateEntities', () => {
   });
 
   it('updates custom entity ids', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(
@@ -337,6 +346,7 @@ describe('updateEntities', () => {
 
   it('updates entity ids from specified collection', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -398,6 +408,7 @@ describe('updateEntities', () => {
 
   it('updates custom entity ids from specified collection', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<Todo>(),
         collection: 'todo',

--- a/modules/signals/entities/spec/updaters/update-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/update-entity.spec.ts
@@ -10,7 +10,7 @@ import { selectTodoId } from '../helpers';
 
 describe('updateEntity', () => {
   it('updates entity', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(
@@ -65,7 +65,10 @@ describe('updateEntity', () => {
       selectId: selectTodoId,
     });
 
-    const Store = signalStore(withEntities(todoConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(todoConfig)
+    );
     const store = new Store();
 
     patchState(store, addEntities([todo2, todo3], todoConfig));
@@ -103,6 +106,7 @@ describe('updateEntity', () => {
 
   it('updates entity from specified entity collection', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<Todo>(),
         collection: 'todo',
@@ -149,7 +153,10 @@ describe('updateEntity', () => {
       selectId: (user) => user.id,
     });
 
-    const Store = signalStore(withEntities(userConfig));
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities(userConfig)
+    );
     const store = new Store();
 
     patchState(store, addEntities([user1, user2, user3], userConfig));
@@ -180,7 +187,7 @@ describe('updateEntity', () => {
   });
 
   it('updates an entity id', () => {
-    const Store = signalStore(withEntities<User>());
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
     const store = new Store();
 
     patchState(
@@ -221,7 +228,7 @@ describe('updateEntity', () => {
   });
 
   it('updates a custom entity id', () => {
-    const Store = signalStore(withEntities<Todo>());
+    const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();
 
     patchState(
@@ -255,6 +262,7 @@ describe('updateEntity', () => {
 
   it('updates an entity id from specified entity collection', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<User>(),
         collection: 'user',
@@ -291,6 +299,7 @@ describe('updateEntity', () => {
 
   it('updates a custom entity id from specified entity collection', () => {
     const Store = signalStore(
+      { protectedState: false },
       withEntities({
         entity: type<Todo>(),
         collection: 'todo',

--- a/modules/signals/spec/signal-state.spec.ts
+++ b/modules/signals/spec/signal-state.spec.ts
@@ -15,7 +15,7 @@ describe('signalState', () => {
     ngrx: 'signals',
   };
 
-  it('has state source', () => {
+  it('has writable state source', () => {
     const state = signalState({});
     const stateSource = state[STATE_SOURCE];
 

--- a/modules/signals/spec/types/patch-state.types.spec.ts
+++ b/modules/signals/spec/types/patch-state.types.spec.ts
@@ -27,7 +27,7 @@ describe('patchState', () => {
     compilerOptions()
   );
 
-  it('infers the state type from StateSource', () => {
+  it('infers the state type from WritableStateSource', () => {
     expectSnippet('patchState(state, increment())').toSucceed();
     expectSnippet("patchState(state, { foo: 'baz' })").toSucceed();
     expectSnippet("patchState(state, { foo: 'baz' }, increment())").toSucceed();

--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -8,6 +8,7 @@ export {
   PartialStateUpdater,
   patchState,
   StateSource,
+  WritableStateSource,
 } from './state-source';
 
 export { withComputed } from './with-computed';

--- a/modules/signals/src/signal-state.ts
+++ b/modules/signals/src/signal-state.ts
@@ -1,9 +1,9 @@
 import { signal } from '@angular/core';
-import { STATE_SOURCE, StateSource } from './state-source';
+import { STATE_SOURCE, WritableStateSource } from './state-source';
 import { DeepSignal, toDeepSignal } from './deep-signal';
 
 export type SignalState<State extends object> = DeepSignal<State> &
-  StateSource<State>;
+  WritableStateSource<State>;
 
 export function signalState<State extends object>(
   initialState: State

--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -1,6 +1,6 @@
 import { Signal } from '@angular/core';
 import { DeepSignal } from './deep-signal';
-import { StateSource } from './state-source';
+import { WritableStateSource } from './state-source';
 import { IsKnownRecord, Prettify } from './ts-helpers';
 
 export type StateSignals<State> = IsKnownRecord<Prettify<State>> extends true
@@ -29,7 +29,7 @@ export type InnerSignalStore<
   computedSignals: ComputedSignals;
   methods: Methods;
   hooks: SignalStoreHooks;
-} & StateSource<State>;
+} & WritableStateSource<State>;
 
 export type SignalStoreFeatureResult = {
   state: object;

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -1,5 +1,5 @@
 import { DestroyRef, inject, Injectable, signal, Type } from '@angular/core';
-import { STATE_SOURCE, StateSource } from './state-source';
+import { STATE_SOURCE, StateSource, WritableStateSource } from './state-source';
 import {
   EmptyFeatureResult,
   InnerSignalStore,
@@ -9,7 +9,7 @@ import {
 } from './signal-store-models';
 import { Prettify } from './ts-helpers';
 
-type SignalStoreConfig = { providedIn: 'root' };
+type SignalStoreConfig = { providedIn?: 'root'; protectedState?: boolean };
 
 type SignalStoreMembers<FeatureResult extends SignalStoreFeatureResult> =
   Prettify<
@@ -436,7 +436,7 @@ export function signalStore<
 ): Type<SignalStoreMembers<R> & StateSource<Prettify<R['state']>>>;
 
 export function signalStore<F1 extends SignalStoreFeatureResult>(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>
 ): Type<SignalStoreMembers<F1> & StateSource<Prettify<F1['state']>>>;
 export function signalStore<
@@ -444,7 +444,7 @@ export function signalStore<
   F2 extends SignalStoreFeatureResult,
   R extends SignalStoreFeatureResult = F1 & F2
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>
 ): Type<SignalStoreMembers<R> & StateSource<Prettify<R['state']>>>;
@@ -454,7 +454,7 @@ export function signalStore<
   F3 extends SignalStoreFeatureResult,
   R extends SignalStoreFeatureResult = F1 & F2 & F3
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>
@@ -466,7 +466,7 @@ export function signalStore<
   F4 extends SignalStoreFeatureResult,
   R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -480,7 +480,7 @@ export function signalStore<
   F5 extends SignalStoreFeatureResult,
   R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4 & F5
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -496,7 +496,7 @@ export function signalStore<
   F6 extends SignalStoreFeatureResult,
   R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4 & F5 & F6
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -514,7 +514,7 @@ export function signalStore<
   F7 extends SignalStoreFeatureResult,
   R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4 & F5 & F6 & F7
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -534,7 +534,7 @@ export function signalStore<
   F8 extends SignalStoreFeatureResult,
   R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -564,7 +564,7 @@ export function signalStore<
     F8 &
     F9
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -597,7 +597,7 @@ export function signalStore<
     F9 &
     F10
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -633,7 +633,7 @@ export function signalStore<
     F10 &
     F11
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -672,7 +672,7 @@ export function signalStore<
     F11 &
     F12
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -720,7 +720,7 @@ export function signalStore<
     F12 &
     F13
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -774,7 +774,7 @@ export function signalStore<
     F13 &
     F14
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -834,7 +834,7 @@ export function signalStore<
     F14 &
     F15
 >(
-  config: SignalStoreConfig,
+  config: { providedIn?: 'root'; protectedState?: true },
   f1: SignalStoreFeature<EmptyFeatureResult, F1>,
   f2: SignalStoreFeature<{} & F1, F2>,
   f3: SignalStoreFeature<F1 & F2, F3>,
@@ -867,15 +867,447 @@ export function signalStore<
   >
 ): Type<SignalStoreMembers<R> & StateSource<Prettify<R['state']>>>;
 
+export function signalStore<F1 extends SignalStoreFeatureResult>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>
+): Type<SignalStoreMembers<F1> & WritableStateSource<Prettify<F1['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 & F2
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 & F2 & F3
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4 & F5
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4 & F5 & F6
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4 & F5 & F6 & F7
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>,
+  f7: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6, F7>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  F8 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>,
+  f7: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6, F7>,
+  f8: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7, F8>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  F8 extends SignalStoreFeatureResult,
+  F9 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 &
+    F2 &
+    F3 &
+    F4 &
+    F5 &
+    F6 &
+    F7 &
+    F8 &
+    F9
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>,
+  f7: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6, F7>,
+  f8: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7, F8>,
+  f9: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8, F9>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  F8 extends SignalStoreFeatureResult,
+  F9 extends SignalStoreFeatureResult,
+  F10 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 &
+    F2 &
+    F3 &
+    F4 &
+    F5 &
+    F6 &
+    F7 &
+    F8 &
+    F9 &
+    F10
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>,
+  f7: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6, F7>,
+  f8: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7, F8>,
+  f9: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8, F9>,
+  f10: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9, F10>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  F8 extends SignalStoreFeatureResult,
+  F9 extends SignalStoreFeatureResult,
+  F10 extends SignalStoreFeatureResult,
+  F11 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 &
+    F2 &
+    F3 &
+    F4 &
+    F5 &
+    F6 &
+    F7 &
+    F8 &
+    F9 &
+    F10 &
+    F11
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>,
+  f7: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6, F7>,
+  f8: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7, F8>,
+  f9: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8, F9>,
+  f10: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9, F10>,
+  f11: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10, F11>
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  F8 extends SignalStoreFeatureResult,
+  F9 extends SignalStoreFeatureResult,
+  F10 extends SignalStoreFeatureResult,
+  F11 extends SignalStoreFeatureResult,
+  F12 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 &
+    F2 &
+    F3 &
+    F4 &
+    F5 &
+    F6 &
+    F7 &
+    F8 &
+    F9 &
+    F10 &
+    F11 &
+    F12
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>,
+  f7: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6, F7>,
+  f8: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7, F8>,
+  f9: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8, F9>,
+  f10: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9, F10>,
+  f11: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10,
+    F11
+  >,
+  f12: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11,
+    F12
+  >
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  F8 extends SignalStoreFeatureResult,
+  F9 extends SignalStoreFeatureResult,
+  F10 extends SignalStoreFeatureResult,
+  F11 extends SignalStoreFeatureResult,
+  F12 extends SignalStoreFeatureResult,
+  F13 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 &
+    F2 &
+    F3 &
+    F4 &
+    F5 &
+    F6 &
+    F7 &
+    F8 &
+    F9 &
+    F10 &
+    F11 &
+    F12 &
+    F13
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>,
+  f7: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6, F7>,
+  f8: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7, F8>,
+  f9: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8, F9>,
+  f10: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9, F10>,
+  f11: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10,
+    F11
+  >,
+  f12: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11,
+    F12
+  >,
+  f13: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11 & F12,
+    F13
+  >
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  F8 extends SignalStoreFeatureResult,
+  F9 extends SignalStoreFeatureResult,
+  F10 extends SignalStoreFeatureResult,
+  F11 extends SignalStoreFeatureResult,
+  F12 extends SignalStoreFeatureResult,
+  F13 extends SignalStoreFeatureResult,
+  F14 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 &
+    F2 &
+    F3 &
+    F4 &
+    F5 &
+    F6 &
+    F7 &
+    F8 &
+    F9 &
+    F10 &
+    F11 &
+    F12 &
+    F13 &
+    F14
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>,
+  f7: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6, F7>,
+  f8: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7, F8>,
+  f9: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8, F9>,
+  f10: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9, F10>,
+  f11: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10,
+    F11
+  >,
+  f12: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11,
+    F12
+  >,
+  f13: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11 & F12,
+    F13
+  >,
+  f14: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11 & F12 & F13,
+    F14
+  >
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+export function signalStore<
+  F1 extends SignalStoreFeatureResult,
+  F2 extends SignalStoreFeatureResult,
+  F3 extends SignalStoreFeatureResult,
+  F4 extends SignalStoreFeatureResult,
+  F5 extends SignalStoreFeatureResult,
+  F6 extends SignalStoreFeatureResult,
+  F7 extends SignalStoreFeatureResult,
+  F8 extends SignalStoreFeatureResult,
+  F9 extends SignalStoreFeatureResult,
+  F10 extends SignalStoreFeatureResult,
+  F11 extends SignalStoreFeatureResult,
+  F12 extends SignalStoreFeatureResult,
+  F13 extends SignalStoreFeatureResult,
+  F14 extends SignalStoreFeatureResult,
+  F15 extends SignalStoreFeatureResult,
+  R extends SignalStoreFeatureResult = F1 &
+    F2 &
+    F3 &
+    F4 &
+    F5 &
+    F6 &
+    F7 &
+    F8 &
+    F9 &
+    F10 &
+    F11 &
+    F12 &
+    F13 &
+    F14 &
+    F15
+>(
+  config: { providedIn?: 'root'; protectedState: false },
+  f1: SignalStoreFeature<EmptyFeatureResult, F1>,
+  f2: SignalStoreFeature<{} & F1, F2>,
+  f3: SignalStoreFeature<F1 & F2, F3>,
+  f4: SignalStoreFeature<F1 & F2 & F3, F4>,
+  f5: SignalStoreFeature<F1 & F2 & F3 & F4, F5>,
+  f6: SignalStoreFeature<F1 & F2 & F3 & F4 & F5, F6>,
+  f7: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6, F7>,
+  f8: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7, F8>,
+  f9: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8, F9>,
+  f10: SignalStoreFeature<F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9, F10>,
+  f11: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10,
+    F11
+  >,
+  f12: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11,
+    F12
+  >,
+  f13: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11 & F12,
+    F13
+  >,
+  f14: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11 & F12 & F13,
+    F14
+  >,
+  f15: SignalStoreFeature<
+    F1 & F2 & F3 & F4 & F5 & F6 & F7 & F8 & F9 & F10 & F11 & F12 & F13 & F14,
+    F15
+  >
+): Type<SignalStoreMembers<R> & WritableStateSource<Prettify<R['state']>>>;
+
 export function signalStore(
   ...args: [SignalStoreConfig, ...SignalStoreFeature[]] | SignalStoreFeature[]
 ): Type<SignalStoreMembers<any>> {
   const signalStoreArgs = [...args];
 
-  const config: Partial<SignalStoreConfig> =
-    'providedIn' in signalStoreArgs[0]
-      ? (signalStoreArgs.shift() as SignalStoreConfig)
-      : {};
+  const config =
+    typeof signalStoreArgs[0] === 'function'
+      ? {}
+      : (signalStoreArgs.shift() as SignalStoreConfig);
   const features = signalStoreArgs as SignalStoreFeature[];
 
   @Injectable({ providedIn: config.providedIn || null })
@@ -888,7 +1320,10 @@ export function signalStore(
       const { stateSignals, computedSignals, methods, hooks } = innerStore;
       const storeMembers = { ...stateSignals, ...computedSignals, ...methods };
 
-      (this as any)[STATE_SOURCE] = innerStore[STATE_SOURCE];
+      (this as any)[STATE_SOURCE] =
+        config.protectedState === false
+          ? innerStore[STATE_SOURCE]
+          : innerStore[STATE_SOURCE].asReadonly();
 
       for (const key in storeMembers) {
         (this as any)[key] = storeMembers[key];

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -1,10 +1,14 @@
-import { WritableSignal } from '@angular/core';
+import { Signal, WritableSignal } from '@angular/core';
 import { Prettify } from './ts-helpers';
 
 export const STATE_SOURCE = Symbol('STATE_SOURCE');
 
-export type StateSource<State extends object> = {
+export type WritableStateSource<State extends object> = {
   [STATE_SOURCE]: WritableSignal<State>;
+};
+
+export type StateSource<State extends object> = {
+  [STATE_SOURCE]: Signal<State>;
 };
 
 export type PartialStateUpdater<State extends object> = (
@@ -12,7 +16,7 @@ export type PartialStateUpdater<State extends object> = (
 ) => Partial<State>;
 
 export function patchState<State extends object>(
-  stateSource: StateSource<State>,
+  stateSource: WritableStateSource<State>,
   ...updaters: Array<
     Partial<Prettify<State>> | PartialStateUpdater<Prettify<State>>
   >

--- a/modules/signals/src/with-hooks.ts
+++ b/modules/signals/src/with-hooks.ts
@@ -1,4 +1,4 @@
-import { STATE_SOURCE, StateSource } from './state-source';
+import { STATE_SOURCE, WritableStateSource } from './state-source';
 import {
   EmptyFeatureResult,
   SignalStoreFeature,
@@ -12,7 +12,7 @@ type HookFn<Input extends SignalStoreFeatureResult> = (
     StateSignals<Input['state']> &
       Input['computed'] &
       Input['methods'] &
-      StateSource<Prettify<Input['state']>>
+      WritableStateSource<Prettify<Input['state']>>
   >
 ) => void;
 
@@ -21,7 +21,7 @@ type HooksFactory<Input extends SignalStoreFeatureResult> = (
     StateSignals<Input['state']> &
       Input['computed'] &
       Input['methods'] &
-      StateSource<Prettify<Input['state']>>
+      WritableStateSource<Prettify<Input['state']>>
   >
 ) => {
   onInit?: () => void;

--- a/modules/signals/src/with-methods.ts
+++ b/modules/signals/src/with-methods.ts
@@ -1,4 +1,4 @@
-import { STATE_SOURCE, StateSource } from './state-source';
+import { STATE_SOURCE, WritableStateSource } from './state-source';
 import { assertUniqueStoreMembers } from './signal-store-assertions';
 import {
   InnerSignalStore,
@@ -19,7 +19,7 @@ export function withMethods<
       StateSignals<Input['state']> &
         Input['computed'] &
         Input['methods'] &
-        StateSource<Prettify<Input['state']>>
+        WritableStateSource<Prettify<Input['state']>>
     >
   ) => Methods
 ): SignalStoreFeature<Input, { state: {}; computed: {}; methods: Methods }> {

--- a/projects/ngrx.io/content/guide/signals/faq.md
+++ b/projects/ngrx.io/content/guide/signals/faq.md
@@ -50,9 +50,12 @@ withMethods(() => {
 
 ```ts
 @Injectable()
-export class CounterStore extends signalStore(withState({ count: 0 })) {
+export class CounterStore extends signalStore(
+  { protectedState: false },
+  withState({ count: 0 })
+) {
   readonly doubleCount = computed(() => this.count() * 2);
-  
+
   increment(): void {
     patchState(this, { count: this.count() + 1 });
   }

--- a/projects/ngrx.io/content/guide/signals/signal-store/index.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/index.md
@@ -47,7 +47,7 @@ The `BooksStore` instance will contain the following properties:
 - `filter.query: Signal<string>`
 - `filter.order: Signal<'asc' | 'desc'>`
 
-<div class="alert alert is-helpful">
+<div class="alert is-helpful">
 
 The `withState` feature also has a signature that takes the initial state factory as an input argument.
 The factory is executed within the injection context, allowing initial state to be obtained from a service or injection token.
@@ -108,7 +108,7 @@ export const BooksStore = signalStore(
 When provided globally, the store is registered with the root injector and becomes accessible anywhere in the application.
 This is beneficial for managing global state, as it ensures a single shared instance of the store across the entire application.
 
-## Consuming State
+## Reading State
 
 Signals generated for state slices can be utilized to access state values, as demonstrated below.
 
@@ -239,10 +239,35 @@ export const BooksStore = signalStore(
 
 </code-example>
 
-<div class="alert alert is-important">
+<div class="alert is-helpful">
 
 The state of the SignalStore is updated using the `patchState` function.
 For more details on the `patchState` function, refer to the [Updating State](/guide/signals/signal-state#updating-state) guide.
+
+</div>
+
+<div class="alert is-important">
+
+By default, SignalStore's state is protected from external modifications, ensuring a consistent and predictable data flow.
+This is the recommended approach.
+However, external updates to the state can be enabled by setting the `protectedState` option to `false` when creating a SignalStore.
+
+```ts
+export const BooksStore = signalStore(
+  { protectedState: false }, // 👈
+  withState(initialState)
+);
+
+@Component({ /* ... */ })
+export class BooksComponent {
+  readonly store = inject(BooksStore);
+
+  addBook(book: Book): void {
+    // ⚠️ The state of the `BooksStore` is unprotected from external modifications.
+    patchState(this.store, ({ books }) => ({ books: [...books, book] }));
+  }
+}
+```
 
 </div>
 
@@ -326,7 +351,7 @@ export const BooksStore = signalStore(
 
 </code-example>
 
-<div class="alert alert is-helpful">
+<div class="alert is-helpful">
 
 To learn more about the `rxMethod` function, visit the [RxJS Integration](/guide/signals/rxjs-integration) page.
 
@@ -420,7 +445,7 @@ The `BooksStore` instance will contain the following properties and methods:
   - `updateOrder(order: 'asc' | 'desc'): void`
   - `loadByQuery: RxMethod<string>`
 
-<div class="alert alert is-helpful">
+<div class="alert is-helpful">
 
 The `BooksStore` implementation can be enhanced further by utilizing the `entities` plugin and creating custom SignalStore features.
 For more details, refer to the [Entity Management](guide/signals/signal-store/entity-management) and [Custom Store Features](guide/signals/signal-store/custom-store-features) guides.
@@ -469,7 +494,7 @@ export class BooksComponent implements OnInit {
 
 </code-example>
 
-<div class="alert alert is-helpful">
+<div class="alert is-helpful">
 
 In addition to component lifecycle hooks, SignalStore also offers the ability to define them at the store level.
 Learn more about SignalStore lifecycle hooks [here](/guide/signals/signal-store/lifecycle-hooks).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

SignalStore's state can be updated from the outside by default:

```ts
export const CounterStore = signalStore(
  withState({ count: 0 }),
  withMethods((store) => ({
    setCount(count: number): void {
      patchState(store, { count }); // ✅
    },
  }))
);

const store = inject(CounterStore);
patchState(store, { count: 10 }); // ✅
```

Closes #4405

## What is the new behavior?

SignalStore's state cannot be updated from the outside by default:

```ts
export const CounterStore = signalStore(
  withState({ count: 0 }),
  withMethods((store) => ({
    setCount(count: number): void {
      patchState(store, { count }); // ✅
    },
  }))
);

const store = inject(CounterStore);
patchState(store, { count: 10 }); // ❌
```

To allow external state modifications, it's necessary to set `protectedState` to `false`:

```ts
export const CounterStore = signalStore(
  { protectedState: false },
  withState({ count: 0 }),
);

const store = inject(CounterStore);
patchState(store, { count: 10 }); // ✅
```


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is not considered as a breaking change because the `@ngrx/signals` package is in developer preview.
