### PR TITLE
refactor(signals): improve `rxMethod` tests by using child injectors

### DIFF
--- a/modules/signals/rxjs-interop/spec/rx-method.spec.ts
+++ b/modules/signals/rxjs-interop/spec/rx-method.spec.ts
@@ -262,7 +262,7 @@ describe('rxMethod', () => {
       expect(globalService.globalSignalChangeCounter).toBe(3);
     });
 
-    it('tracks an observable until the component is destroyed', () => {
+    it('tracks an observable until the instanceInjector is destroyed', () => {
       const instanceInjector = createEnvironmentInjector(
         [],
         TestBed.inject(EnvironmentInjector)


### PR DESCRIPTION
Refactor the tests for `rxMethod` to avoid component navigation when testing the behavior of switching injection contexts.

Rename the `signalMethod` method in the testing service to `trackSignal` for better readability.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
