### PR TITLE
fix(signals): remove usage of SIGNAL from @angular/core/primitives/signals package

### DIFF
--- a/modules/signals/spec/signal-store.spec.ts
+++ b/modules/signals/spec/signal-store.spec.ts
@@ -47,7 +47,6 @@ describe('signalStore', () => {
 
       expect(isSignal(stateSource)).toBe(true);
       expect(stateSource()).toEqual({ foo: 'bar' });
-      expect(typeof (stateSource as any).update === 'undefined').toBe(true);
     });
 
     it('creates a store with readonly state source when protectedState option is true', () => {
@@ -60,7 +59,6 @@ describe('signalStore', () => {
 
       expect(isSignal(stateSource)).toBe(true);
       expect(stateSource()).toEqual({ foo: 'bar' });
-      expect(typeof (stateSource as any).update === 'undefined').toBe(true);
     });
 
     it('creates a store with writable state source when protectedState option is false', () => {

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -1357,10 +1357,7 @@ export function signalStore(
       const { stateSignals, computedSignals, methods, hooks } = innerStore;
       const storeMembers = { ...stateSignals, ...computedSignals, ...methods };
 
-      (this as any)[STATE_SOURCE] =
-        config.protectedState === false
-          ? innerStore[STATE_SOURCE]
-          : innerStore[STATE_SOURCE].asReadonly();
+      (this as any)[STATE_SOURCE] = innerStore[STATE_SOURCE];
 
       for (const key in storeMembers) {
         (this as any)[key] = storeMembers[key];

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -7,7 +7,6 @@ import {
   untracked,
   WritableSignal,
 } from '@angular/core';
-import { SIGNAL } from '@angular/core/primitives/signals';
 import { Prettify } from './ts-helpers';
 
 const STATE_WATCHERS = new WeakMap<object, Array<StateWatcher<any>>>();
@@ -79,7 +78,7 @@ export function watchState<State extends object>(
 function getWatchers<State extends object>(
   stateSource: StateSource<State>
 ): Array<StateWatcher<State>> {
-  return STATE_WATCHERS.get(stateSource[STATE_SOURCE][SIGNAL] as object) || [];
+  return STATE_WATCHERS.get(stateSource[STATE_SOURCE] as object) || [];
 }
 
 function notifyWatchers<State extends object>(
@@ -98,7 +97,7 @@ function addWatcher<State extends object>(
   watcher: StateWatcher<State>
 ): void {
   const watchers = getWatchers(stateSource);
-  STATE_WATCHERS.set(stateSource[STATE_SOURCE][SIGNAL] as object, [
+  STATE_WATCHERS.set(stateSource[STATE_SOURCE] as object, [
     ...watchers,
     watcher,
   ]);
@@ -110,7 +109,7 @@ function removeWatcher<State extends object>(
 ): void {
   const watchers = getWatchers(stateSource);
   STATE_WATCHERS.set(
-    stateSource[STATE_SOURCE][SIGNAL] as object,
+    stateSource[STATE_SOURCE] as object,
     watchers.filter((w) => w !== watcher)
   );
 }

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { Prettify } from './ts-helpers';
 
-const STATE_WATCHERS = new WeakMap<object, Array<StateWatcher<any>>>();
+const STATE_WATCHERS = new WeakMap<Signal<object>, Array<StateWatcher<any>>>();
 
 export const STATE_SOURCE = Symbol('STATE_SOURCE');
 
@@ -78,7 +78,7 @@ export function watchState<State extends object>(
 function getWatchers<State extends object>(
   stateSource: StateSource<State>
 ): Array<StateWatcher<State>> {
-  return STATE_WATCHERS.get(stateSource[STATE_SOURCE] as object) || [];
+  return STATE_WATCHERS.get(stateSource[STATE_SOURCE]) || [];
 }
 
 function notifyWatchers<State extends object>(
@@ -97,10 +97,7 @@ function addWatcher<State extends object>(
   watcher: StateWatcher<State>
 ): void {
   const watchers = getWatchers(stateSource);
-  STATE_WATCHERS.set(stateSource[STATE_SOURCE] as object, [
-    ...watchers,
-    watcher,
-  ]);
+  STATE_WATCHERS.set(stateSource[STATE_SOURCE], [...watchers, watcher]);
 }
 
 function removeWatcher<State extends object>(
@@ -109,7 +106,7 @@ function removeWatcher<State extends object>(
 ): void {
   const watchers = getWatchers(stateSource);
   STATE_WATCHERS.set(
-    stateSource[STATE_SOURCE] as object,
+    stateSource[STATE_SOURCE],
     watchers.filter((w) => w !== watcher)
   );
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

- The `SIGNAL` symbol is imported from the `@angular/core/primitives/signals` package. This is a private import from Angular. This causes issues syncing the NgRx Signals library into G3.
- Removes `readonly` from internal signal as this is checked at the type level

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The `SIGNAL` symbol is no longer imported from the `@angular/core/primitives/signals` package.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
