### PR TITLE
feat(signals): define SignalStore members as readonly

### DIFF
--- a/modules/signals/entities/src/models.ts
+++ b/modules/signals/entities/src/models.ts
@@ -2,11 +2,11 @@ import { Signal } from '@angular/core';
 
 export type EntityId = string | number;
 
-export type EntityMap<Entity> = Record<EntityId, Entity>;
+export type EntityMap<Entity> = Readonly<Record<EntityId, Entity>>;
 
 export type EntityState<Entity> = {
-  entityMap: EntityMap<Entity>;
-  ids: EntityId[];
+  readonly entityMap: EntityMap<Entity>;
+  readonly ids: readonly EntityId[];
 };
 
 export type NamedEntityState<Entity, Collection extends string> = {
@@ -14,7 +14,7 @@ export type NamedEntityState<Entity, Collection extends string> = {
 };
 
 export type EntityProps<Entity> = {
-  entities: Signal<Entity[]>;
+  entities: Signal<readonly Entity[]>;
 };
 
 export type NamedEntityProps<Entity, Collection extends string> = {

--- a/modules/signals/spec/types/signal-store.types.spec.ts
+++ b/modules/signals/spec/types/signal-store.types.spec.ts
@@ -34,7 +34,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'Store',
-      'Type<{ foo: Signal<string>; bar: Signal<number[]>; } & StateSource<{ foo: string; bar: number[]; }>>'
+      'Type<{ readonly foo: Signal<string>; readonly bar: Signal<number[]>; } & StateSource<{ foo: string; bar: number[]; }>>'
     );
   });
 
@@ -64,7 +64,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ user: DeepSignal<{ age: number; details: { first: string; flags: boolean[]; }; }>; } & StateSource<{ user: { age: number; details: { first: string; flags: boolean[]; }; }; }>'
+      '{ readonly user: DeepSignal<{ age: number; details: { first: string; flags: boolean[]; }; }>; } & StateSource<{ user: { age: number; details: { first: string; flags: boolean[]; }; }; }>'
     );
 
     expectSnippet(snippet).toInfer(
@@ -265,7 +265,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ foo: Signal<number | { s: string; }>; bar: DeepSignal<{ baz: { b: boolean; } | null; }>; x: DeepSignal<{ y: { z: number | undefined; }; }>; } & StateSource<{ foo: number | { ...; }; bar: { ...; }; x: { ...; }; }>'
+      '{ readonly foo: Signal<number | { s: string; }>; readonly bar: DeepSignal<{ baz: { b: boolean; } | null; }>; readonly x: DeepSignal<{ y: { z: number | undefined; }; }>; } & StateSource<...>'
     );
 
     expectSnippet(snippet).toInfer('foo', 'Signal<number | { s: string; }>');
@@ -305,7 +305,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet1).toInfer(
       'Store',
-      'Type<{ name: DeepSignal<{ x: { y: string; }; }>; arguments: Signal<number[]>; call: Signal<boolean>; } & StateSource<{ name: { x: { y: string; }; }; arguments: number[]; call: boolean; }>>'
+      'Type<{ readonly name: DeepSignal<{ x: { y: string; }; }>; readonly arguments: Signal<number[]>; readonly call: Signal<boolean>; } & StateSource<{ name: { x: { y: string; }; }; arguments: number[]; call: boolean; }>>'
     );
 
     const snippet2 = `
@@ -322,7 +322,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet2).toInfer(
       'Store',
-      'Type<{ apply: Signal<string>; bind: DeepSignal<{ foo: string; }>; prototype: Signal<string[]>; } & StateSource<{ apply: string; bind: { foo: string; }; prototype: string[]; }>>'
+      'Type<{ readonly apply: Signal<string>; readonly bind: DeepSignal<{ foo: string; }>; readonly prototype: Signal<string[]>; } & StateSource<{ apply: string; bind: { foo: string; }; prototype: string[]; }>>'
     );
 
     const snippet3 = `
@@ -338,7 +338,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet3).toInfer(
       'Store',
-      'Type<{ length: Signal<number>; caller: Signal<undefined>; } & StateSource<{ length: number; caller: undefined; }>>'
+      'Type<{ readonly length: Signal<number>; readonly caller: Signal<undefined>; } & StateSource<{ length: number; caller: undefined; }>>'
     );
   });
 
@@ -393,7 +393,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ bar: DeepSignal<{ baz?: number | undefined; }>; x: DeepSignal<{ y?: { z: boolean; } | undefined; }>; } & StateSource<{ bar: { baz?: number | undefined; }; x: { y?: { z: boolean; } | undefined; }; }>'
+      '{ readonly bar: DeepSignal<{ baz?: number | undefined; }>; readonly x: DeepSignal<{ y?: { z: boolean; } | undefined; }>; } & StateSource<{ bar: { baz?: number | undefined; }; x: { ...; }; }>'
     );
 
     expectSnippet(snippet).toInfer(
@@ -503,7 +503,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store1',
-      '{ count: Signal<number>; } & StateSource<{ count: number; }>'
+      '{ readonly count: Signal<number>; } & StateSource<{ count: number; }>'
     );
 
     expectSnippet(snippet).toInfer('state1', '{ count: number; }');
