### PR TITLE
ci: disable deploy step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,5 @@ jobs:
         with:
           name: artifact-modules
           path: dist
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
-      - run: pnpm run deploy:builds
+      # TODO: Add deployment steps here
+      # - run: pnpm run deploy:builds


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The build is red due to the ssh step.

## What is the new behavior?

The deploy step is disabled, because we like green builds.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

We will have to figure out how to re-enable the deploy step (do we need the deploy key? can we use an action for this step? ...?).

I don't know an easy/quick way to test this, maybe that we can include these steps in the CI build to shorten the feedback loop? Once it works we can revert the changes to the CI build, and update the main build.


