### PR TITLE
feat(signals): add watchState function

### DIFF
--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -13,6 +13,7 @@ export {
   PartialStateUpdater,
   patchState,
   StateSource,
+  watchState,
   WritableStateSource,
 } from './state-source';
 export { Prettify } from './ts-helpers';

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -1,4 +1,13 @@
-import { Signal, WritableSignal } from '@angular/core';
+import {
+  assertInInjectionContext,
+  DestroyRef,
+  inject,
+  Injector,
+  Signal,
+  untracked,
+  WritableSignal,
+} from '@angular/core';
+import { SIGNAL } from '@angular/core/primitives/signals';
 import { Prettify } from './ts-helpers';
 
 export const STATE_SOURCE = Symbol('STATE_SOURCE');
@@ -30,10 +39,76 @@ export function patchState<State extends object>(
       currentState
     )
   );
+
+  notifyWatchers(stateSource);
 }
 
 export function getState<State extends object>(
   stateSource: StateSource<State>
 ): State {
   return stateSource[STATE_SOURCE]();
+}
+
+export function watchState<State extends object>(
+  stateSource: StateSource<State>,
+  watcher: StateWatcher<State>,
+  config?: { injector?: Injector }
+): { destroy(): void } {
+  if (!config?.injector) {
+    assertInInjectionContext(watchState);
+  }
+
+  const injector = config?.injector ?? inject(Injector);
+  const destroyRef = injector.get(DestroyRef);
+
+  addWatcher(stateSource, watcher);
+  watcher(getState(stateSource));
+
+  const destroy = () => removeWatcher(stateSource, watcher);
+  destroyRef.onDestroy(destroy);
+
+  return { destroy };
+}
+
+const STATE_WATCHERS = new WeakMap<object, Array<StateWatcher<any>>>();
+
+type StateWatcher<State extends object> = (state: NoInfer<State>) => void;
+
+function getWatchers<State extends object>(
+  stateSource: StateSource<State>
+): Array<StateWatcher<State>> {
+  return STATE_WATCHERS.get(stateSource[STATE_SOURCE][SIGNAL] as object) || [];
+}
+
+function notifyWatchers<State extends object>(
+  stateSource: StateSource<State>
+): void {
+  const watchers = getWatchers(stateSource);
+
+  for (const watcher of watchers) {
+    const state = untracked(() => getState(stateSource));
+    watcher(state);
+  }
+}
+
+function addWatcher<State extends object>(
+  stateSource: StateSource<State>,
+  watcher: StateWatcher<State>
+): void {
+  const watchers = getWatchers(stateSource);
+  STATE_WATCHERS.set(stateSource[STATE_SOURCE][SIGNAL] as object, [
+    ...watchers,
+    watcher,
+  ]);
+}
+
+function removeWatcher<State extends object>(
+  stateSource: StateSource<State>,
+  watcher: StateWatcher<State>
+): void {
+  const watchers = getWatchers(stateSource);
+  STATE_WATCHERS.set(
+    stateSource[STATE_SOURCE][SIGNAL] as object,
+    watchers.filter((w) => w !== watcher)
+  );
 }

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -10,6 +10,8 @@ import {
 import { SIGNAL } from '@angular/core/primitives/signals';
 import { Prettify } from './ts-helpers';
 
+const STATE_WATCHERS = new WeakMap<object, Array<StateWatcher<any>>>();
+
 export const STATE_SOURCE = Symbol('STATE_SOURCE');
 
 export type WritableStateSource<State extends object> = {
@@ -23,6 +25,10 @@ export type StateSource<State extends object> = {
 export type PartialStateUpdater<State extends object> = (
   state: State
 ) => Partial<State>;
+
+export type StateWatcher<State extends object> = (
+  state: NoInfer<State>
+) => void;
 
 export function patchState<State extends object>(
   stateSource: WritableStateSource<State>,
@@ -69,10 +75,6 @@ export function watchState<State extends object>(
 
   return { destroy };
 }
-
-const STATE_WATCHERS = new WeakMap<object, Array<StateWatcher<any>>>();
-
-type StateWatcher<State extends object> = (state: NoInfer<State>) => void;
 
 function getWatchers<State extends object>(
   stateSource: StateSource<State>

--- a/projects/ngrx.io/content/guide/signals/signal-store/index.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/index.md
@@ -141,30 +141,6 @@ export class BooksComponent {
 
 </code-example>
 
-The `@ngrx/signals` package also offers the `getState` function to get the current state value of the SignalStore.
-When used within the reactive context, state changes are automatically tracked.
-
-<code-example header="books.component.ts">
-
-import { Component, effect, inject } from '@angular/core';
-import { getState } from '@ngrx/signals';
-import { BooksStore } from './books.store';
-
-@Component({ /* ... */ })
-export class BooksComponent {
-  readonly store = inject(BooksStore);
-
-  constructor() {
-    effect(() => {
-      // 👇 The effect will be re-executed whenever the state changes.
-      const state = getState(this.store);
-      console.log('books state changed', state);
-    });
-  }
-}
-
-</code-example>
-
 ## Defining Computed Signals
 
 Computed signals can be added to the store using the `withComputed` feature.

--- a/projects/ngrx.io/content/guide/signals/signal-store/state-tracking.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/state-tracking.md
@@ -1,0 +1,158 @@
+# State Tracking
+
+State tracking enables the implementation of custom SignalStore features such as logging, state undo/redo, and storage synchronization.
+
+## Using `getState` and `effect`
+
+The `getState` function is used to get the current state value of the SignalStore.
+When used within a reactive context, state changes are automatically tracked.
+
+<code-example header="counter.store.ts">
+
+import { effect } from '@angular/core';
+import {
+  getState,
+  patchState,
+  signalStore,
+  withHooks,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+
+export const CounterStore = signalStore(
+  withState({ count: 0 }),
+  withMethods((store) => ({
+    increment(): void {
+      patchState(store, { count: store.count() + 1 });
+    },
+  })),
+  withHooks({
+    onInit(store) {
+      effect(() => {
+        // 👇 The effect is re-executed on state change.
+        const state = getState(store);
+        console.log('counter state', state);
+      });
+
+      setInterval(() => store.increment(), 1_000);
+    },
+  })
+);
+
+</code-example>
+
+Due to the `effect` glitch-free behavior, if the state is changed multiple times in the same tick, the effect function will be executed only once with the final state value.
+While the asynchronous effect execution is beneficial for performance reasons, functionalities such as state undo/redo require tracking all SignalStore's state changes without coalescing state updates in the same tick.
+
+## Using `watchState`
+
+The `watchState` function allows for synchronous tracking of SignalStore's state changes.
+It accepts a SignalStore instance as the first argument and a watcher function as the second argument.
+
+By default, the `watchState` function needs to be executed within an injection context.
+It is tied to its lifecycle and is automatically cleaned up when the injector is destroyed.
+
+<code-example header="counter.store.ts">
+
+import { effect } from '@angular/core';
+import {
+  getState,
+  patchState,
+  signalStore,
+  watchState,
+  withHooks,
+  withState,
+} from '@ngrx/signals';
+
+export const CounterStore = signalStore(
+  withState({ count: 0 }),
+  withMethods((store) => ({
+    increment(): void {
+      patchState(store, { count: store.count() + 1 });
+    },
+  })),
+  withHooks({
+    onInit(store) {
+      watchState(store, (state) => {
+        console.log('[watchState] counter state', state);
+      }); // logs: { count: 0 }, { count: 1 }, { count: 2 }
+      
+      effect(() => {
+        console.log('[effect] counter state', getState(store));
+      }); // logs: { count: 2 }
+
+      store.increment();
+      store.increment();
+    },
+  })
+);
+
+</code-example>
+
+In the example above, the `watchState` function will execute the provided watcher 3 times: once with the initial counter state value and two times after each increment.
+Conversely, the `effect` function will be executed only once with the final counter state value.
+
+### Manual Cleanup
+
+If a state watcher needs to be cleaned up before the injector is destroyed, manual cleanup can be performed by calling the `destroy` method.
+
+<code-example header="counter.store.ts">
+
+import {
+  patchState,
+  signalStore,
+  watchState,
+  withHooks,
+  witMethods,
+  withState,
+} from '@ngrx/signals';
+
+export const CounterStore = signalStore(
+  withState({ count: 0 }),
+  withMethods((store) => ({
+    increment(): void {
+      patchState(store, { count: store.count() + 1 });
+    },
+  })),
+  withHooks({
+    onInit(store) {
+      const { destroy } = watchState(store, console.log);
+
+      setInterval(() => store.increment(), 1_000);
+
+      // 👇 Stop watching after 5 seconds.
+      setTimeout(() => destroy(), 5_000);
+    },
+  })
+);
+
+</code-example>
+
+### Usage Outside of Injection Context
+
+The `watchState` function can be used outside an injection context by providing an injector as the second argument.
+
+<code-example header="counter.component.ts">
+
+import { Component, inject, Injector, OnInit } from '@angular/core';
+import { watchState } from '@ngrx/signals';
+import { CounterStore } from './counter.store';
+
+@Component({
+  /* ... */
+  providers: [CounterStore],
+})
+export class CounterComponent implements OnInit {
+  readonly #injector = inject(Injector);
+  readonly store = inject(CounterStore);
+
+  ngOnInit(): void {
+    watchState(this.store, console.log, {
+      injector: this.#injector,
+    });
+
+    setInterval(() => this.store.increment(), 2_000);
+  }
+}
+
+</code-example>

--- a/projects/ngrx.io/content/navigation.json
+++ b/projects/ngrx.io/content/navigation.json
@@ -294,6 +294,10 @@
                   "url": "guide/signals/signal-store/lifecycle-hooks"
                 },
                 {
+                  "title": "State Tracking",
+                  "url": "guide/signals/signal-store/state-tracking"
+                },
+                {
                   "title": "Custom Store Features",
                   "url": "guide/signals/signal-store/custom-store-features"
                 },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There is no way to synchronously track SignalState/SignalStore's state changes.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4416

## What is the new behavior?

The `watchState` function is provided to synchronously track state changes:

```ts
const state = signalState({ count: 0 });

watchState(state, console.log);
// logs: { count: 0 }, { count: 1 }, { count: 2 }

patchState(state, { count: 1 });
patchState(state, { count: 2 });
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
