### PR TITLE
refactor(store-devtools): resolve import cycle to improve tool compatibility

### DIFF
--- a/modules/store-devtools/src/instrument.ts
+++ b/modules/store-devtools/src/instrument.ts
@@ -1,14 +1,6 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { StateObservable } from '@ngrx/store';
 import { StoreDevtoolsOptions } from './config';
-import { StoreDevtools } from './devtools';
 import { provideStoreDevtools } from './provide-store-devtools';
-
-export function createStateObservable(
-  devtools: StoreDevtools
-): StateObservable {
-  return devtools.state;
-}
 
 @NgModule({})
 export class StoreDevtoolsModule {

--- a/modules/store-devtools/src/provide-store-devtools.ts
+++ b/modules/store-devtools/src/provide-store-devtools.ts
@@ -19,7 +19,6 @@ import {
   StoreDevtoolsOptions,
 } from './config';
 import { ReducerManagerDispatcher, StateObservable } from '@ngrx/store';
-import { createStateObservable } from './instrument';
 import { StoreDevtools } from './devtools';
 
 export const IS_EXTENSION_OR_MONITOR_PRESENT = new InjectionToken<boolean>(
@@ -44,6 +43,12 @@ export function createReduxDevtoolsExtension() {
   } else {
     return null;
   }
+}
+
+export function createStateObservable(
+  devtools: StoreDevtools
+): StateObservable {
+  return devtools.state;
 }
 
 /**


### PR DESCRIPTION
This change resolves the cyclical import dependency `store-devtools/src/{provide-store-devtools <-> instrument}.ts` by moving `createStateObservable` to `provide-store-devtools.ts`, its only user.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The import cycle breaks TS language tools/environments (e.g. Google's TS build) that don't support cyclical imports. 

## What is the new behavior?

Support TS language tools/environments that don't support cyclical imports.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
