### PR TITLE
fix(signals): skip assertions when ngDevMode is not defined

### DIFF
--- a/modules/signals/entities/src/helpers.ts
+++ b/modules/signals/entities/src/helpers.ts
@@ -201,7 +201,11 @@ export function updateEntitiesMutably(
     didMutate = DidMutate.Both;
   }
 
-  if (ngDevMode && state.ids.length !== Object.keys(state.entityMap).length) {
+  if (
+    typeof ngDevMode !== 'undefined' &&
+    ngDevMode &&
+    state.ids.length !== Object.keys(state.entityMap).length
+  ) {
     console.warn(
       '@ngrx/signals/entities: Entities with IDs:',
       ids,

--- a/modules/signals/src/signal-store-assertions.ts
+++ b/modules/signals/src/signal-store-assertions.ts
@@ -6,7 +6,7 @@ export function assertUniqueStoreMembers(
   store: InnerSignalStore,
   newMemberKeys: Array<string | symbol>
 ): void {
-  if (!ngDevMode) {
+  if (typeof ngDevMode === 'undefined' || !ngDevMode) {
     return;
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Error is thrown when the `ngDevMode` global variable is not defined.

Closes #4699

## What is the new behavior?

SignalStore assertions are skipped when the `ngDevMode` global variable is not defined.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
