### PR TITLE
feat(signals): rename `rxMethod.unsubscribe` to `destroy`

### DIFF
--- a/modules/signals/rxjs-interop/spec/rx-method.spec.ts
+++ b/modules/signals/rxjs-interop/spec/rx-method.spec.ts
@@ -96,8 +96,8 @@ describe('rxMethod', () => {
       const subject$ = new Subject<number>();
       const sig = signal(0);
 
-      const sub1 = method(subject$);
-      const sub2 = method(sig);
+      const ref1 = method(subject$);
+      const ref2 = method(sig);
       expect(results).toEqual([]);
 
       subject$.next(1);
@@ -105,13 +105,13 @@ describe('rxMethod', () => {
       TestBed.flushEffects();
       expect(results).toEqual([1, 1]);
 
-      sub1.unsubscribe();
+      ref1.destroy();
       subject$.next(2);
       sig.set(2);
       TestBed.flushEffects();
       expect(results).toEqual([1, 1, 2]);
 
-      sub2.unsubscribe();
+      ref2.destroy();
       sig.set(3);
       TestBed.flushEffects();
       expect(results).toEqual([1, 1, 2]);
@@ -138,7 +138,7 @@ describe('rxMethod', () => {
     method(1);
     expect(results).toEqual([1, 1, 1]);
 
-    method.unsubscribe();
+    method.destroy();
     expect(destroyed).toBe(true);
 
     subject1$.next(2);

--- a/projects/ngrx.io/content/guide/signals/rxjs-integration.md
+++ b/projects/ngrx.io/content/guide/signals/rxjs-integration.md
@@ -247,7 +247,7 @@ If the injector is not provided when calling the reactive method outside of curr
 
 ### Manual Cleanup
 
-If a reactive method needs to be cleaned up before the injector is destroyed, manual cleanup can be performed by calling the `unsubscribe` method.
+If a reactive method needs to be cleaned up before the injector is destroyed, manual cleanup can be performed by calling the `destroy` method.
 
 ```ts
 import { Component, OnInit } from '@angular/core';
@@ -266,15 +266,15 @@ export class NumbersComponent implements OnInit {
     this.logNumber(num2$);
 
     setTimeout(() => {
-      // 👇 Clean up all reactive method subscriptions after 3 seconds.
-      this.logNumber.unsubscribe();
+      // 👇 Destroy the reactive method after 3 seconds.
+      this.logNumber.destroy();
     }, 3_000);
   }
 }
 ```
 
-When invoked, the reactive method returns a subscription.
-Using this subscription allows manual unsubscribing from a specific call, preserving the activity of other reactive method calls until the corresponding injector is destroyed.
+When invoked, the reactive method returns the object with the `destroy` method.
+This allows manual cleanup of a specific call, preserving the activity of other reactive method calls until the corresponding injector is destroyed.
 
 ```ts
 import { Component, OnInit } from '@angular/core';
@@ -289,12 +289,12 @@ export class NumbersComponent implements OnInit {
     const num1$ = interval(500);
     const num2$ = interval(1_000);
 
-    const num1Sub = this.logNumber(num1$);
-    this.logNumber(num2$);
+    const num1Ref = this.logNumber(num1$);
+    const num2Ref = this.logNumber(num2$);
 
     setTimeout(() => {
-      // 👇 Clean up the first reactive method subscription after 2 seconds.
-      num1Sub.unsubscribe();
+      // 👇 Destroy the first reactive method call after 2 seconds.
+      num1Ref.destroy();
     }, 2_000);
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?

The `unsubscribe` method from `rxMethod` is renamed to `destroy`.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

```
BREAKING CHANGES:

The `unsubscribe` method from `rxMethod` is renamed to `destroy`.

BEFORE:

const logNumber = rxMethod<number>(tap(console.log));

const num1Ref = logNumber(interval(1_000));
const num2Ref = logNumber(interval(2_000));

// destroy `num1Ref` after 2 seconds
setTimeout(() => num1Ref.unsubscribe(), 2_000);

// destroy all reactive method refs after 5 seconds
setTimeout(() => logNumber.unsubscribe(), 5_000);

AFTER:

const logNumber = rxMethod<number>(tap(console.log));

const num1Ref = logNumber(interval(1_000));
const num2Ref = logNumber(interval(2_000));

// destroy `num1Ref` after 2 seconds
setTimeout(() => num1Ref.destroy(), 2_000);

// destroy all reactive method refs after 5 seconds
setTimeout(() => logNumber.destroy(), 5_000);

```
