### PR TITLE
feat(schematics): change standalone default to true for components

### DIFF
--- a/modules/schematics/src/container/schema.json
+++ b/modules/schematics/src/container/schema.json
@@ -102,7 +102,8 @@
     },
     "standalone": {
       "description": "Whether the generated component is standalone.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     },
     "displayBlock": {
       "description": "Specifies if the style will contain :host { display: block; }.",


### PR DESCRIPTION
"feat(schematics): change standalone default to true for components"

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ✓] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[✓ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The default setting for generating components using schematics does not use standalone components.

Closes #4563

## What is the new behavior?
By default, component schematics will now generate standalone components, setting "standalone": true in schema.json.
## Does this PR introduce a breaking change?

```
[ ] Yes
[✓ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
N/A
