### PR TITLE
feat(signals): add `withProps` base feature

### DIFF
--- a/modules/signals/entities/src/index.ts
+++ b/modules/signals/entities/src/index.ts
@@ -12,11 +12,11 @@ export { updateAllEntities } from './updaters/update-all-entities';
 
 export { entityConfig } from './entity-config';
 export {
-  EntityComputed,
   EntityId,
   EntityMap,
+  EntityProps,
   EntityState,
-  NamedEntityComputed,
+  NamedEntityProps,
   NamedEntityState,
   SelectEntityId,
 } from './models';

--- a/modules/signals/entities/src/models.ts
+++ b/modules/signals/entities/src/models.ts
@@ -13,12 +13,12 @@ export type NamedEntityState<Entity, Collection extends string> = {
   [K in keyof EntityState<Entity> as `${Collection}${Capitalize<K>}`]: EntityState<Entity>[K];
 };
 
-export type EntityComputed<Entity> = {
+export type EntityProps<Entity> = {
   entities: Signal<Entity[]>;
 };
 
-export type NamedEntityComputed<Entity, Collection extends string> = {
-  [K in keyof EntityComputed<Entity> as `${Collection}${Capitalize<K>}`]: EntityComputed<Entity>[K];
+export type NamedEntityProps<Entity, Collection extends string> = {
+  [K in keyof EntityProps<Entity> as `${Collection}${Capitalize<K>}`]: EntityProps<Entity>[K];
 };
 
 export type SelectEntityId<Entity> = (entity: Entity) => EntityId;

--- a/modules/signals/entities/src/with-entities.ts
+++ b/modules/signals/entities/src/with-entities.ts
@@ -7,11 +7,11 @@ import {
   withState,
 } from '@ngrx/signals';
 import {
-  EntityComputed,
+  EntityProps,
   EntityId,
   EntityMap,
   EntityState,
-  NamedEntityComputed,
+  NamedEntityProps,
   NamedEntityState,
 } from './models';
 import { getEntityStateKeys } from './helpers';
@@ -20,7 +20,7 @@ export function withEntities<Entity>(): SignalStoreFeature<
   EmptyFeatureResult,
   {
     state: EntityState<Entity>;
-    computed: EntityComputed<Entity>;
+    props: EntityProps<Entity>;
     methods: {};
   }
 >;
@@ -31,7 +31,7 @@ export function withEntities<Entity, Collection extends string>(config: {
   EmptyFeatureResult,
   {
     state: NamedEntityState<Entity, Collection>;
-    computed: NamedEntityComputed<Entity, Collection>;
+    props: NamedEntityProps<Entity, Collection>;
     methods: {};
   }
 >;
@@ -41,7 +41,7 @@ export function withEntities<Entity>(config: {
   EmptyFeatureResult,
   {
     state: EntityState<Entity>;
-    computed: EntityComputed<Entity>;
+    props: EntityProps<Entity>;
     methods: {};
   }
 >;

--- a/modules/signals/spec/signal-store-feature.spec.ts
+++ b/modules/signals/spec/signal-store-feature.spec.ts
@@ -33,7 +33,7 @@ describe('signalStoreFeature', () => {
     return signalStoreFeature(
       {
         state: type<{ foo: string }>(),
-        computed: type<{ s: Signal<number> }>(),
+        props: type<{ s: Signal<number> }>(),
       },
       withState({ foo1: 1 }),
       withState({ foo2: 2 })

--- a/modules/signals/spec/types/signal-store.types.spec.ts
+++ b/modules/signals/spec/types/signal-store.types.spec.ts
@@ -846,7 +846,7 @@ describe('signalStore', () => {
         return signalStoreFeature(
           {
             state: type<{ q1: string }>(),
-            computed: type<{ sig: Signal<boolean> }>(),
+            props: type<{ sig: Signal<boolean> }>(),
           },
           withState({ y: initialY }),
           withComputed(() => ({ sigY: computed(() => 'sigY') })),
@@ -932,7 +932,7 @@ describe('signalStore', () => {
         ${baseSnippet}
 
         const feature = signalStoreFeature(
-          { computed: type<{ sig: Signal<boolean> }>() },
+          { props: type<{ sig: Signal<boolean> }>() },
           withX(),
           withState({ q1: 'q1' }),
           withY(),
@@ -976,7 +976,7 @@ describe('signalStore', () => {
         ${baseSnippet}
 
         const feature = signalStoreFeature(
-          { computed: type<{ sig: Signal<string> }>() },
+          { props: type<{ sig: Signal<string> }>() },
           withX(),
           withState({ q1: 'q1' }),
           withY(),
@@ -1007,7 +1007,7 @@ describe('signalStore', () => {
 
         const feature = signalStoreFeature(
           {
-            computed: type<{ sig: Signal<boolean> }>(),
+            props: type<{ sig: Signal<boolean> }>(),
             methods: type<{ f(): void; g(arg: string): string; }>(),
           },
           withX(),
@@ -1046,7 +1046,7 @@ describe('signalStore', () => {
               entities: Entity[];
               selectedEntity: Entity | null;
             };
-            computed: {
+            props: {
               selectedEntity2: Signal<Entity | undefined>;
             };
             methods: {

--- a/modules/signals/spec/with-computed.spec.ts
+++ b/modules/signals/spec/with-computed.spec.ts
@@ -11,11 +11,11 @@ describe('withComputed', () => {
 
     const store = withComputed(() => ({ s1, s2 }))(initialStore);
 
-    expect(Object.keys(store.computedSignals)).toEqual(['s1', 's2']);
-    expect(Object.keys(initialStore.computedSignals)).toEqual([]);
+    expect(Object.keys(store.props)).toEqual(['s1', 's2']);
+    expect(Object.keys(initialStore.props)).toEqual([]);
 
-    expect(store.computedSignals.s1).toBe(s1);
-    expect(store.computedSignals.s2).toBe(s2);
+    expect(store.props.s1).toBe(s1);
+    expect(store.props.s2).toBe(s2);
   });
 
   it('logs warning if previously defined signal store members have the same name', () => {

--- a/modules/signals/spec/with-props.spec.ts
+++ b/modules/signals/spec/with-props.spec.ts
@@ -1,0 +1,54 @@
+import { signal } from '@angular/core';
+import { of } from 'rxjs';
+import { withMethods, withProps, withState } from '../src';
+import { getInitialInnerStore } from '../src/signal-store';
+
+describe('withProps', () => {
+  it('adds properties to the store immutably', () => {
+    const initialStore = getInitialInnerStore();
+
+    const p1 = 1;
+    const p2 = 2;
+
+    const store = withProps(() => ({ p1, p2 }))(initialStore);
+
+    expect(Object.keys(store.props)).toEqual(['p1', 'p2']);
+    expect(Object.keys(initialStore.props)).toEqual([]);
+
+    expect(store.props.p1).toBe(1);
+    expect(store.props.p2).toBe(2);
+  });
+
+  it('logs warning if previously defined signal store members have the same name', () => {
+    const initialStore = [
+      withState({
+        s1: 10,
+        s2: 's2',
+      }),
+      withProps(({ s1 }) => ({
+        p1: of(100),
+        p2: 10,
+      })),
+      withMethods(() => ({
+        m1() {},
+        m2() {},
+      })),
+    ].reduce((acc, feature) => feature(acc), getInitialInnerStore());
+    const p2 = 100;
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    withProps(() => ({
+      s1: { foo: 'bar' },
+      p: 10,
+      p2: signal(100),
+      m1: { ngrx: 'rocks' },
+      m3: of('m3'),
+    }))(initialStore);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '@ngrx/signals: SignalStore members cannot be overridden.',
+      'Trying to override:',
+      's1, p2, m1'
+    );
+  });
+});

--- a/modules/signals/spec/with-props.spec.ts
+++ b/modules/signals/spec/with-props.spec.ts
@@ -7,10 +7,7 @@ describe('withProps', () => {
   it('adds properties to the store immutably', () => {
     const initialStore = getInitialInnerStore();
 
-    const p1 = 1;
-    const p2 = 2;
-
-    const store = withProps(() => ({ p1, p2 }))(initialStore);
+    const store = withProps(() => ({ p1: 1, p2: 2 }))(initialStore);
 
     expect(Object.keys(store.props)).toEqual(['p1', 'p2']);
     expect(Object.keys(initialStore.props)).toEqual([]);
@@ -25,7 +22,7 @@ describe('withProps', () => {
         s1: 10,
         s2: 's2',
       }),
-      withProps(({ s1 }) => ({
+      withProps(() => ({
         p1: of(100),
         p2: 10,
       })),
@@ -34,7 +31,6 @@ describe('withProps', () => {
         m2() {},
       })),
     ].reduce((acc, feature) => feature(acc), getInitialInnerStore());
-    const p2 = 100;
     jest.spyOn(console, 'warn').mockImplementation();
 
     withProps(() => ({

--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -23,4 +23,5 @@ export { Prettify } from './ts-helpers';
 export { withComputed } from './with-computed';
 export { withHooks } from './with-hooks';
 export { withMethods } from './with-methods';
+export { withProps } from './with-props';
 export { withState } from './with-state';

--- a/modules/signals/src/signal-store-assertions.ts
+++ b/modules/signals/src/signal-store-assertions.ts
@@ -12,7 +12,7 @@ export function assertUniqueStoreMembers(
 
   const storeMembers = {
     ...store.stateSignals,
-    ...store.computedSignals,
+    ...store.props,
     ...store.methods,
   };
   const overriddenKeys = Object.keys(storeMembers).filter((memberKey) =>

--- a/modules/signals/src/signal-store-feature.ts
+++ b/modules/signals/src/signal-store-feature.ts
@@ -7,7 +7,7 @@ import { Prettify } from './ts-helpers';
 
 type PrettifyFeatureResult<Result extends SignalStoreFeatureResult> = Prettify<{
   state: Prettify<Result['state']>;
-  computed: Prettify<Result['computed']>;
+  props: Prettify<Result['props']>;
   methods: Prettify<Result['methods']>;
 }>;
 

--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -22,26 +22,26 @@ export type SignalStoreHooks = {
 
 export type InnerSignalStore<
   State extends object = object,
-  ComputedSignals extends SignalsDictionary = SignalsDictionary,
+  Props extends object = object,
   Methods extends MethodsDictionary = MethodsDictionary
 > = {
   stateSignals: StateSignals<State>;
-  computedSignals: ComputedSignals;
+  props: Props;
   methods: Methods;
   hooks: SignalStoreHooks;
 } & WritableStateSource<State>;
 
 export type SignalStoreFeatureResult = {
   state: object;
-  computed: SignalsDictionary;
+  props: object;
   methods: MethodsDictionary;
 };
 
-export type EmptyFeatureResult = { state: {}; computed: {}; methods: {} };
+export type EmptyFeatureResult = { state: {}; props: {}; methods: {} };
 
 export type SignalStoreFeature<
   Input extends SignalStoreFeatureResult = SignalStoreFeatureResult,
   Output extends SignalStoreFeatureResult = SignalStoreFeatureResult
 > = (
-  store: InnerSignalStore<Input['state'], Input['computed'], Input['methods']>
-) => InnerSignalStore<Output['state'], Output['computed'], Output['methods']>;
+  store: InnerSignalStore<Input['state'], Input['props'], Input['methods']>
+) => InnerSignalStore<Output['state'], Output['props'], Output['methods']>;

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -15,7 +15,7 @@ type SignalStoreMembers<FeatureResult extends SignalStoreFeatureResult> =
   Prettify<
     OmitPrivate<
       StateSignals<FeatureResult['state']> &
-        FeatureResult['computed'] &
+        FeatureResult['props'] &
         FeatureResult['methods']
     >
   >;
@@ -1354,8 +1354,8 @@ export function signalStore(
         (store, feature) => feature(store),
         getInitialInnerStore()
       );
-      const { stateSignals, computedSignals, methods, hooks } = innerStore;
-      const storeMembers = { ...stateSignals, ...computedSignals, ...methods };
+      const { stateSignals, props, methods, hooks } = innerStore;
+      const storeMembers = { ...stateSignals, ...props, ...methods };
 
       (this as any)[STATE_SOURCE] = innerStore[STATE_SOURCE];
 
@@ -1382,7 +1382,7 @@ export function getInitialInnerStore(): InnerSignalStore {
   return {
     [STATE_SOURCE]: signal({}),
     stateSignals: {},
-    computedSignals: {},
+    props: {},
     methods: {},
     hooks: {},
   };

--- a/modules/signals/src/with-computed.ts
+++ b/modules/signals/src/with-computed.ts
@@ -1,34 +1,22 @@
-import { assertUniqueStoreMembers } from './signal-store-assertions';
 import {
-  InnerSignalStore,
   SignalsDictionary,
   SignalStoreFeature,
   SignalStoreFeatureResult,
   StateSignals,
 } from './signal-store-models';
 import { Prettify } from './ts-helpers';
+import { withProps } from './with-props';
 
 export function withComputed<
   Input extends SignalStoreFeatureResult,
   ComputedSignals extends SignalsDictionary
 >(
   signalsFactory: (
-    store: Prettify<StateSignals<Input['state']> & Input['computed']>
+    store: Prettify<StateSignals<Input['state']> & Input['props']>
   ) => ComputedSignals
 ): SignalStoreFeature<
   Input,
-  { state: {}; computed: ComputedSignals; methods: {} }
+  { state: {}; props: ComputedSignals; methods: {} }
 > {
-  return (store) => {
-    const computedSignals = signalsFactory({
-      ...store.stateSignals,
-      ...store.computedSignals,
-    });
-    assertUniqueStoreMembers(store, Object.keys(computedSignals));
-
-    return {
-      ...store,
-      computedSignals: { ...store.computedSignals, ...computedSignals },
-    } as InnerSignalStore<Record<string, unknown>, ComputedSignals>;
-  };
+  return withProps(signalsFactory);
 }

--- a/modules/signals/src/with-hooks.ts
+++ b/modules/signals/src/with-hooks.ts
@@ -10,7 +10,7 @@ import { Prettify } from './ts-helpers';
 type HookFn<Input extends SignalStoreFeatureResult> = (
   store: Prettify<
     StateSignals<Input['state']> &
-      Input['computed'] &
+      Input['props'] &
       Input['methods'] &
       WritableStateSource<Prettify<Input['state']>>
   >
@@ -19,7 +19,7 @@ type HookFn<Input extends SignalStoreFeatureResult> = (
 type HooksFactory<Input extends SignalStoreFeatureResult> = (
   store: Prettify<
     StateSignals<Input['state']> &
-      Input['computed'] &
+      Input['props'] &
       Input['methods'] &
       WritableStateSource<Prettify<Input['state']>>
   >
@@ -48,7 +48,7 @@ export function withHooks<Input extends SignalStoreFeatureResult>(
     const storeMembers = {
       [STATE_SOURCE]: store[STATE_SOURCE],
       ...store.stateSignals,
-      ...store.computedSignals,
+      ...store.props,
       ...store.methods,
     };
     const hooks =

--- a/modules/signals/src/with-props.ts
+++ b/modules/signals/src/with-props.ts
@@ -2,39 +2,37 @@ import { STATE_SOURCE, WritableStateSource } from './state-source';
 import { assertUniqueStoreMembers } from './signal-store-assertions';
 import {
   InnerSignalStore,
-  MethodsDictionary,
-  SignalsDictionary,
   SignalStoreFeature,
   SignalStoreFeatureResult,
   StateSignals,
 } from './signal-store-models';
 import { Prettify } from './ts-helpers';
 
-export function withMethods<
+export function withProps<
   Input extends SignalStoreFeatureResult,
-  Methods extends MethodsDictionary
+  Props extends object
 >(
-  methodsFactory: (
+  propsFactory: (
     store: Prettify<
       StateSignals<Input['state']> &
         Input['props'] &
         Input['methods'] &
         WritableStateSource<Prettify<Input['state']>>
     >
-  ) => Methods
-): SignalStoreFeature<Input, { state: {}; props: {}; methods: Methods }> {
+  ) => Props
+): SignalStoreFeature<Input, { state: {}; props: Props; methods: {} }> {
   return (store) => {
-    const methods = methodsFactory({
+    const props = propsFactory({
       [STATE_SOURCE]: store[STATE_SOURCE],
       ...store.stateSignals,
       ...store.props,
       ...store.methods,
     });
-    assertUniqueStoreMembers(store, Object.keys(methods));
+    assertUniqueStoreMembers(store, Object.keys(props));
 
     return {
       ...store,
-      methods: { ...store.methods, ...methods },
-    } as InnerSignalStore<Record<string, unknown>, SignalsDictionary, Methods>;
+      props: { ...store.props, ...props },
+    } as InnerSignalStore<object, Props>;
   };
 }

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -15,19 +15,19 @@ export function withState<State extends object>(
   stateFactory: () => State
 ): SignalStoreFeature<
   EmptyFeatureResult,
-  { state: State; computed: {}; methods: {} }
+  { state: State; props: {}; methods: {} }
 >;
 export function withState<State extends object>(
   state: State
 ): SignalStoreFeature<
   EmptyFeatureResult,
-  { state: State; computed: {}; methods: {} }
+  { state: State; props: {}; methods: {} }
 >;
 export function withState<State extends object>(
   stateOrFactory: State | (() => State)
 ): SignalStoreFeature<
   SignalStoreFeatureResult,
-  { state: State; computed: {}; methods: {} }
+  { state: State; props: {}; methods: {} }
 > {
   return (store) => {
     const state =

--- a/projects/ngrx.io/content/guide/signals/signal-store/custom-store-features.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/custom-store-features.md
@@ -153,7 +153,7 @@ State changes will be logged to the console whenever the `BooksStore` state is u
 
 ## Creating a Custom Feature with Input
 
-The `signalStoreFeature` function provides the ability to create a custom feature that requires specific state slices, computed signals, and/or methods to be defined in the store where it is used.
+The `signalStoreFeature` function provides the ability to create a custom feature that requires specific state slices, properties, and/or methods to be defined in the store where it is used.
 This enables the utilization of input properties within the custom feature, even if they are not explicitly defined within the feature itself.
 
 The expected input type should be defined as the first argument of the `signalStoreFeature` function, using the `type` helper function from the `@ngrx/signals` package.
@@ -238,9 +238,9 @@ export const BooksStore = signalStore(
 
 </code-example>
 
-### Example 4: Defining Computed Props and Methods as Input
+### Example 4: Defining Properties and Methods as Input
 
-In addition to state, it's also possible to define expected computed signals and methods in the following way:
+In addition to state, it's also possible to define expected properties and methods in the following way:
 
 <code-example header="baz.feature.ts">
 
@@ -250,7 +250,7 @@ import { signalStoreFeature, type, withMethods } from '@ngrx/signals';
 export function withBaz&lt;Foo extends string | number&gt;() {
   return signalStoreFeature(
     {
-      computed: type&lt;{ foo: Signal&lt;Foo&gt; }&gt;(),
+      props: type&lt;{ foo: Signal&lt;Foo&gt; }&gt;(),
       methods: type&lt;{ bar(foo: number): void }&gt;(),
     },
     withMethods((store) => ({
@@ -264,7 +264,7 @@ export function withBaz&lt;Foo extends string | number&gt;() {
 
 </code-example>
 
-The `withBaz` feature can only be used in a store where the computed signal `foo` and the method `bar` are defined. 
+The `withBaz` feature can only be used in a store where the property `foo` and the method `bar` are defined. 
 
 ## Known TypeScript Issues
 

--- a/projects/ngrx.io/content/guide/signals/signal-store/custom-store-properties.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/custom-store-properties.md
@@ -65,7 +65,7 @@ export const BooksStore = signalStore(
   withHooks({
     onInit({ logger }) {
       logger.debug('BooksStore initialized');
-    }
+    },
   }),
 );
 

--- a/projects/ngrx.io/content/guide/signals/signal-store/custom-store-properties.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/custom-store-properties.md
@@ -1,0 +1,72 @@
+# Custom Store Properties
+
+The `withProps` feature can be used to add static properties, observables, dependencies, or other custom properties to a SignalStore.
+It accepts a factory function that returns an object containing additional properties for the store.
+The factory function receives an object containing state signals, previously defined properties, and methods as its input argument.
+
+## Exposing Observables
+
+`withProps` can be useful for exposing observables from a SignalStore, which can serve as integration points with RxJS-based APIs:
+
+<code-example header="books.store.ts">
+
+import { toObservable } from '@angular/core/rxjs-interop';
+import { signalStore, withProps, withState } from '@ngrx/signals';
+import { Book } from './book.model';
+
+type BooksState = {
+  books: Book[];
+  isLoading: boolean;
+};
+
+export const BooksStore = signalStore(
+  withState&lt;BooksState&gt;({ books: [], isLoading: false }),
+  withProps(({ isLoading }) => ({
+    isLoading$: toObservable(isLoading),
+  })),
+);
+
+</code-example>
+
+## Grouping Dependencies
+
+Dependencies required across multiple store features can be grouped using `withProps`:
+
+<code-example header="books.store.ts">
+
+import { inject } from '@angular/core';
+import { signalStore, withProps, withState } from '@ngrx/signals';
+import { Logger } from './logger';
+import { Book } from './book.model';
+import { BooksService } from './books.service';
+
+type BooksState = {
+  books: Book[];
+  isLoading: boolean;
+};
+
+export const BooksStore = signalStore(
+  withState&lt;BooksState&gt;({ books: [], isLoading: false }),
+  withProps(() => ({
+    booksService: inject(BooksService),
+    logger: inject(Logger),
+  })),
+  withMethods(({ booksService, logger, ...store }) => ({
+    async loadBooks(): Promise&lt;void&gt; {
+      logger.debug('Loading books...');
+      patchState(store, { isLoading: true });
+      
+      const books = await booksService.getAll();
+      logger.debug('Books loaded successfully', books);
+      
+      patchState(store, { books, isLoading: false });
+    },
+  })),
+  withHooks({
+    onInit({ logger }) {
+      logger.debug('BooksStore initialized');
+    }
+  }),
+);
+
+</code-example>

--- a/projects/ngrx.io/content/guide/signals/signal-store/index.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/index.md
@@ -7,7 +7,7 @@ The simplicity and flexibility of SignalStore, coupled with its opinionated and 
 ## Creating a Store
 
 A SignalStore is created using the `signalStore` function. This function accepts a sequence of store features.
-Through the combination of store features, the SignalStore gains state, computed signals, and methods, allowing for a flexible and extensible store implementation.
+Through the combination of store features, the SignalStore gains state, properties, and methods, allowing for a flexible and extensible store implementation.
 Based on the utilized features, the `signalStore` function returns an injectable service that can be provided and injected where needed.
 
 The `withState` feature is used to add state slices to the SignalStore.
@@ -141,11 +141,11 @@ export class BooksComponent {
 
 </code-example>
 
-## Defining Computed Signals
+## Defining Store Properties
 
 Computed signals can be added to the store using the `withComputed` feature.
 This feature accepts a factory function as an input argument, which is executed within the injection context.
-The factory should return a dictionary of computed signals, utilizing previously defined state and computed signals that are accessible through its input argument.
+The factory should return a dictionary of computed signals, utilizing previously defined state signals and properties that are accessible through its input argument.
 
 <code-example header="books.store.ts">
 
@@ -159,7 +159,7 @@ const initialState: BooksState = { /* ... */ };
 
 export const BooksStore = signalStore(
   withState(initialState),
-  // 👇 Accessing previously defined state and computed signals.
+  // 👇 Accessing previously defined state signals and properties.
   withComputed(({ books, filter }) => ({
     booksCount: computed(() => books().length),
     sortedBooks: computed(() => {
@@ -174,12 +174,19 @@ export const BooksStore = signalStore(
 
 </code-example>
 
+<div class="alert is-helpful">
+
+The `withProps` feature can be used to add static properties, observables, dependencies, and any other custom properties to a SignalStore.
+For more details, see the [Custom Store Properties](/guide/signals/signal-store/custom-store-properties) guide.
+
+</div>
+
 ## Defining Store Methods
 
 Methods can be added to the store using the `withMethods` feature.
 This feature takes a factory function as an input argument and returns a dictionary of methods.
 Similar to `withComputed`, the `withMethods` factory is also executed within the injection context.
-The store instance, including previously defined state, computed signals, and methods, is accessible through the factory input.
+The store instance, including previously defined state signals, properties, and methods, is accessible through the factory input.
 
 <code-example header="books.store.ts">
 
@@ -200,8 +207,8 @@ const initialState: BooksState = { /* ... */ };
 export const BooksStore = signalStore(
   withState(initialState),
   withComputed(/* ... */),
-  // 👇 Accessing a store instance with previously defined state,
-  // computed signals, and methods.
+  // 👇 Accessing a store instance with previously defined state signals,
+  // properties, and methods.
   withMethods((store) => ({
     updateQuery(query: string): void {
       // 👇 Updating state using the `patchState` function.

--- a/projects/ngrx.io/content/guide/signals/signal-store/private-store-members.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/private-store-members.md
@@ -7,11 +7,13 @@ This includes root-level state slices, properties, and methods.
 <code-pane header="counter.store.ts">
 
 import { computed } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import {
   patchState,
   signalStore,
   withComputed,
   withMethods,
+  withProps,
   withState,
 } from '@ngrx/signals';
 
@@ -25,6 +27,11 @@ export const CounterStore = signalStore(
     // 👇 private computed signal
     _doubleCount1: computed(() => count1() * 2),
     doubleCount2: computed(() => _count2() * 2),
+  })),
+  withProps(({ count2, _doubleCount1 }) => ({
+    // 👇 private property
+    _count2$: toObservable(count2),
+    doubleCount1$: toObservable(_doubleCount1),
   })),
   withMethods((store) => ({
     increment1(): void {
@@ -57,6 +64,9 @@ export class CounterComponent implements OnInit {
 
     console.log(this.store._doubleCount1()); // ❌
     console.log(this.store.doubleCount2()); // ✅
+
+    this.store._count2$.subscribe(console.log); // ❌
+    this.store.doubleCount1$.subscribe(console.log); // ✅
 
     this.store.increment1(); // ✅
     this.store._increment2(); // ❌

--- a/projects/ngrx.io/content/guide/signals/signal-store/private-store-members.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/private-store-members.md
@@ -1,7 +1,7 @@
 # Private Store Members
 
 SignalStore allows defining private members that cannot be accessed from outside the store by using the `_` prefix.
-This includes root-level state slices, computed signals, and methods.
+This includes root-level state slices, properties, and methods.
 
 <code-tabs linenums="false">
 <code-pane header="counter.store.ts">

--- a/projects/ngrx.io/content/navigation.json
+++ b/projects/ngrx.io/content/navigation.json
@@ -294,6 +294,10 @@
                   "url": "guide/signals/signal-store/lifecycle-hooks"
                 },
                 {
+                  "title": "Custom Store Properties",
+                  "url": "guide/signals/signal-store/custom-store-properties"
+                },
+                {
                   "title": "State Tracking",
                   "url": "guide/signals/signal-store/state-tracking"
                 },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4504

## What is the new behavior?

- The `computed` property in `SignalStoreFeatureResult` type is renamed to `props`.
- The `EntityComputed` and `NamedEntityComputed` types in the `entities` plugin are renamed to `EntityProps` and `NamedEntityProps`.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

```
BREAKING CHANGES:

- The `computed` property in `SignalStoreFeatureResult` type is renamed to `props`.
- The `EntityComputed` and `NamedEntityComputed` types in the `entities` plugin are renamed to `EntityProps` and `NamedEntityProps`.

BEFORE:

import { computed, Signal } from '@angular/core';
import {
  signalStoreFeature,
  SignalStoreFeature,
  type,
  withComputed,
} from '@ngrx/signals';
import { EntityComputed } from '@ngrx/signals/entities';

export function withTotalEntities<Entity>(): SignalStoreFeature
  { state: {}, computed: EntityComputed<Entity>, methods: {} },
  { state: {}, computed: { total: Signal<number> }, methods: {} },
> {
  return signalStoreFeature(
    { computed: type<EntityComputed<Entity>>() },
    withComputed(({ entities }) => ({
      total: computed(() => entities().length),
    })),
  );
}

AFTER:

import { computed, Signal } from '@angular/core';
import {
  signalStoreFeature,
  SignalStoreFeature,
  type,
  withComputed,
} from '@ngrx/signals';
import { EntityProps } from '@ngrx/signals/entities';

export function withTotalEntities<Entity>(): SignalStoreFeature
  { state: {}, props: EntityProps<Entity>, methods: {} },
  { state: {}, props: { total: Signal<number> }, methods: {} },
> {
  return signalStoreFeature(
    { props: type<EntityProps<Entity>>() },
    withComputed(({ entities }) => ({
      total: computed(() => entities().length),
    })),
  );
}
```
