### PR TITLE
feat(signals): add `signalMethod`

### DIFF
--- a/modules/signals/spec/signal-method.spec.ts
+++ b/modules/signals/spec/signal-method.spec.ts
@@ -1,0 +1,201 @@
+import { signalMethod } from '../src/signal-method';
+import { TestBed } from '@angular/core/testing';
+import {
+  createEnvironmentInjector,
+  EnvironmentInjector,
+  runInInjectionContext,
+  signal,
+} from '@angular/core';
+
+describe('signalMethod', () => {
+  const createAdder = (processingFn: (value: number) => void) =>
+    TestBed.runInInjectionContext(() => signalMethod<number>(processingFn));
+
+  it('processes a non-signal input', () => {
+    let a = 1;
+    const adder = createAdder((value) => (a += value));
+    adder(2);
+    expect(a).toBe(3);
+  });
+
+  it('processes a signal input', () => {
+    let a = 1;
+    const summand = signal(1);
+    const adder = createAdder((value) => (a += value));
+
+    adder(summand);
+    expect(a).toBe(1);
+
+    TestBed.flushEffects();
+    expect(a).toBe(2);
+
+    summand.set(2);
+    summand.set(2);
+    TestBed.flushEffects();
+    expect(a).toBe(4);
+
+    TestBed.flushEffects();
+    expect(a).toBe(4);
+  });
+
+  it('throws if is a not created in an injection context', () => {
+    expect(() => signalMethod<void>(() => void true)).toThrowError();
+  });
+
+  it('stops signal tracking, when signalMethod gets destroyed', () => {
+    let a = 1;
+    const summand = signal(1);
+    const adder = createAdder((value) => (a += value));
+    adder(summand);
+
+    summand.set(2);
+    TestBed.flushEffects();
+    expect(a).toBe(3);
+
+    adder.destroy();
+
+    summand.set(2);
+    TestBed.flushEffects();
+    expect(a).toBe(3);
+  });
+
+  it('can also destroy a signalMethod that processes non-signal inputs', () => {
+    const adder = createAdder(() => void true);
+    expect(() => adder(1).destroy()).not.toThrowError();
+  });
+
+  describe('destroying signalMethod', () => {
+    it('stops tracking all signals on signalMethod destroy', () => {
+      let a = 1;
+      const summand1 = signal(1);
+      const summand2 = signal(2);
+      const adder = createAdder((value) => (a += value));
+      adder(summand1);
+      adder(summand2);
+
+      summand1.set(2);
+      summand2.set(3);
+      TestBed.flushEffects();
+      expect(a).toBe(6);
+
+      adder.destroy();
+
+      summand1.set(2);
+      summand2.set(3);
+      TestBed.flushEffects();
+      expect(a).toBe(6);
+    });
+
+    it('does not cause issues if destroyed signalMethodFn contains destroyed effectRefs', () => {
+      let a = 1;
+      const summand1 = signal(1);
+      const summand2 = signal(2);
+      const adder = createAdder((value) => (a += value));
+
+      const childInjector = createEnvironmentInjector(
+        [],
+        TestBed.inject(EnvironmentInjector)
+      );
+
+      adder(summand1, { injector: childInjector });
+      adder(summand2);
+
+      TestBed.flushEffects();
+      expect(a).toBe(4);
+      childInjector.destroy();
+
+      summand1.set(2);
+      summand2.set(2);
+      TestBed.flushEffects();
+
+      adder.destroy();
+      expect(a).toBe(4);
+    });
+
+    it('uses the provided injector (source injector) on creation', () => {
+      let a = 1;
+      const sourceInjector = createEnvironmentInjector(
+        [],
+        TestBed.inject(EnvironmentInjector)
+      );
+      const adder = signalMethod((value: number) => (a += value), {
+        injector: sourceInjector,
+      });
+      const value = signal(1);
+
+      adder(value);
+      TestBed.flushEffects();
+
+      sourceInjector.destroy();
+      value.set(2);
+      TestBed.flushEffects();
+
+      expect(a).toBe(2);
+    });
+
+    it('prioritizes the provided caller injector over source injector', () => {
+      let a = 1;
+      const callerInjector = createEnvironmentInjector(
+        [],
+        TestBed.inject(EnvironmentInjector)
+      );
+      const sourceInjector = createEnvironmentInjector(
+        [],
+        TestBed.inject(EnvironmentInjector)
+      );
+      const adder = signalMethod((value: number) => (a += value), {
+        injector: sourceInjector,
+      });
+      const value = signal(1);
+
+      TestBed.runInInjectionContext(() => {
+        adder(value, { injector: callerInjector });
+      });
+      TestBed.flushEffects();
+      expect(a).toBe(2);
+
+      sourceInjector.destroy();
+      value.set(2);
+      TestBed.flushEffects();
+
+      expect(a).toBe(4);
+    });
+
+    it('prioritizes the provided injector over source and caller injector', () => {
+      let a = 1;
+      const callerInjector = createEnvironmentInjector(
+        [],
+        TestBed.inject(EnvironmentInjector)
+      );
+      const sourceInjector = createEnvironmentInjector(
+        [],
+        TestBed.inject(EnvironmentInjector)
+      );
+      const providedInjector = createEnvironmentInjector(
+        [],
+        TestBed.inject(EnvironmentInjector)
+      );
+
+      const adder = signalMethod((value: number) => (a += value), {
+        injector: sourceInjector,
+      });
+      const value = signal(1);
+
+      runInInjectionContext(callerInjector, () =>
+        adder(value, { injector: providedInjector })
+      );
+      TestBed.flushEffects();
+      expect(a).toBe(2);
+
+      sourceInjector.destroy();
+      value.set(2);
+      TestBed.flushEffects();
+      expect(a).toBe(4);
+
+      callerInjector.destroy();
+      value.set(1);
+      TestBed.flushEffects();
+      expect(a).toBe(5);
+    });
+  });
+});

