### PR TITLE
feat(signals): set state in `patchState` to readonly

### DIFF
--- a/modules/signals/spec/types/patch-state.types.spec.ts
+++ b/modules/signals/spec/types/patch-state.types.spec.ts
@@ -1,5 +1,6 @@
 import { expecter } from 'ts-snippet';
 import { compilerOptions } from './helpers';
+import { patchState, signalState } from '@ngrx/signals';
 
 describe('patchState', () => {
   const expectSnippet = expecter(
@@ -68,5 +69,48 @@ describe('patchState', () => {
     expectSnippet('patchState(state, addNumber(10), increment())').toFail(
       /Property 'numbers' is missing in type '{ count: number; foo: string; }'/
     );
+  });
+
+  describe('state in patchState', () => {
+    it('is readonly for primitive types', () => {
+      const state = signalState({ id: 1, name: 'Hugo' });
+
+      patchState(state, (value) => {
+        //@ts-expect-error cannot modify primitive type
+        value.id = 2;
+
+        return value;
+      });
+    });
+
+    it('is readonly for nested objects', () => {
+      const state = signalState({
+        user: { id: 1 },
+      });
+
+      patchState(state, (value) => {
+        //@ts-expect-error cannot modify nested object
+        value.user.id = 2;
+
+        return value;
+      });
+    });
+
+    it('is readonly for arrays', () => {
+      const state = signalState({
+        education: [
+          'Elementary School',
+          'Lycée Français',
+          'University of Technology',
+        ],
+      });
+
+      patchState(state, (value) => {
+        //@ts-expect-error cannot modify array
+        value.education.push('University of Applied Sciences');
+
+        return value;
+      });
+    });
   });
 });

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -8,7 +8,7 @@ import {
   WritableSignal,
 } from '@angular/core';
 import { SIGNAL } from '@angular/core/primitives/signals';
-import { Prettify } from './ts-helpers';
+import { DeepReadonly, Prettify } from './ts-helpers';
 
 const STATE_WATCHERS = new WeakMap<object, Array<StateWatcher<any>>>();
 
@@ -23,8 +23,8 @@ export type StateSource<State extends object> = {
 };
 
 export type PartialStateUpdater<State extends object> = (
-  state: State
-) => Partial<State>;
+  state: DeepReadonly<State>
+) => Partial<State | DeepReadonly<State>>;
 
 export type StateWatcher<State extends object> = (
   state: NoInfer<State>

--- a/modules/signals/src/ts-helpers.ts
+++ b/modules/signals/src/ts-helpers.ts
@@ -27,3 +27,11 @@ export type IsKnownRecord<T> = IsRecord<T> extends true
 export type OmitPrivate<T> = {
   [K in keyof T as K extends `_${string}` ? never : K]: T[K];
 };
+
+export type DeepReadonly<T> = T extends object
+  ? {
+      readonly [P in keyof T]: DeepReadonly<T[P]>;
+    }
+  : T extends []
+  ? ReadonlyArray<DeepReadonly<T>>
+  : T;


### PR DESCRIPTION
As discussed in #4030, the update function of `patchState`, provides the state as deep readonly.

Notes on the test: I've decided to go with `@ts-expect-error` instead of ts-snippet. ts-snippet requires the source code as string, whereas @ts-expect-error can be applied to normal code. This makes it easier to write but also to refactor.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?


```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4030 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