@@ -515,7 +515,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store2',
-      '{ count: Signal<number>; } & StateSource<{ count: number; }>'
+      '{ readonly count: Signal<number>; } & StateSource<{ count: number; }>'
     );
 
     expectSnippet(snippet).toInfer('state2', '{ count: number; }');
@@ -548,7 +548,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store1',
-      '{ count: Signal<number>; } & StateSource<{ count: number; }>'
+      '{ readonly count: Signal<number>; } & StateSource<{ count: number; }>'
     );
 
     expectSnippet(snippet).toInfer('state1', '{ count: number; }');
@@ -560,7 +560,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store2',
-      '{ count: Signal<number>; } & StateSource<{ count: number; }>'
+      '{ readonly count: Signal<number>; } & StateSource<{ count: number; }>'
     );
 
     expectSnippet(snippet).toInfer('state2', '{ count: number; }');
@@ -593,14 +593,14 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store1',
-      '{ count: Signal<number>; } & WritableStateSource<{ count: number; }>'
+      '{ readonly count: Signal<number>; } & WritableStateSource<{ count: number; }>'
     );
 
     expectSnippet(snippet).toInfer('state1', '{ count: number; }');
 
     expectSnippet(snippet).toInfer(
       'store2',
-      '{ count: Signal<number>; } & WritableStateSource<{ count: number; }>'
+      '{ readonly count: Signal<number>; } & WritableStateSource<{ count: number; }>'
     );
 
     expectSnippet(snippet).toInfer('state2', '{ count: number; }');
@@ -762,7 +762,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ ngrx: Signal<string>; x: DeepSignal<{ y: string; }>; signals: Signal<number[]>; mgmt: (arg: boolean) => number; } & StateSource<{ ngrx: string; x: { y: string; }; }>'
+      '{ readonly ngrx: Signal<string>; readonly x: DeepSignal<{ y: string; }>; readonly signals: Signal<number[]>; readonly mgmt: (arg: boolean) => number; } & StateSource<...>'
     );
   });
 
@@ -790,7 +790,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ foo: Signal<number>; bar: Signal<string>; baz: (x: number) => void; } & StateSource<{ foo: number; }>'
+      '{ readonly foo: Signal<number>; readonly bar: Signal<string>; readonly baz: (x: number) => void; } & StateSource<{ foo: number; }>'
     );
   });
 
@@ -838,7 +838,7 @@ describe('signalStore', () => {
 
     expectSnippet(snippet).toInfer(
       'store',
-      '{ count1: Signal<number>; doubleCount2: Signal<number>; increment1: () => void; } & StateSource<{ count1: number; }>'
+      '{ readonly count1: Signal<number>; readonly doubleCount2: Signal<number>; readonly increment1: () => void; } & StateSource<{ count1: number; }>'
     );
   });
 

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -13,10 +13,12 @@ type SignalStoreConfig = { providedIn?: 'root'; protectedState?: boolean };
 
 type SignalStoreMembers<FeatureResult extends SignalStoreFeatureResult> =
   Prettify<
-    OmitPrivate<
-      StateSignals<FeatureResult['state']> &
-        FeatureResult['props'] &
-        FeatureResult['methods']
+    Readonly<
+      OmitPrivate<
+        StateSignals<FeatureResult['state']> &
+          FeatureResult['props'] &
+          FeatureResult['methods']
+      >
     >
   >;
 

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -14,11 +14,11 @@ const STATE_WATCHERS = new WeakMap<Signal<object>, Array<StateWatcher<any>>>();
 export const STATE_SOURCE = Symbol('STATE_SOURCE');
 
 export type WritableStateSource<State extends object> = {
-  [STATE_SOURCE]: WritableSignal<State>;
+  readonly [STATE_SOURCE]: WritableSignal<State>;
 };
 
 export type StateSource<State extends object> = {
-  [STATE_SOURCE]: Signal<State>;
+  readonly [STATE_SOURCE]: Signal<State>;
 };
 
 export type PartialStateUpdater<State extends object> = (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Feature
```

## What is the current behavior?

https://github.com/ngrx/platform/discussions/4712

## What is the new behavior?

After these changes, the store and entities will become type-safe:

```ts
this.userStore.entities = signal([{ id: 1000, name: 'Vova' }]); // error
this.userStore.entityMap()[0] = { id: 2000, name: 'Dima' }; // error
this.userStore.entities()[0] = { id: 2000, name: 'Dima' }; // error
this.userStore.entities = signal([]); // error
this.userStore.loadAll = () => undefined; // error
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If someone modifies the store or directly edits entities, they will need to fix these errors (or add just `as any`). However, this will help prevent future errors by enforcing type safety.

Also, I want to mention that it doesn't introduces "breaking changes" in logic, like it was with `Object.freeze` that was reverted https://github.com/ngrx/platform/issues/4683.

## Other information

In my application, almost every type includes readonly to ensure type safety. I always know when this rule is broken—only when using the `as` keyword. It would be great to have similar safety in @ngrx/signals.

This PR provides the minimum type safety I want. Additionally, I suggest changing every instance like this:

```ts
SignalStoreFeature<Input, { state: {}; props: {}; methods: Methods }>
```

To:
```ts
{
    readonly state: {};
    readonly props: {};
    readonly methods: Methods;
  }
```

I can also implement this change if the idea is accepted. 

