### PR TITLE
feat(signals): pass missing methods to store in `withComputed`

### DIFF
--- a/modules/signals/spec/with-computed.spec.ts
+++ b/modules/signals/spec/with-computed.spec.ts
@@ -1,5 +1,11 @@
-import { signal } from '@angular/core';
-import { withComputed, withMethods, withState } from '../src';
+import { computed, signal } from '@angular/core';
+import {
+  type Prettify,
+  type StateSignals,
+  withComputed,
+  withMethods,
+  withState,
+} from '../src';
 import { getInitialInnerStore } from '../src/signal-store';
 
 describe('withComputed', () => {
@@ -50,5 +56,33 @@ describe('withComputed', () => {
       'Trying to override:',
       'p1, s2, m1'
     );
+  });
+
+  it('allow to use methods', () => {
+    const initialStore = [
+      withState({
+        p1: 1,
+        p2: 2,
+      }),
+      withMethods(() => ({
+        m1: Object.assign(() => {}, { multiplier: 3 }),
+      })),
+    ].reduce((acc, feature) => feature(acc), getInitialInnerStore());
+
+    const store = withComputed((store) => {
+      const { p1, p2, m1 } = store as unknown as Prettify<
+        StateSignals<{ p1: number; p2: number }> & {
+          m1: (() => undefined) & { multiplier: number };
+        }
+      >;
+
+      return {
+        c1: computed<number>(() => p1() * m1.multiplier),
+        c2: computed<number>(() => p2() * m1.multiplier),
+      };
+    })(initialStore);
+
+    expect(store.computedSignals.c1()).toBe(3);
+    expect(store.computedSignals.c2()).toBe(6);
   });
 });

--- a/modules/signals/src/with-computed.ts
+++ b/modules/signals/src/with-computed.ts
@@ -13,7 +13,7 @@ export function withComputed<
   ComputedSignals extends SignalsDictionary
 >(
   signalsFactory: (
-    store: Prettify<StateSignals<Input['state']> & Input['computed']>
+    store: Prettify<StateSignals<Input['state']> & Input['computed'] & Input['methods']>
   ) => ComputedSignals
 ): SignalStoreFeature<
   Input,
@@ -23,6 +23,7 @@ export function withComputed<
     const computedSignals = signalsFactory({
       ...store.stateSignals,
       ...store.computedSignals,
+      ...store.methods
     });
     assertUniqueStoreMembers(store, Object.keys(computedSignals));
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

When using `withComputed` store passed to factory there were missing methods.

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Methods are missing in `signalsFactory` store.

## What is the new behavior?

Methods are available in `signalsFactory` store.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Should not have negative effect.

## Other information
