### PR TITLE
feat(store): enable dispatching actions on signal changes

### DIFF
--- a/modules/store/src/helpers.ts
+++ b/modules/store/src/helpers.ts
@@ -5,3 +5,12 @@ export function capitalize<T extends string>(text: T): Capitalize<T> {
 export function uncapitalize<T extends string>(text: T): Uncapitalize<T> {
   return (text.charAt(0).toLowerCase() + text.substring(1)) as Uncapitalize<T>;
 }
+
+export function assertDefined<T>(
+  value: T | null | undefined,
+  name: string
+): asserts value is T {
+  if (value === null || value === undefined) {
+    throw new Error(`${name} must be defined.`);
+  }
+}

--- a/modules/store/src/models.ts
+++ b/modules/store/src/models.ts
@@ -80,10 +80,10 @@ export const primitivesAreNotAllowedInProps =
   'action creator props cannot be a primitive value';
 type PrimitivesAreNotAllowedInProps = typeof primitivesAreNotAllowedInProps;
 
-export type FunctionIsNotAllowed<
-  T,
-  ErrorMessage extends string
-> = T extends Function ? ErrorMessage : T;
+export type CreatorsNotAllowedCheck<T> = T extends ActionCreator
+  ? 'Action creator is not allowed to be dispatched. Did you forget to call it?'
+  : unknown;
+
 /**
  * A function that returns an object in the shape of the `Action` interface.  Configured using `createAction`.
  */

--- a/projects/ngrx.io/content/guide/store/actions.md
+++ b/projects/ngrx.io/content/guide/store/actions.md
@@ -111,7 +111,7 @@ class BookComponent {
 
   ngOnInit() {
     // runs outside the injection context
-    store.dispatch(() => loadBook({ id: this.bookId() }), { injector: this.injector });
+    this.store.dispatch(() => loadBook({ id: this.bookId() }), { injector: this.injector });
   }
 }
 </code-example>

--- a/projects/ngrx.io/content/guide/store/actions.md
+++ b/projects/ngrx.io/content/guide/store/actions.md
@@ -126,7 +126,7 @@ class BookComponent {
 
   ngOnInit() {
     // uses the injection context of Store, i.e. root injector
-    this.loadBookEffectRef = store.dispatch(() => loadBook({ id: this.bookId() }));
+    this.loadBookEffectRef = this.store.dispatch(() => loadBook({ id: this.bookId() }));
   }
 
   ngOnDestroy() {

--- a/projects/ngrx.io/content/guide/store/actions.md
+++ b/projects/ngrx.io/content/guide/store/actions.md
@@ -85,6 +85,59 @@ The returned action has very specific context about where the action came from a
 
 </div>
 
+## Dispatching actions on signal changes
+
+You can also dispatch functions that return actions, with property values derived from signals:
+
+<code-example header="book.component.ts">
+class BookComponent {
+  bookId = input.required&lt;number&gt;();
+
+  constructor(store: Store) {
+    store.dispatch(() => loadBook({ id: this.bookId() })));
+  }
+}
+</code-example>
+
+`dispatch` executes initially and every time the `bookId` changes. If `dispatch` is called within an injection context, the signal is tracked until the context is destroyed. In the example above, that would be when `BookComponent` is destroyed.
+
+When `dispatch` is called outside a component's injection context, the signal is tracked globally throughout the application's lifecycle. To ensure proper cleanup in such a case, provide the component's injector to the `dispatch` method:
+
+<code-example header="book.component.ts">
+class BookComponent {  
+  bookId = input.required&lt;number&gt;();
+  injector = inject(Injector);
+  store = inject(Store);
+
+  ngOnInit() {
+    // runs outside the injection context
+    store.dispatch(() => loadBook({ id: this.bookId() }), { injector: this.injector });
+  }
+}
+</code-example>
+
+When passing a function to the `dispatch` method, it returns an `EffectRef`. For manual cleanup, call the `destroy` method on the `EffectRef`:
+
+<code-example header="book.component.ts">
+class BookComponent {
+  bookId = input.required&lt;number&gt;();
+  loadBookEffectRef: EffectRef | undefined;
+  store = inject(Store);
+
+  ngOnInit() {
+    // uses the injection context of Store, i.e. root injector
+    this.loadBookEffectRef = store.dispatch(() => loadBook({ id: this.bookId() }));
+  }
+
+  ngOnDestroy() {
+    if (this.loadBookEffectRef) {
+      // destroys the effect
+      this.loadBookEffectRef.destroy();
+    }
+  }
+}
+</code-example>
+
 ## Next Steps
 
 Action's only responsibilities are to express unique events and intents. Learn how they are handled in the guides below.


### PR DESCRIPTION
A type of Signal<Action> can be passed to dispatch:

```typescript
class BookComponent {
  bookId = input.required<number>();
  bookAction = computed(() => loadBook({id: this.bookId()}));

  store = inject(Store);

  constructor() {
    this.store.dispatch(this.bookAction);
  }
}
```
The benefit is that users no longer need to use an effect to track the Signal. The Store handles this internally.

If `dispatch` receives a `Signal` it returns an `EffectRef`, allowing manual destruction.

By default, the injection context of the caller is used. If the call happens outside an injection context, the Store will use its own injection context, which is usually the root injector.

It is also possible to provide a custom injector as the second parameter:
```typescript
this.store.dispatch(this.bookAction, {injector: this.injector});
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Users need to manually track Signals via `effect`

Closes #4537

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

