### PR TITLE
refactor(operators): Adjust `mapResponse` type signature to use `any` as default error type

### DIFF
--- a/modules/operators/src/map-response.ts
+++ b/modules/operators/src/map-response.ts
@@ -32,7 +32,7 @@ type MapResponseObserver<T, E, R1, R2> = {
  * });
  * ```
  */
-export function mapResponse<T, E, R1, R2>(
+export function mapResponse<T, R1, R2, E = any>(
   observer: MapResponseObserver<T, E, R1, R2>
 ): (source$: Observable<T>) => Observable<R1 | R2> {
   return (source$) =>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Minor type convenience change.

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The error type `E` in `mapResponse` is inferred as `unknown` which is generally unnatural when working with errors.

## What is the new behavior?

The error type `E` now defaults to `any` when it isn't inferred.

## Does this PR introduce a breaking change?

```
[x] Yes
[x] No
```

I don't see a scenario where depending on `E` being `unknown` by default is natural, but this would ultimately be a breaking change if there is dependence on the existing behavior.
