### PR TITLE
feat(signals): remove RxMethodInput for better readability

### DIFF
--- a/modules/signals/rxjs-interop/src/rx-method.ts
+++ b/modules/signals/rxjs-interop/src/rx-method.ts
@@ -10,9 +10,9 @@ import {
 } from '@angular/core';
 import { isObservable, noop, Observable, Subject, Unsubscribable } from 'rxjs';
 
-type RxMethodInput<Input> = Input | Observable<Input> | Signal<Input>;
-
-type RxMethod<Input> = ((input: RxMethodInput<Input>) => Unsubscribable) &
+type RxMethod<Input> = ((
+  input: Input | Signal<Input> | Observable<Input>
+) => Unsubscribable) &
   Unsubscribable;
 
 export function rxMethod<Input>(
@@ -30,7 +30,7 @@ export function rxMethod<Input>(
   const sourceSub = generator(source$).subscribe();
   destroyRef.onDestroy(() => sourceSub.unsubscribe());
 
-  const rxMethodFn = (input: RxMethodInput<Input>) => {
+  const rxMethodFn = (input: Input | Signal<Input> | Observable<Input>) => {
     if (isSignal(input)) {
       const watcher = effect(
         () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the following example:

```ts
const logNumber = rxMethod<number>(tap(console.log));
```

The `logNumber` input type is `RxMethodInput<number>`.

## What is the new behavior?

The `logNumber` input type is `number | Signal<number> | Observable<number>`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
