### PR TITLE
fix(signals): enable `withProps` to handle Symbols

### DIFF
--- a/modules/signals/spec/deep-freeze.spec.ts
+++ b/modules/signals/spec/deep-freeze.spec.ts
@@ -5,6 +5,9 @@ import { TestBed } from '@angular/core/testing';
 import { withState } from '../src/with-state';
 
 describe('deepFreeze', () => {
+  const DIRECT_SECRET = Symbol('direct secret');
+  const SECRET = Symbol('secret');
+
   const initialState = {
     user: {
       firstName: 'John',
@@ -13,6 +16,14 @@ describe('deepFreeze', () => {
     foo: 'bar',
     numbers: [1, 2, 3],
     ngrx: 'signals',
+    [DIRECT_SECRET]: 'secret',
+    nestedSymbol: {
+      [SECRET]: 'another secret',
+    },
+    [SECRET]: {
+      code: 'secret',
+      value: '123',
+    },
   };
 
   for (const { stateFactory, name } of [
@@ -71,7 +82,7 @@ describe('deepFreeze', () => {
           );
         });
 
-        it('throws when mutable change happens for', () => {
+        it('throws when mutable change happens', () => {
           const state = stateFactory();
           const s = { user: { firstName: 'M', lastName: 'S' } };
           patchState(state, s);
@@ -81,6 +92,30 @@ describe('deepFreeze', () => {
           }).toThrowError(
             "Cannot assign to read only property 'firstName' of object"
           );
+        });
+
+        describe('symbol', () => {
+          it('throws on a mutable change on property of a frozen symbol', () => {
+            const state = stateFactory();
+            const s = getState(state);
+
+            expect(() => {
+              s[SECRET].code = 'mutable change';
+            }).toThrowError(
+              "Cannot assign to read only property 'code' of object"
+            );
+          });
+
+          it('throws on a mutable change on nested symbol', () => {
+            const state = stateFactory();
+            const s = getState(state);
+
+            expect(() => {
+              s.nestedSymbol[SECRET] = 'mutable change';
+            }).toThrowError(
+              "Cannot assign to read only property 'Symbol(secret)' of object"
+            );
+          });
         });
       });
     });

--- a/modules/signals/spec/deep-freeze.spec.ts
+++ b/modules/signals/spec/deep-freeze.spec.ts
@@ -1,11 +1,13 @@
-import { getState, patchState } from '../src/state-source';
-import { signalState } from '../src/signal-state';
-import { signalStore } from '../src/signal-store';
 import { TestBed } from '@angular/core/testing';
-import { withState } from '../src/with-state';
+import {
+  getState,
+  patchState,
+  signalState,
+  signalStore,
+  withState,
+} from '../src';
 
 describe('deepFreeze', () => {
-  const DIRECT_SECRET = Symbol('direct secret');
   const SECRET = Symbol('secret');
 
   const initialState = {
@@ -16,7 +18,6 @@ describe('deepFreeze', () => {
     foo: 'bar',
     numbers: [1, 2, 3],
     ngrx: 'signals',
-    [DIRECT_SECRET]: 'secret',
     nestedSymbol: {
       [SECRET]: 'another secret',
     },
@@ -63,6 +64,7 @@ describe('deepFreeze', () => {
           "Cannot assign to read only property 'firstName' of object"
         );
       });
+
       describe('mutable changes outside of patchState', () => {
         it('throws on reassigned a property of the exposed state', () => {
           const state = stateFactory();
@@ -94,28 +96,26 @@ describe('deepFreeze', () => {
           );
         });
 
-        describe('symbol', () => {
-          it('throws on a mutable change on property of a frozen symbol', () => {
-            const state = stateFactory();
-            const s = getState(state);
+        it('throws when mutable change of root symbol property happens', () => {
+          const state = stateFactory();
+          const s = getState(state);
 
-            expect(() => {
-              s[SECRET].code = 'mutable change';
-            }).toThrowError(
-              "Cannot assign to read only property 'code' of object"
-            );
-          });
+          expect(() => {
+            s[SECRET].code = 'mutable change';
+          }).toThrowError(
+            "Cannot assign to read only property 'code' of object"
+          );
+        });
 
-          it('throws on a mutable change on nested symbol', () => {
-            const state = stateFactory();
-            const s = getState(state);
+        it('throws when mutable change of nested symbol property happens', () => {
+          const state = stateFactory();
+          const s = getState(state);
 
-            expect(() => {
-              s.nestedSymbol[SECRET] = 'mutable change';
-            }).toThrowError(
-              "Cannot assign to read only property 'Symbol(secret)' of object"
-            );
-          });
+          expect(() => {
+            s.nestedSymbol[SECRET] = 'mutable change';
+          }).toThrowError(
+            "Cannot assign to read only property 'Symbol(secret)' of object"
+          );
         });
       });
     });

--- a/modules/signals/spec/signal-store.spec.ts
+++ b/modules/signals/spec/signal-store.spec.ts
@@ -152,7 +152,7 @@ describe('signalStore', () => {
       expect(store.foo()).toBe('foo');
     });
 
-    it('can have symbols as keys as well', () => {
+    it('allows symbols as state keys', () => {
       const SECRET = Symbol('SECRET');
       const Store = signalStore(withState({ [SECRET]: 'bar' }));
       const store = new Store();
@@ -198,7 +198,7 @@ describe('signalStore', () => {
       expect(store.foo).toBe('bar');
     });
 
-    it('allows symbols as props', () => {
+    it('allows symbols as property keys', () => {
       const SECRET = Symbol('SECRET');
 
       const Store = signalStore(withProps(() => ({ [SECRET]: 'secret' })));
@@ -209,37 +209,13 @@ describe('signalStore', () => {
       expect(store[SECRET]).toBe('secret');
     });
 
-    it('allows numbers as props', () => {
+    it('allows numbers as property keys', () => {
       const Store = signalStore(withProps(() => ({ 1: 'Number One' })));
       const store = TestBed.configureTestingModule({
         providers: [Store],
       }).inject(Store);
 
       expect(store[1]).toBe('Number One');
-    });
-
-    it('passes on a symbol to the features', () => {
-      const SECRET = Symbol('SECRET');
-      const SecretStore = signalStore(
-        { providedIn: 'root' },
-        withProps(() => ({
-          [SECRET]: 'not your business',
-        })),
-        withMethods((store) => ({
-          reveil() {
-            return store[SECRET];
-          },
-        })),
-        withComputed((state) => ({
-          secret: computed(() => state[SECRET]),
-        }))
-      );
-
-      const secretStore = TestBed.inject(SecretStore);
-
-      expect(secretStore.reveil()).toBe('not your business');
-      expect(secretStore.secret()).toBe('not your business');
-      expect(secretStore[SECRET]).toBe('not your business');
     });
   });
 
@@ -280,24 +256,18 @@ describe('signalStore', () => {
       expect(store.bar()).toBe('bar');
     });
 
-    it('can also expose a symbol', () => {
+    it('allows symbols as computed keys', () => {
       const SECRET = Symbol('SECRET');
       const SecretStore = signalStore(
         { providedIn: 'root' },
         withComputed(() => ({
           [SECRET]: computed(() => 'secret'),
-        })),
-        withMethods((store) => ({
-          reveil() {
-            return store[SECRET];
-          },
         }))
       );
 
       const secretStore = TestBed.inject(SecretStore);
-      const secretSignal = secretStore.reveil();
 
-      expect(secretSignal()).toBe('secret');
+      expect(secretStore[SECRET]()).toBe('secret');
     });
   });
 
@@ -342,7 +312,7 @@ describe('signalStore', () => {
       expect(store.baz()).toBe('baz');
     });
 
-    it('can also expose a symbol', () => {
+    it('allows symbols as method keys', () => {
       const SECRET = Symbol('SECRET');
       const SecretStore = signalStore(
         { providedIn: 'root' },
@@ -545,6 +515,29 @@ describe('signalStore', () => {
           'j, m',
         ],
       ]);
+    });
+
+    it('passes on a symbol key to the features', () => {
+      const SECRET = Symbol('SECRET');
+      const SecretStore = signalStore(
+        withProps(() => ({
+          [SECRET]: 'not your business',
+        })),
+        withComputed((store) => ({
+          secret: computed(() => store[SECRET]),
+        })),
+        withMethods((store) => ({
+          reveil() {
+            return store[SECRET];
+          },
+        }))
+      );
+
+      const secretStore = new SecretStore();
+
+      expect(secretStore.reveil()).toBe('not your business');
+      expect(secretStore.secret()).toBe('not your business');
+      expect(secretStore[SECRET]).toBe('not your business');
     });
   });
 });

--- a/modules/signals/spec/state-source.spec.ts
+++ b/modules/signals/spec/state-source.spec.ts
@@ -81,7 +81,7 @@ describe('StateSource', () => {
           });
         });
 
-        it('patches property with symbol keys', () => {
+        it('patches state slice with symbol key', () => {
           const state = stateFactory();
 
           patchState(state, { [SECRET]: 'another secret' });

--- a/modules/signals/spec/state-source.spec.ts
+++ b/modules/signals/spec/state-source.spec.ts
@@ -18,6 +18,8 @@ import {
 import { STATE_SOURCE } from '../src/state-source';
 import { createLocalService } from './helpers';
 
+const SECRET = Symbol('SECRET');
+
 describe('StateSource', () => {
   const initialState = {
     user: {
@@ -27,6 +29,7 @@ describe('StateSource', () => {
     foo: 'bar',
     numbers: [1, 2, 3],
     ngrx: 'signals',
+    [SECRET]: 'secret',
   };
 
   describe('patchState', () => {
@@ -76,6 +79,13 @@ describe('StateSource', () => {
             numbers: [1, 2, 3, 4],
             ngrx: 'rocks',
           });
+        });
+
+        it('patches property with symbol keys', () => {
+          const state = stateFactory();
+
+          patchState(state, { [SECRET]: 'another secret' });
+          expect(state[SECRET]()).toBe('another secret');
         });
 
         it('patches state via sequence of partial state objects and updater functions', () => {

--- a/modules/signals/spec/with-computed.spec.ts
+++ b/modules/signals/spec/with-computed.spec.ts
@@ -19,6 +19,7 @@ describe('withComputed', () => {
   });
 
   it('logs warning if previously defined signal store members have the same name', () => {
+    const COMPUTED_SECRET = Symbol('computed_secret');
     const initialStore = [
       withState({
         p1: 10,
@@ -27,6 +28,7 @@ describe('withComputed', () => {
       withComputed(() => ({
         s1: signal('s1').asReadonly(),
         s2: signal({ s: 2 }).asReadonly(),
+        [COMPUTED_SECRET]: signal(1).asReadonly(),
       })),
       withMethods(() => ({
         m1() {},
@@ -43,12 +45,13 @@ describe('withComputed', () => {
       m1: signal({ m: 1 }).asReadonly(),
       m3: signal({ m: 3 }).asReadonly(),
       s3: signal({ s: 3 }).asReadonly(),
+      [COMPUTED_SECRET]: signal(10).asReadonly(),
     }))(initialStore);
 
     expect(console.warn).toHaveBeenCalledWith(
       '@ngrx/signals: SignalStore members cannot be overridden.',
       'Trying to override:',
-      'p1, s2, m1'
+      'p1, s2, m1, Symbol(computed_secret)'
     );
   });
 });

--- a/modules/signals/spec/with-methods.spec.ts
+++ b/modules/signals/spec/with-methods.spec.ts
@@ -19,14 +19,18 @@ describe('withMethods', () => {
   });
 
   it('logs warning if previously defined signal store members have the same name', () => {
+    const STATE_SECRET = Symbol('state_secret');
+    const COMPUTED_SECRET = Symbol('computed_secret');
     const initialStore = [
       withState({
         p1: 'p1',
         p2: false,
+        [STATE_SECRET]: 1,
       }),
       withComputed(() => ({
         s1: signal(true).asReadonly(),
         s2: signal({ s: 2 }).asReadonly(),
+        [COMPUTED_SECRET]: signal(1).asReadonly(),
       })),
       withMethods(() => ({
         m1() {},
@@ -43,12 +47,14 @@ describe('withMethods', () => {
       s1: () => 100,
       m2,
       m3: () => 'm3',
+      [STATE_SECRET]() {},
+      [COMPUTED_SECRET]() {},
     }))(initialStore);
 
     expect(console.warn).toHaveBeenCalledWith(
       '@ngrx/signals: SignalStore members cannot be overridden.',
       'Trying to override:',
-      'p2, s1, m2'
+      'p2, s1, m2, Symbol(state_secret), Symbol(computed_secret)'
     );
   });
 });

--- a/modules/signals/spec/with-props.spec.ts
+++ b/modules/signals/spec/with-props.spec.ts
@@ -1,7 +1,8 @@
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
-import { withMethods, withProps, withState } from '../src';
+import { signalStore, withMethods, withProps, withState } from '../src';
 import { getInitialInnerStore } from '../src/signal-store';
+import { TestBed } from '@angular/core/testing';
 
 describe('withProps', () => {
   it('adds properties to the store immutably', () => {
@@ -46,5 +47,16 @@ describe('withProps', () => {
       'Trying to override:',
       's1, p2, m1'
     );
+  });
+
+  it('allows symbols as props', () => {
+    const SECRET = Symbol('SECRET');
+
+    const Store = signalStore(withProps(() => ({ [SECRET]: 'secret' })));
+    const store = TestBed.configureTestingModule({ providers: [Store] }).inject(
+      Store
+    );
+
+    expect(store[SECRET]).toBe('secret');
   });
 });

--- a/modules/signals/spec/with-props.spec.ts
+++ b/modules/signals/spec/with-props.spec.ts
@@ -1,8 +1,7 @@
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
-import { signalStore, withMethods, withProps, withState } from '../src';
+import { withMethods, withProps, withState } from '../src';
 import { getInitialInnerStore } from '../src/signal-store';
-import { TestBed } from '@angular/core/testing';
 
 describe('withProps', () => {
   it('adds properties to the store immutably', () => {
@@ -47,25 +46,5 @@ describe('withProps', () => {
       'Trying to override:',
       's1, p2, m1'
     );
-  });
-
-  it('allows symbols as props', () => {
-    const SECRET = Symbol('SECRET');
-
-    const Store = signalStore(withProps(() => ({ [SECRET]: 'secret' })));
-    const store = TestBed.configureTestingModule({ providers: [Store] }).inject(
-      Store
-    );
-
-    expect(store[SECRET]).toBe('secret');
-  });
-
-  it('allows numbers as props', () => {
-    const Store = signalStore(withProps(() => ({ 1: 'Number One' })));
-    const store = TestBed.configureTestingModule({ providers: [Store] }).inject(
-      Store
-    );
-
-    expect(store[1]).toBe('Number One');
   });
 });

--- a/modules/signals/spec/with-props.spec.ts
+++ b/modules/signals/spec/with-props.spec.ts
@@ -59,4 +59,13 @@ describe('withProps', () => {
 
     expect(store[SECRET]).toBe('secret');
   });
+
+  it('allows numbers as props', () => {
+    const Store = signalStore(withProps(() => ({ 1: 'Number One' })));
+    const store = TestBed.configureTestingModule({ providers: [Store] }).inject(
+      Store
+    );
+
+    expect(store[1]).toBe('Number One');
+  });
 });

--- a/modules/signals/spec/with-props.spec.ts
+++ b/modules/signals/spec/with-props.spec.ts
@@ -17,10 +17,13 @@ describe('withProps', () => {
   });
 
   it('logs warning if previously defined signal store members have the same name', () => {
+    const STATE_SECRET = Symbol('state_secret');
+    const METHOD_SECRET = Symbol('method_secret');
     const initialStore = [
       withState({
         s1: 10,
         s2: 's2',
+        [STATE_SECRET]: 1,
       }),
       withProps(() => ({
         p1: of(100),
@@ -29,6 +32,7 @@ describe('withProps', () => {
       withMethods(() => ({
         m1() {},
         m2() {},
+        [METHOD_SECRET]() {},
       })),
     ].reduce((acc, feature) => feature(acc), getInitialInnerStore());
     vi.spyOn(console, 'warn').mockImplementation();
@@ -39,12 +43,14 @@ describe('withProps', () => {
       p2: signal(100),
       m1: { ngrx: 'rocks' },
       m3: of('m3'),
+      [STATE_SECRET]: 10,
+      [METHOD_SECRET]: { x: 'y' },
     }))(initialStore);
 
     expect(console.warn).toHaveBeenCalledWith(
       '@ngrx/signals: SignalStore members cannot be overridden.',
       'Trying to override:',
-      's1, p2, m1'
+      's1, p2, m1, Symbol(state_secret), Symbol(method_secret)'
     );
   });
 });

--- a/modules/signals/spec/with-state.spec.ts
+++ b/modules/signals/spec/with-state.spec.ts
@@ -55,6 +55,8 @@ describe('withState', () => {
   });
 
   it('logs warning if previously defined signal store members have the same name', () => {
+    const COMPUTED_SECRET = Symbol('computed_secret');
+    const METHOD_SECRET = Symbol('method_secret');
     const initialStore = [
       withState({
         p1: 10,
@@ -63,10 +65,12 @@ describe('withState', () => {
       withComputed(() => ({
         s1: signal('s1').asReadonly(),
         s2: signal({ s: 2 }).asReadonly(),
+        [COMPUTED_SECRET]: signal(1).asReadonly(),
       })),
       withMethods(() => ({
         m1() {},
         m2() {},
+        [METHOD_SECRET]() {},
       })),
     ].reduce((acc, feature) => feature(acc), getInitialInnerStore());
     vi.spyOn(console, 'warn').mockImplementation();
@@ -78,12 +82,14 @@ describe('withState', () => {
       m: { s: 10 },
       m2: { m: 2 },
       p3: 'p3',
+      [COMPUTED_SECRET]: 10,
+      [METHOD_SECRET]: 100,
     }))(initialStore);
 
     expect(console.warn).toHaveBeenCalledWith(
       '@ngrx/signals: SignalStore members cannot be overridden.',
       'Trying to override:',
-      'p2, s2, m2'
+      'p2, s2, m2, Symbol(computed_secret), Symbol(method_secret)'
     );
   });
 });

--- a/modules/signals/src/deep-freeze.ts
+++ b/modules/signals/src/deep-freeze.ts
@@ -30,14 +30,14 @@ export function deepFreeze<T extends object>(target: T): T {
   return target;
 }
 
-export function freezeInDevMode<T>(target: T): T {
+export function freezeInDevMode<T extends object>(target: T): T {
   return ngDevMode ? deepFreeze(target) : target;
 }
 
 function hasOwnProperty(
   target: unknown,
-  propertyName: string
-): target is { [propertyName: string]: unknown } {
+  propertyName: string | symbol
+): target is { [propertyName: string | symbol]: unknown } {
   return isObjectLike(target)
     ? Object.prototype.hasOwnProperty.call(target, propertyName)
     : false;

--- a/modules/signals/src/deep-freeze.ts
+++ b/modules/signals/src/deep-freeze.ts
@@ -1,13 +1,12 @@
 declare const ngDevMode: boolean;
 
-export function deepFreeze<T>(target: T): T {
+export function deepFreeze<T extends object>(target: T): T {
   Object.freeze(target);
 
   const targetIsFunction = typeof target === 'function';
 
-  Object.getOwnPropertyNames(target).forEach((prop) => {
-    // Ignore Ivy properties, ref: https://github.com/ngrx/platform/issues/2109#issuecomment-582689060
-    if (prop.startsWith('ɵ')) {
+  Reflect.ownKeys(target).forEach((prop) => {
+    if (String(prop).startsWith('ɵ')) {
       return;
     }
 

--- a/modules/signals/src/signal-store-assertions.ts
+++ b/modules/signals/src/signal-store-assertions.ts
@@ -4,7 +4,7 @@ declare const ngDevMode: unknown;
 
 export function assertUniqueStoreMembers(
   store: InnerSignalStore,
-  newMemberKeys: string[]
+  newMemberKeys: (string | symbol)[]
 ): void {
   if (!ngDevMode) {
     return;
@@ -15,7 +15,7 @@ export function assertUniqueStoreMembers(
     ...store.props,
     ...store.methods,
   };
-  const overriddenKeys = Object.keys(storeMembers).filter((memberKey) =>
+  const overriddenKeys = Reflect.ownKeys(storeMembers).filter((memberKey) =>
     newMemberKeys.includes(memberKey)
   );
 
@@ -23,7 +23,7 @@ export function assertUniqueStoreMembers(
     console.warn(
       '@ngrx/signals: SignalStore members cannot be overridden.',
       'Trying to override:',
-      overriddenKeys.join(', ')
+      overriddenKeys.map((key) => String(key)).join(', ')
     );
   }
 }

--- a/modules/signals/src/signal-store-assertions.ts
+++ b/modules/signals/src/signal-store-assertions.ts
@@ -4,7 +4,7 @@ declare const ngDevMode: unknown;
 
 export function assertUniqueStoreMembers(
   store: InnerSignalStore,
-  newMemberKeys: (string | symbol)[]
+  newMemberKeys: Array<string | symbol>
 ): void {
   if (!ngDevMode) {
     return;

--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -11,9 +11,9 @@ export type StateSignals<State> = IsKnownRecord<Prettify<State>> extends true
     }
   : {};
 
-export type SignalsDictionary = Record<string | symbol, Signal<unknown>>;
+export type SignalsDictionary = Record<string, Signal<unknown>>;
 
-export type MethodsDictionary = Record<string | symbol, Function>;
+export type MethodsDictionary = Record<string, Function>;
 
 export type SignalStoreHooks = {
   onInit?: () => void;

--- a/modules/signals/src/signal-store-models.ts
+++ b/modules/signals/src/signal-store-models.ts
@@ -11,9 +11,9 @@ export type StateSignals<State> = IsKnownRecord<Prettify<State>> extends true
     }
   : {};
 
-export type SignalsDictionary = Record<string, Signal<unknown>>;
+export type SignalsDictionary = Record<string | symbol, Signal<unknown>>;
 
-export type MethodsDictionary = Record<string, Function>;
+export type MethodsDictionary = Record<string | symbol, Function>;
 
 export type SignalStoreHooks = {
   onInit?: () => void;

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -1364,9 +1364,7 @@ export function signalStore(
       (this as any)[STATE_SOURCE] = innerStore[STATE_SOURCE];
 
       for (const key of Reflect.ownKeys(storeMembers)) {
-        if (typeof key === 'string' || typeof key === 'symbol') {
-          (this as any)[key] = storeMembers[key];
-        }
+        (this as any)[key] = storeMembers[key];
       }
 
       const { onInit, onDestroy } = hooks;

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -1355,12 +1355,18 @@ export function signalStore(
         getInitialInnerStore()
       );
       const { stateSignals, props, methods, hooks } = innerStore;
-      const storeMembers = { ...stateSignals, ...props, ...methods };
+      const storeMembers: Record<string | symbol, unknown> = {
+        ...stateSignals,
+        ...props,
+        ...methods,
+      };
 
       (this as any)[STATE_SOURCE] = innerStore[STATE_SOURCE];
 
-      for (const key in storeMembers) {
-        (this as any)[key] = storeMembers[key];
+      for (const key of Reflect.ownKeys(storeMembers)) {
+        if (typeof key === 'string' || typeof key === 'symbol') {
+          (this as any)[key] = storeMembers[key];
+        }
       }
 
       const { onInit, onDestroy } = hooks;

--- a/modules/signals/src/with-methods.ts
+++ b/modules/signals/src/with-methods.ts
@@ -30,7 +30,7 @@ export function withMethods<
       ...store.props,
       ...store.methods,
     });
-    assertUniqueStoreMembers(store, Object.keys(methods));
+    assertUniqueStoreMembers(store, Reflect.ownKeys(methods));
 
     return {
       ...store,

--- a/modules/signals/src/with-props.ts
+++ b/modules/signals/src/with-props.ts
@@ -28,7 +28,7 @@ export function withProps<
       ...store.props,
       ...store.methods,
     });
-    assertUniqueStoreMembers(store, Object.keys(props));
+    assertUniqueStoreMembers(store, Reflect.ownKeys(props));
 
     return {
       ...store,

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -32,7 +32,7 @@ export function withState<State extends object>(
   return (store) => {
     const state =
       typeof stateOrFactory === 'function' ? stateOrFactory() : stateOrFactory;
-    const stateKeys = Object.keys(state);
+    const stateKeys = Reflect.ownKeys(state);
 
     assertUniqueStoreMembers(store, stateKeys);
 

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -45,7 +45,7 @@ export function withState<State extends object>(
 
     const stateSignals = stateKeys.reduce((acc, key) => {
       const sliceSignal = computed(
-        () => (store[STATE_SOURCE]() as Record<string, unknown>)[key]
+        () => (store[STATE_SOURCE]() as Record<string | symbol, unknown>)[key]
       );
       return { ...acc, [key]: toDeepSignal(sliceSignal) };
     }, {} as SignalsDictionary);


### PR DESCRIPTION
Resolve an issue in `signalStore` that prevented Symbols from being added as property keys when merging
different features.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The value is just undefined.

Closes #4655

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
