### PR TITLE
fix(store-devtools): add @angular/core as peer dependency

### DIFF
--- a/modules/store-devtools/package.json
+++ b/modules/store-devtools/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/ngrx/platform#readme",
   "peerDependencies": {
+    "@angular/core": "^18.0.0",
     "@ngrx/store": "18.0.2",
     "rxjs": "^6.5.3 || ^7.5.0"
   },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When installing using pnpm which isolates the dependencies per default. The application will fail to start because there is no @angular/core (./rxjs-interop) available to import. 

Error:

`✘ [ERROR] Missing "./rxjs-interop" specifier in "@angular/core" package [plugin vite:dep-pre-bundle]`

and

`7 │ import { toSignal } from '@angular/core/rxjs-interop';`

Closes #4479 

## What is the new behavior?

Adding a peer dependency should make @angular/core available within the isolated scope of @ngrx/store-devtools. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
There is a peerDependency on @ngrx/store which has a peerDependency on @angular/core but this will not make it available to @ngrx/store-devtools automatically unless installed on workspace level or using _shamefully_ hoisting.