### PR TITLE
fix: exclude class instance from `DeepSignal`

### DIFF
--- a/modules/signals/spec/types/signal-state.types.spec.ts
+++ b/modules/signals/spec/types/signal-state.types.spec.ts
@@ -160,6 +160,22 @@ describe('signalState', () => {
     );
   });
 
+  it('does not create deep signals for a class instance', () => {
+    const snippet = `
+      class User {
+        id = 0;
+        name = 'Konrad';
+      }
+
+      const state = signalState({ user: new User() });
+      const user = state.user;
+    `;
+
+    expectSnippet(snippet).toSucceed();
+
+    expectSnippet(snippet).toInfer('user', 'Signal<User>');
+  });
+
   it('does not create deep signals for optional state slices', () => {
     const snippet = `
       type State = {

--- a/modules/signals/src/ts-helpers.ts
+++ b/modules/signals/src/ts-helpers.ts
@@ -1,3 +1,6 @@
+import { Signal } from '@angular/core';
+import { signalState } from './signal-state';
+
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
 export type IsRecord<T> = T extends object
@@ -9,7 +12,11 @@ export type IsRecord<T> = T extends object
     ? false
     : T extends Function
     ? false
-    : true
+    : T extends { prototype: unknown } // check for constructor did not work
+    ? false
+    : T extends { [key: string]: unknown }
+    ? true
+    : false
   : false;
 
 export type IsUnknownRecord<T> = string extends keyof T
@@ -27,3 +34,27 @@ export type IsKnownRecord<T> = IsRecord<T> extends true
 export type OmitPrivate<T> = {
   [K in keyof T as K extends `_${string}` ? never : K]: T[K];
 };
+
+class User {
+  id = 0;
+  name = 'Konrad';
+}
+
+const state = {
+  user: new User(),
+  id: 1,
+  address: { city: 'Wien', zip: '1040' },
+};
+
+type AssertFalse<T extends false> = T;
+type AssertTrue<T extends true> = T;
+
+type T1 = AssertFalse<IsRecord<User>>;
+type T2 = AssertFalse<IsRecord<typeof state.id>>;
+type T3 = AssertTrue<IsRecord<typeof state.address>>;
+
+const store = signalState(state);
+const address: Signal<{ city: string; zip: string }> = store.address;
+const user: Signal<User> = store.user;
+const zip: Signal<string> = store.address.zip;
+const id: Signal<number> = store.id;


### PR DESCRIPTION
This is a draft. Whoever has an idea, for the fix, please let me know. It tries to solve the following problem.

```typescript
class User {
  id = 0;
  name = 'Konrad';
}

const state = signalState({ user: new User() });
const user = state.user; // should not be DeepSignal<User>
```

`IsRecord` tries to differentiate a class instance from object literal by checking
if a prototype is there or not.

Fore more details, checkout the commit.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Closes #4604

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
