### PR TITLE
fix(signals): export toDeepSignal

### DIFF
--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -1,4 +1,4 @@
-export { DeepSignal } from './deep-signal';
+export { DeepSignal, toDeepSignal } from './deep-signal';
 export { signalState, SignalState } from './signal-state';
 export { signalStore } from './signal-store';
 export { signalStoreFeature, type } from './signal-store-feature';


### PR DESCRIPTION
## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`@ngrx/signals` have the `toDeepSignal` utility that could be useful for monorepos where a library requires this kind of stuff without creating a `signalState`.

In my case, I'm using `xstate` and `xstate-ngx` where we select a state-slice or a single value from it, we can convert it to Signal/DeepSignal easily with this utility.

Refs #4377

## What is the new behavior?

Being able to `import { toDeepSignal } from '@ngrx/signals'` instead duplicating it inside our monorepos.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