--- a/modules/signals/spec/signal-method.spec.ts
+++ b/modules/signals/spec/signal-method.spec.ts
@@ -1,4 +1,4 @@
-import { signalMethod } from '../src/signal-method';
+import { signalMethod } from '../src';
 import { TestBed } from '@angular/core/testing';
 import {
   createEnvironmentInjector,

--- a/modules/signals/spec/signal-method.spec.ts
+++ b/modules/signals/spec/signal-method.spec.ts
@@ -42,29 +42,29 @@ describe('signalMethod', () => {
     expect(() => signalMethod<void>(() => void true)).toThrowError();
   });
 
-  it('stops signal tracking, when signalMethod gets destroyed', () => {
-    let a = 1;
-    const summand = signal(1);
-    const adder = createAdder((value) => (a += value));
-    adder(summand);
-
-    summand.set(2);
-    TestBed.flushEffects();
-    expect(a).toBe(3);
-
-    adder.destroy();
-
-    summand.set(2);
-    TestBed.flushEffects();
-    expect(a).toBe(3);
-  });
-
-  it('can also destroy a signalMethod that processes non-signal inputs', () => {
-    const adder = createAdder(() => void true);
-    expect(() => adder(1).destroy()).not.toThrowError();
-  });
-
   describe('destroying signalMethod', () => {
+    it('stops signal tracking, when signalMethod gets destroyed', () => {
+      let a = 1;
+      const summand = signal(1);
+      const adder = createAdder((value) => (a += value));
+      adder(summand);
+
+      summand.set(2);
+      TestBed.flushEffects();
+      expect(a).toBe(3);
+
+      adder.destroy();
+
+      summand.set(2);
+      TestBed.flushEffects();
+      expect(a).toBe(3);
+    });
+
+    it('can also destroy a signalMethod that processes non-signal inputs', () => {
+      const adder = createAdder(() => void true);
+      expect(() => adder(1).destroy()).not.toThrowError();
+    });
+
     it('stops tracking all signals on signalMethod destroy', () => {
       let a = 1;
       const summand1 = signal(1);

--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -1,5 +1,6 @@
 export { deepComputed } from './deep-computed';
 export { DeepSignal } from './deep-signal';
+export { signalMethod } from './signal-method';
 export { signalState, SignalState } from './signal-state';
 export { signalStore } from './signal-store';
 export { signalStoreFeature, type } from './signal-store-feature';

--- a/modules/signals/src/signal-method.ts
+++ b/modules/signals/src/signal-method.ts
@@ -1,0 +1,66 @@
+import {
+  assertInInjectionContext,
+  effect,
+  EffectRef,
+  inject,
+  Injector,
+  isSignal,
+  Signal,
+  untracked,
+} from '@angular/core';
+
+type SignalMethod<Input> = ((
+  input: Input | Signal<Input>,
+  config?: { injector?: Injector }
+) => EffectRef) &
+  EffectRef;
+
+export function signalMethod<Input>(
+  processingFn: (value: Input) => void,
+  config?: { injector?: Injector }
+): SignalMethod<Input> {
+  if (!config?.injector) {
+    assertInInjectionContext(signalMethod);
+  }
+
+  const watchers: EffectRef[] = [];
+  const sourceInjector = config?.injector ?? inject(Injector);
+
+  const signalMethodFn = (
+    input: Input | Signal<Input>,
+    config?: { injector?: Injector }
+  ): EffectRef => {
+    if (isSignal(input)) {
+      const instanceInjector =
+        config?.injector ?? getCallerInjector() ?? sourceInjector;
+
+      const watcher = effect(
+        (onCleanup) => {
+          const value = input();
+          untracked(() => processingFn(value));
+          onCleanup(() => watchers.splice(watchers.indexOf(watcher), 1));
+        },
+        { injector: instanceInjector }
+      );
+      watchers.push(watcher);
+
+      return watcher;
+    } else {
+      processingFn(input);
+      return { destroy: () => void true };
+    }
+  };
+
+  signalMethodFn.destroy = () =>
+    watchers.forEach((watcher) => watcher.destroy());
+
+  return signalMethodFn;
+}
+
+function getCallerInjector(): Injector | null {
+  try {
+    return inject(Injector);
+  } catch {
+    return null;
+  }
+}

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -50,19 +50,16 @@ By default, the `effect` runs in the injection context of the caller. In the exa
 If the call happens outside of an injection context, then the injector of the `signalMethod` is used. This would be the case, if `logDoubledNumber` runs in `ngOnInit`:
 
 ```ts
-
-@Component({ /* ... */})
-export class NumbersComponent {
-  readonly logDoubledNumber = signalMethod<number>(num => {
+@Component({ /* ... */ })
+export class NumbersComponent implements OnInit {
+  readonly logDoubledNumber = signalMethod<number>((num) => {
     const double = num * 2;
     console.log(double);
-  })
+  });
 
   ngOnInit(): void {
-    this.logDoubledNumber(1);
-
     const value = signal(2);
-    // 👇 uses the injection context of the `signalMethod`
+    // 👇 Uses the injection context of the `NumbersComponent`.
     this.logDoubledNumber(value);
   }
 }

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -189,7 +189,7 @@ export class NumbersComponent {
 
 However, `signalMethod` offers three distinctive advantages over `effect`:
 
-- **Flexible Parameter**: The parameter can also be a simple number, not just a Signal.
+- **Flexible Input**: The input argument can be a static value, not just a signal. Additionally, the processor function can be called multiple times with different inputs.
 - **No Injection Context Required**: Unlike an `effect`, which requires an injection context or an Injector, `signalMethod`'s "processor function" can be called without an injection context.
 - **Explicit Tracking**: Only the Signal of the parameter is tracked, while Signals within the "processor function" stay untracked.
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -3,17 +3,17 @@
 `signalMethod` is a standalone factory function used for managing side effects with Angular signals. It accepts a callback and returns a processor function that can handle either a static value or a signal. The input type can be specified using a generic type argument:
 
 ```ts
-import {Component} from '@angular/core';
-import {signalMethod} from '@ngrx/signals';
+import { Component } from '@angular/core';
+import { signalMethod } from '@ngrx/signals';
 
-@Component({ /* ... */})
+@Component({ /* ... */ })
 export class NumbersComponent {
   // 👇 This method will have an input argument
   // of type `number | Signal<number>`.
-  readonly logDoubledNumber = signalMethod<number>(num => {
+  readonly logDoubledNumber = signalMethod<number>((num) => {
     const double = num * 2;
     console.log(double);
-  })
+  });
 }
 ```
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -137,33 +137,22 @@ export class NumbersComponent {
 }
 ```
 
-Whereas the "processor function" doesn't require an active injection context, the call of `signalMethod` does:
+## Initialization Outside of Injection Context
+
+The `signalMethod` must be initialized within an injection context. To initialize it outside an injection context, it's necessary to provide an injector as the second argument:
 
 ```ts
-
-@Component({ /* ... */})
-export class NumbersComponent {
-// 👇 Would cause a runtime error
-  ngOnInit() {
-    const logDoubledNumber = signalMethod<number>(num => console.log(num * 2));
-  }
-}
-```
-
-In these cases, you also have to provide the injector manually:
-
-```ts
-
-@Component({ /* ... */})
-export class NumbersComponent {
+@Component({ /* ... */ })
+export class NumbersComponent implements OnInit {
   readonly injector = inject(Injector);
 
   ngOnInit() {
-    // 👇 Works now
-    const logDoubledNumber = signalMethod<number>(num => console.log(num * 2), {injector: this.injector});
+    const logDoubledNumber = signalMethod<number>(
+      (num) => console.log(num * 2),
+      { injector: this.injector },
+    );
   }
 }
-```
 
 ## Advantages over Effect
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -2,8 +2,6 @@
 
 `signalMethod` is a factory function that executes side effects based on signal changes. It creates one function (processing function) with one typed parameter that can be a static value or a Signal. Upon invocation, the "processing function" has to be provided.
 
-`signalMethod` can also be used outside of `signalStore` or `signalState`:
-
 ```ts
 import {Component} from '@angular/core';
 import {signalMethod} from '@ngrx/signals';

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -167,7 +167,7 @@ export class NumbersComponent {
 }
 ```
 
-## Advantages over simple effect
+## Advantages over Effect
 
 At first sight, `signalMethod`, might be the same as `effect`:
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -2,7 +2,7 @@
 
 `signalMethod` is a factory function that executes side effects based on signal changes. It creates one function (processing function) with one typed parameter that can be a static value or a Signal. Upon invocation, the "processing function" has to be provided.
 
-`signalMethod` is `rxMethod` without RxJS. `signalMethod` can also be used outside of `signalStore` or `signalState`:
+`signalMethod` can also be used outside of `signalStore` or `signalState`:
 
 ```ts
 import {Component} from '@angular/core';
@@ -193,9 +193,8 @@ However, `signalMethod` offers three distinctive advantages over `effect`:
 - **No Injection Context Required**: Unlike an `effect`, which requires an injection context or an Injector, `signalMethod`'s "processor function" can be called without an injection context.
 - **Explicit Tracking**: Only the Signal of the parameter is tracked, while Signals within the "processor function" stay untracked.
 
+## `signalMethod` compared to `rxMethod`
 
-<div class="alert is-helpful">
+`signalMethod` is `rxMethod` without RxJS, and is therefore much smaller in terms of bundle size.
 
 Be aware that RxJS is superior to Signals in managing race conditions. Signals have a glitch-free effect, meaning that for multiple synchronous changes, only the last change is propagated. Additionally, they lack powerful operators like `switchMap` or `concatMap`.
-
-</div>

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -19,7 +19,7 @@ export class NumbersComponent {
 }
 ```
 
-`logDoubledNumber` can be called with a static value of type number or a Signal of type number:
+`logDoubledNumber` can be called with a static value of type `number`, or a Signal of type `number`:
 
 ```ts
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -116,7 +116,7 @@ export class NumbersComponent {
 }
 ```
 
-## Providing an Injector
+## Manual Cleanup
 
 If you cannot run the "processor function" in an injection context, you can also provide an injector manually:
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -94,7 +94,7 @@ Here, the `effect` outlives the component, which would produce a memory leak.
 
 ## Manual Cleanup
 
-If you cannot run the "processor function" in an injection context, you can also provide an injector manually:
+When a `signalMethod` is created in an ancestor injection context, it's necessary to explicitly provide the caller injector to ensure proper cleanup:
 
 ```ts
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -1,6 +1,6 @@
 # signalMethod
 
-`signalMethod` is a factory function to execute side effects based on Signal changes. It creates one function (processing function) with one typed parameter that can be a static value or a Signal. Upon invocation, the "processing function" has to be provided.
+`signalMethod` is a factory function that executes side effects based on signal changes. It creates one function (processing function) with one typed parameter that can be a static value or a Signal. Upon invocation, the "processing function" has to be provided.
 
 `signalMethod` is `rxMethod` without RxJS. `signalMethod` can also be used outside of `signalStore` or `signalState`:
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -111,7 +111,7 @@ export class NumbersComponent implements OnInit {
     });
   
     // 👇 No need to provide an injector for static values.
-    this.logDoubledNumber(2);
+    this.numbersService.logDoubledNumber(2);
   }
 }
 ```

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -44,7 +44,6 @@ export class NumbersComponent {
 ## Automatic Cleanup
 
 `signalMethod` uses an `effect` internally to track the Signal changes.
-
 By default, the `effect` runs in the injection context of the caller. In the example above, that is `NumbersComponent`. That means, that the `effect` is automatically cleaned up when the component is destroyed.
 
 If the call happens outside an injection context, then the injector of the `signalMethod` is used. This would be the case, if `logDoubledNumber` runs in `ngOnInit`:

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -1,4 +1,4 @@
-# signalMethod
+# SignalMethod
 
 `signalMethod` is a factory function that executes side effects based on signal changes. It creates one function (processing function) with one typed parameter that can be a static value or a Signal. Upon invocation, the "processing function" has to be provided.
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -41,7 +41,7 @@ export class NumbersComponent {
 }
 ```
 
-## Automatic Signal Tracking
+## Automatic Cleanup
 
 `signalMethod` uses an `effect` internally to track the Signal changes.
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -65,9 +65,9 @@ export class NumbersComponent implements OnInit {
 }
 ```
 
-For the `NumbersComponent`, it doesn't make a difference. Again, the `effect` is automatically cleaned up when the component is destroyed.
+Even though `logDoubledNumber` is called outside an injection context, automatic cleanup occurs when `NumbersComponent` is destroyed, since `logDoubledNumber` was created within the component's injection context.
 
-Careful, when `signalMethod` is used in a service which is provided in `root`:
+However, when creating a `signalMethod` in an ancestor injection context, the cleanup behavior is different:
 
 ```ts
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -70,25 +70,22 @@ Even though `logDoubledNumber` is called outside an injection context, automatic
 However, when creating a `signalMethod` in an ancestor injection context, the cleanup behavior is different:
 
 ```ts
-
-@Injectable({providedIn: 'root'})
+@Injectable({ providedIn: 'root' })
 export class NumbersService {
-  readonly logDoubledNumber = signalMethod<number>(num => {
+  readonly logDoubledNumber = signalMethod<number>((num) => {
     const double = num * 2;
     console.log(double);
-  })
+  });
 }
 
-@Component({ /* ... */})
-export class NumbersComponent {
-  readonly logDoubledNumber = inject(NumbersService).logDoubledNumber;
+@Component({ /* ... */ })
+export class NumbersComponent implements OnInit {
+  readonly numbersService = inject(NumbersService);
 
   ngOnInit(): void {
-    this.logDoubledNumber(1);
-
     const value = signal(2);
-    // 👇 uses the injection context of the `NumbersService`, which is root.
-    this.logDoubledNumber(value);
+    // 👇 Uses the injection context of the `NumbersService`, which is root.
+    this.numbersService.logDoubledNumber(value);
   }
 }
 ```

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -97,18 +97,21 @@ Here, the `effect` outlives the component, which would produce a memory leak.
 When a `signalMethod` is created in an ancestor injection context, it's necessary to explicitly provide the caller injector to ensure proper cleanup:
 
 ```ts
-
-@Component({ /* ... */})
-export class NumbersComponent {
-  readonly logDoubledNumber = inject(NumbersService).logDoubledNumber;
+@Component({ /* ... */ })
+export class NumbersComponent implements OnInit {
+  readonly numbersService = inject(NumbersService);
   readonly injector = inject(Injector);
 
   ngOnInit(): void {
-    this.logDoubledNumber(1);
-
-    const value = signal(2);
-    // 👇 uses the injection context of the `NumbersService`, which is root.
-    this.logDoubledNumber(value, {injector: this.injector});
+    const value = signal(1);
+    // 👇 Providing the `NumbersComponent` injector
+    // to ensure cleanup on component destroy.
+    this.numbersService.logDoubledNumber(value, {
+      injector: this.injector,
+    });
+  
+    // 👇 No need to provide an injector for static values.
+    this.logDoubledNumber(2);
   }
 }
 ```

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -159,17 +159,18 @@ export class NumbersComponent implements OnInit {
 At first sight, `signalMethod`, might be the same as `effect`:
 
 ```ts
-
-@Component({ /* ... */})
+@Component({ /* ... */ })
 export class NumbersComponent {
-  readonly value = signal(2);
+  readonly num = signal(2);
   readonly logDoubledNumberEffect = effect(() => {
-    const double = num * 2;
-    console.log(double);
-  })
+    console.log(this.num() * 2);
+  });
+  readonly logDoubledNumber = signalMethod<number>((num) => {
+    console.log(num * 2);
+  });
 
-  constructor(): void {
-    this.logDoubledNumber(value);
+  constructor() {
+    this.logDoubledNumber(this.num);
   }
 }
 ```

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -169,7 +169,7 @@ export class NumbersComponent {
 
 ## Advantages over simple effect
 
-On first sight, `signalMethod`, might be the same as `effect`:
+At first sight, `signalMethod`, might be the same as `effect`:
 
 ```ts
 

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -1,6 +1,6 @@
 # SignalMethod
 
-`signalMethod` is a factory function that executes side effects based on signal changes. It creates one function (processing function) with one typed parameter that can be a static value or a Signal. Upon invocation, the "processing function" has to be provided.
+`signalMethod` is a standalone factory function used for managing side effects with Angular signals. It accepts a callback and returns a processor function that can handle either a static value or a signal. The input type can be specified using a generic type argument:
 
 ```ts
 import {Component} from '@angular/core';

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -92,24 +92,6 @@ export class NumbersComponent implements OnInit {
 
 Here, the `effect` outlives the component, which would produce a memory leak.
 
-As a consequence, try to call the "processor function" always in an injection context:
-
-```ts
-
-@Component({ /* ... */})
-export class NumbersComponent {
-  readonly logDoubledNumber = inject(NumbersService).logDoubledNumber;
-
-  ngOnInit(): void {
-    this.logDoubledNumber(1);
-
-    const value = signal(2);
-    // 👇 uses the injection context of the `NumbersService`, which is root.
-    this.logDoubledNumber(value);
-  }
-}
-```
-
 ## Manual Cleanup
 
 If you cannot run the "processor function" in an injection context, you can also provide an injector manually:

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -20,23 +20,23 @@ export class NumbersComponent {
 `logDoubledNumber` can be called with a static value of type `number`, or a Signal of type `number`:
 
 ```ts
-
-@Component({ /* ... */})
+@Component({ /* ... */ })
 export class NumbersComponent {
-  // 👇 This method will have an input argument
-  // of type `number | Signal<number>`.
-  readonly logDoubledNumber = signalMethod<number>(num => {
+  readonly logDoubledNumber = signalMethod<number>((num) => {
     const double = num * 2;
     console.log(double);
-  })
+  });
 
-  constructor(): void {
-    // 👇 prints 2 synchronously
+  constructor() {
     this.logDoubledNumber(1);
+    // console output: 2
 
-    const value = signal(2);
-    // 👇 prints 4 asynchronously (triggered by an internal effect())
-    this.logDoubledNumber(value);
+    const num = signal(2);
+    this.logDoubledNumber(num);
+    // console output: 4
+    
+    setTimeout(() => num.set(3), 3_000);
+    // console output after 3 seconds: 6
   }
 }
 ```

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -1,0 +1,201 @@
+# signalMethod
+
+`signalMethod` is a factory function to execute side effects based on Signal changes. It creates one function (processing function) with one typed parameter that can be a static value or a Signal. Upon invocation, the "processing function" has to be provided.
+
+`signalMethod` is `rxMethod` without RxJS. `signalMethod` can also be used outside of `signalStore` or `signalState`:
+
+```ts
+import {Component} from '@angular/core';
+import {signalMethod} from '@ngrx/signals';
+
+@Component({ /* ... */})
+export class NumbersComponent {
+  // 👇 This method will have an input argument
+  // of type `number | Signal<number>`.
+  readonly logDoubledNumber = signalMethod<number>(num => {
+    const double = num * 2;
+    console.log(double);
+  })
+}
+```
+
+`logDoubledNumber` can be called with a static value of type number or a Signal of type number:
+
+```ts
+
+@Component({ /* ... */})
+export class NumbersComponent {
+  // 👇 This method will have an input argument
+  // of type `number | Signal<number>`.
+  readonly logDoubledNumber = signalMethod<number>(num => {
+    const double = num * 2;
+    console.log(double);
+  })
+
+  constructor(): void {
+    // 👇 prints 2 synchronously
+    this.logDoubledNumber(1);
+
+    const value = signal(2);
+    // 👇 prints 4 asynchronously (triggered by an internal effect())
+    this.logDoubledNumber(value);
+  }
+}
+```
+
+## Automatic Signal Tracking
+
+`signalMethod` uses an `effect` internally to track the Signal changes.
+
+By default, the `effect` runs in the injection context of the caller. In the example above, that is `NumbersComponent`. That means, that the `effect` is automatically cleaned up when the component is destroyed.
+
+If the call happens outside of an injection context, then the injector of the `signalMethod` is used. This would be the case, if `logDoubledNumber` runs in `ngOnInit`:
+
+```ts
+
+@Component({ /* ... */})
+export class NumbersComponent {
+  readonly logDoubledNumber = signalMethod<number>(num => {
+    const double = num * 2;
+    console.log(double);
+  })
+
+  ngOnInit(): void {
+    this.logDoubledNumber(1);
+
+    const value = signal(2);
+    // 👇 uses the injection context of the `signalMethod`
+    this.logDoubledNumber(value);
+  }
+}
+```
+
+For the `NumbersComponent`, it doesn't make a difference. Again, the `effect` is automatically cleaned up when the component is destroyed.
+
+Careful, when `signalMethod` is used in a service which is provided in `root`:
+
+```ts
+
+@Injectable({providedIn: 'root'})
+export class NumbersService {
+  readonly logDoubledNumber = signalMethod<number>(num => {
+    const double = num * 2;
+    console.log(double);
+  })
+}
+
+@Component({ /* ... */})
+export class NumbersComponent {
+  readonly logDoubledNumber = inject(NumbersService).logDoubledNumber;
+
+  ngOnInit(): void {
+    this.logDoubledNumber(1);
+
+    const value = signal(2);
+    // 👇 uses the injection context of the `NumbersService`, which is root.
+    this.logDoubledNumber(value);
+  }
+}
+```
+
+Here, the `effect` outlives the component, which would produce a memory leak.
+
+As a consequence, try to call the "processor function" always in an injection context:
+
+```ts
+
+@Component({ /* ... */})
+export class NumbersComponent {
+  readonly logDoubledNumber = inject(NumbersService).logDoubledNumber;
+
+  ngOnInit(): void {
+    this.logDoubledNumber(1);
+
+    const value = signal(2);
+    // 👇 uses the injection context of the `NumbersService`, which is root.
+    this.logDoubledNumber(value);
+  }
+}
+```
+
+## Providing an Injector
+
+If you cannot run the "processor function" in an injection context, you can also provide an injector manually:
+
+```ts
+
+@Component({ /* ... */})
+export class NumbersComponent {
+  readonly logDoubledNumber = inject(NumbersService).logDoubledNumber;
+  readonly injector = inject(Injector);
+
+  ngOnInit(): void {
+    this.logDoubledNumber(1);
+
+    const value = signal(2);
+    // 👇 uses the injection context of the `NumbersService`, which is root.
+    this.logDoubledNumber(value, {injector: this.injector});
+  }
+}
+```
+
+Whereas the "processor function" doesn't require an active injection context, the call of `signalMethod` does:
+
+```ts
+
+@Component({ /* ... */})
+export class NumbersComponent {
+// 👇 Would cause a runtime error
+  ngOnInit() {
+    const logDoubledNumber = signalMethod<number>(num => console.log(num * 2));
+  }
+}
+```
+
+In these cases, you also have to provide the injector manually:
+
+```ts
+
+@Component({ /* ... */})
+export class NumbersComponent {
+  readonly injector = inject(Injector);
+
+  ngOnInit() {
+    // 👇 Works now
+    const logDoubledNumber = signalMethod<number>(num => console.log(num * 2), {injector: this.injector});
+  }
+}
+```
+
+## Advantages over simple effect
+
+On first sight, `signalMethod`, might be the same as `effect`:
+
+```ts
+
+@Component({ /* ... */})
+export class NumbersComponent {
+  readonly value = signal(2);
+  readonly logDoubledNumberEffect = effect(() => {
+    const double = num * 2;
+    console.log(double);
+  })
+
+  constructor(): void {
+    this.logDoubledNumber(value);
+  }
+}
+```
+
+However, `signalMethod` offers three distinctive advantages over `effect`:
+
+- **Flexible Parameter**: The parameter can also be a simple number, not just a Signal.
+- **No Injection Context Required**: Unlike an `effect`, which requires an injection context or an Injector, `signalMethod`'s "processor function" can be called without an injection context.
+- **Explicit Tracking**: Only the Signal of the parameter is tracked, while Signals within the "processor function" stay untracked.
+
+
+<div class="alert is-helpful">
+
+Be aware that RxJS is superior to Signals in managing race conditions. Signals have a glitch-free effect, meaning that for multiple synchronous changes, only the last change is propagated. Additionally, they lack powerful operators like `switchMap` or `concatMap`.
+
+</div>

--- a/projects/ngrx.io/content/guide/signals/signal-method.md
+++ b/projects/ngrx.io/content/guide/signals/signal-method.md
@@ -47,7 +47,7 @@ export class NumbersComponent {
 
 By default, the `effect` runs in the injection context of the caller. In the example above, that is `NumbersComponent`. That means, that the `effect` is automatically cleaned up when the component is destroyed.
 
-If the call happens outside of an injection context, then the injector of the `signalMethod` is used. This would be the case, if `logDoubledNumber` runs in `ngOnInit`:
+If the call happens outside an injection context, then the injector of the `signalMethod` is used. This would be the case, if `logDoubledNumber` runs in `ngOnInit`:
 
 ```ts
 @Component({ /* ... */ })
@@ -132,6 +132,7 @@ export class NumbersComponent implements OnInit {
     );
   }
 }
+```
 
 ## Advantages over Effect
 

--- a/projects/ngrx.io/content/navigation.json
+++ b/projects/ngrx.io/content/navigation.json
@@ -328,6 +328,10 @@
               "url": "guide/signals/deep-computed"
             },
             {
+              "title":  "SignalMethod",
+              "url": "guide/signals/signal-method"
+            },
+            {
               "title": "RxJS Integration",
               "url": "guide/signals/rxjs-integration"
             },


### PR DESCRIPTION
`signalMethod` is a factory function to process side effects on Signals or static values.

It is similar to `rxMethod` but does not support RxJS.

`signalMethod` follows Angular's pattern of RxJS-less utilities for Signals, like `resource` and `rxResource`.

`signalMethod` expects a type and processor function:

```typescript
const doubleLogger = signalMethod<number>(value => console.log(value * 2))

const value = signal(1);
doubleLogger(value); // tracks value and executes initially and on every change
```

It also supports static values, e.g., `doubleLogger(1)`.

This PR also contains the documentation and tests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

Closes #4581

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

