### PR TITLE
fix(router-store): use non-const enum to allow isolatedModules tsconfig option

### DIFF
--- a/modules/router-store/src/router_store_config.ts
+++ b/modules/router-store/src/router_store_config.ts
@@ -29,7 +29,7 @@ export const ROUTER_CONFIG = new InjectionToken(
  * Minimal = Serializes the router event with MinimalRouterStateSerializer
  * Full = Serializes the router event with FullRouterStateSerializer
  */
-export const enum RouterState {
+export enum RouterState {
   Full,
   Minimal,
 }


### PR DESCRIPTION
Using a const enum here triggers "Cannot access ambient const enums when 'isolatedModules' is enabled." error when "isolatedModules" is `true` in tsconfig.json.

"isolatedModules" is set to `true` by default in new Angular CLI applications.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
