### PR TITLE
feat(signals): Added selectable entities behaviour by default

### DIFF
--- a/modules/signals/entities/spec/updaters/clear-selected-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/clear-selected-entity.spec.ts
@@ -1,0 +1,57 @@
+import { patchState, signalStore } from '@ngrx/signals';
+import {
+  addEntities,
+  withEntities,
+  selectEntity,
+  clearSelectedEntity,
+} from '../../src';
+import { User, user1, user2, user3 } from '../mocks';
+
+describe('selectEntity', () => {
+  it('should clear the selectedEntity and selectedEntityId if an entity is selected and exists in the state', () => {
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
+    const store = new Store();
+
+    patchState(store, addEntities([user1, user2, user3]));
+    patchState(store, selectEntity(user1.id));
+
+    expect(store.selectedId()).toBe(user1.id);
+    expect(store.selectedEntity()).toBe(user1);
+
+    patchState(store, clearSelectedEntity());
+
+    expect(store.selectedId()).toBe(null);
+    expect(store.selectedEntity()).toBe(null);
+  });
+
+  it('should clear the selectedEntity and selectedEntityId if an entity is selected and it does not exists in the state', () => {
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
+    const store = new Store();
+
+    patchState(store, addEntities([user1, user2]));
+    patchState(store, selectEntity(user3.id));
+
+    expect(store.selectedId()).toBe(user3.id);
+    expect(store.selectedEntity()).toBe(null);
+
+    patchState(store, clearSelectedEntity());
+
+    expect(store.selectedId()).toBe(null);
+    expect(store.selectedEntity()).toBe(null);
+  });
+
+  it('should not change the state if an entity is not selected', () => {
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
+    const store = new Store();
+
+    patchState(store, addEntities([user1, user2, user3]));
+
+    expect(store.selectedId()).toBe(null);
+    expect(store.selectedEntity()).toBe(null);
+
+    patchState(store, clearSelectedEntity());
+
+    expect(store.selectedId()).toBe(null);
+    expect(store.selectedEntity()).toBe(null);
+  });
+});

--- a/modules/signals/entities/spec/updaters/select-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/select-entity.spec.ts
@@ -1,0 +1,49 @@
+import { patchState, signalStore, type } from '@ngrx/signals';
+import {
+  addEntities,
+  addEntity,
+  withEntities,
+  selectEntity,
+  setEntities,
+} from '../../src';
+import { Todo, todo1, todo2, todo3, User, user1, user2, user3 } from '../mocks';
+
+describe('selectEntity', () => {
+  it('should select an entity and return it if exists', () => {
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
+    const store = new Store();
+
+    patchState(store, addEntities([user1, user2, user3]));
+    patchState(store, selectEntity(user1.id));
+
+    expect(store.selectedId()).toBe(user1.id);
+    expect(store.selectedEntity()).toBe(user1);
+  });
+
+  it('should select an entity and return null if it does not exists', () => {
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
+    const store = new Store();
+
+    patchState(store, addEntities([user1, user2]));
+    patchState(store, selectEntity(user3.id));
+
+    expect(store.selectedId()).toBe(user3.id);
+    expect(store.selectedEntity()).toBe(null);
+  });
+
+  it('should return null if the selected entity does not exist and return the entity as soon as it is added to the state', () => {
+    const Store = signalStore({ protectedState: false }, withEntities<User>());
+    const store = new Store();
+
+    patchState(store, addEntities([user1, user2]));
+    patchState(store, selectEntity(user3.id));
+
+    expect(store.selectedId()).toBe(user3.id);
+    expect(store.selectedEntity()).toBe(null);
+
+    patchState(store, addEntity(user3));
+
+    expect(store.selectedId()).toBe(user3.id);
+    expect(store.selectedEntity()).toBe(user3);
+  });
+});

--- a/modules/signals/entities/spec/with-entities.spec.ts
+++ b/modules/signals/entities/spec/with-entities.spec.ts
@@ -5,31 +5,41 @@ import { Todo, todo2, todo3, User, user1, user2 } from './mocks';
 import { selectTodoId } from './helpers';
 
 describe('withEntities', () => {
-  it('adds entity feature to the store', () => {
-    const Store = signalStore(
-      withEntities<User>(),
-      withMethods((store) => ({
-        addUsers(): void {
-          patchState(store, addEntities([user1, user2]));
-        },
-      }))
-    );
-    const store = new Store();
+  describe('signle entity feature', () => {
+    it('adds entity feature to the store', () => {
+      const Store = signalStore(
+        withEntities<User>(),
+        withMethods((store) => ({
+          addUsers(): void {
+            patchState(store, addEntities([user1, user2]));
+          },
+        }))
+      );
+      const store = new Store();
 
-    expect(isSignal(store.entityMap)).toBe(true);
-    expect(store.entityMap()).toEqual({});
+      expect(isSignal(store.entityMap)).toBe(true);
+      expect(store.entityMap()).toEqual({});
 
-    expect(isSignal(store.ids)).toBe(true);
-    expect(store.ids()).toEqual([]);
+      expect(isSignal(store.ids)).toBe(true);
+      expect(store.ids()).toEqual([]);
 
-    expect(isSignal(store.entities)).toBe(true);
-    expect(store.entities()).toEqual([]);
+      expect(isSignal(store.entities)).toBe(true);
+      expect(store.entities()).toEqual([]);
 
-    store.addUsers();
+      expect(isSignal(store.selectedId)).toBe(true);
+      expect(store.selectedId()).toEqual(null);
 
-    expect(store.entityMap()).toEqual({ 1: user1, 2: user2 });
-    expect(store.ids()).toEqual([1, 2]);
-    expect(store.entities()).toEqual([user1, user2]);
+      expect(isSignal(store.selectedEntity)).toBe(true);
+      expect(store.selectedEntity()).toEqual(null);
+
+      store.addUsers();
+
+      expect(store.entityMap()).toEqual({ 1: user1, 2: user2 });
+      expect(store.ids()).toEqual([1, 2]);
+      expect(store.entities()).toEqual([user1, user2]);
+      expect(store.selectedId()).toEqual(null);
+      expect(store.selectedEntity()).toEqual(null);
+    });
   });
 
   it('adds named entity feature to the store', () => {
@@ -55,11 +65,19 @@ describe('withEntities', () => {
     expect(isSignal(store.userEntities)).toBe(true);
     expect(store.userEntities()).toEqual([]);
 
+    expect(isSignal(store.userSelectedId)).toBe(true);
+    expect(store.userSelectedId()).toEqual(null);
+
+    expect(isSignal(store.userSelectedEntity)).toBe(true);
+    expect(store.userSelectedEntity()).toEqual(null);
+
     store.addUsers();
 
     expect(store.userEntityMap()).toEqual({ 2: user2, 1: user1 });
     expect(store.userIds()).toEqual([2, 1]);
     expect(store.userEntities()).toEqual([user2, user1]);
+    expect(store.userSelectedId()).toEqual(null);
+    expect(store.userSelectedEntity()).toEqual(null);
   });
 
   it('combines multiple entity features', () => {
@@ -99,13 +117,28 @@ describe('withEntities', () => {
     expect(isSignal(store.todoEntities)).toBe(true);
     expect(store.todoEntities()).toEqual([]);
 
+    expect(isSignal(store.selectedId)).toBe(true);
+    expect(store.selectedId()).toEqual(null);
+    expect(isSignal(store.todoSelectedId)).toBe(true);
+    expect(store.todoSelectedId()).toEqual(null);
+
+    expect(isSignal(store.selectedEntity)).toBe(true);
+    expect(store.selectedEntity()).toEqual(null);
+    expect(isSignal(store.todoSelectedEntity)).toBe(true);
+    expect(store.todoSelectedEntity()).toEqual(null);
+
     store.addEntities();
 
     expect(store.entityMap()).toEqual({ 2: user2, 1: user1 });
     expect(store.ids()).toEqual([2, 1]);
     expect(store.entities()).toEqual([user2, user1]);
+    expect(store.selectedId()).toEqual(null);
+    expect(store.selectedEntity()).toEqual(null);
+
     expect(store.todoEntityMap()).toEqual({ y: todo2, z: todo3 });
     expect(store.todoIds()).toEqual(['y', 'z']);
     expect(store.todoEntities()).toEqual([todo2, todo3]);
+    expect(store.todoSelectedId()).toEqual(null);
+    expect(store.todoSelectedEntity()).toEqual(null);
   });
 });

--- a/modules/signals/entities/src/index.ts
+++ b/modules/signals/entities/src/index.ts
@@ -9,6 +9,8 @@ export { setAllEntities } from './updaters/set-all-entities';
 export { updateEntity } from './updaters/update-entity';
 export { updateEntities } from './updaters/update-entities';
 export { updateAllEntities } from './updaters/update-all-entities';
+export { selectEntity } from './updaters/select-entity';
+export { clearSelectedEntity } from './updaters/clear-selected-entity';
 
 export { entityConfig } from './entity-config';
 export {

--- a/modules/signals/entities/src/models.ts
+++ b/modules/signals/entities/src/models.ts
@@ -7,6 +7,7 @@ export type EntityMap<Entity> = Record<EntityId, Entity>;
 export type EntityState<Entity> = {
   entityMap: EntityMap<Entity>;
   ids: EntityId[];
+  selectedId: EntityId | null;
 };
 
 export type NamedEntityState<Entity, Collection extends string> = {
@@ -15,6 +16,7 @@ export type NamedEntityState<Entity, Collection extends string> = {
 
 export type EntityProps<Entity> = {
   entities: Signal<Entity[]>;
+  selectedEntity: Signal<Entity | null>;
 };
 
 export type NamedEntityProps<Entity, Collection extends string> = {
@@ -29,8 +31,13 @@ export type EntityChanges<Entity> =
   | Partial<Entity>
   | ((entity: Entity) => Partial<Entity>);
 
-export enum DidMutate {
-  None,
-  Entities,
-  Both,
+export enum Mutated {
+  None = 1 << 0,
+  Entities = 1 << 1,
+  Ids = 1 << 2,
+  SelectedEntityId = 1 << 3,
+}
+
+export function didMutate(value: Mutated, flag: Mutated): boolean {
+  return (value & flag) === flag;
 }

--- a/modules/signals/entities/src/updaters/clear-selected-entity.ts
+++ b/modules/signals/entities/src/updaters/clear-selected-entity.ts
@@ -1,0 +1,20 @@
+import { PartialStateUpdater } from '@ngrx/signals';
+import { NamedEntityState, EntityState } from '../models';
+import { getEntityStateKeys } from '../helpers';
+
+/**
+ * Sets the selected entity and the selected id to null.
+ */
+export function clearSelectedEntity(): PartialStateUpdater<EntityState<any>>;
+export function clearSelectedEntity<Collection extends string>(config: {
+  collection: Collection;
+}): PartialStateUpdater<NamedEntityState<any, Collection>>;
+export function clearSelectedEntity(config?: {
+  collection?: string;
+}): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  const { selectedEntityIdKey } = getEntityStateKeys(config);
+
+  return () => {
+    return { [selectedEntityIdKey]: null };
+  };
+}

--- a/modules/signals/entities/src/updaters/select-entity.ts
+++ b/modules/signals/entities/src/updaters/select-entity.ts
@@ -1,0 +1,26 @@
+import { PartialStateUpdater } from '@ngrx/signals';
+import { getEntityStateKeys } from '../helpers';
+import { EntityState, EntityId, NamedEntityState } from '../models';
+
+/**
+ * Selects an entity by its id.
+ *
+ * Note: It does not throw any error if the entity does not exists it will simply return null on the selectedEntity property.
+ */
+export function selectEntity(
+  id: EntityId
+): PartialStateUpdater<EntityState<any>>;
+export function selectEntity<Collection extends string>(
+  id: EntityId,
+  config: { collection: Collection }
+): PartialStateUpdater<NamedEntityState<any, Collection>>;
+export function selectEntity(
+  id: EntityId,
+  config?: { collection?: string }
+): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  const { selectedEntityIdKey } = getEntityStateKeys(config);
+
+  return () => {
+    return { [selectedEntityIdKey]: id };
+  };
+}

--- a/modules/signals/entities/src/updaters/set-all-entities.ts
+++ b/modules/signals/entities/src/updaters/set-all-entities.ts
@@ -37,7 +37,11 @@ export function setAllEntities(
   const stateKeys = getEntityStateKeys(config);
 
   return () => {
-    const state: EntityState<any> = { entityMap: {}, ids: [] };
+    const state: EntityState<any> = {
+      entityMap: {},
+      ids: [],
+      selectedId: null,
+    };
     setEntitiesMutably(state, entities, selectId);
 
     return {

--- a/modules/signals/entities/src/with-entities.ts
+++ b/modules/signals/entities/src/with-entities.ts
@@ -49,12 +49,19 @@ export function withEntities<Entity>(config?: {
   entity: Entity;
   collection?: string;
 }): SignalStoreFeature {
-  const { entityMapKey, idsKey, entitiesKey } = getEntityStateKeys(config);
+  const {
+    selectedEntityIdKey,
+    selectedEntityKey,
+    entityMapKey,
+    idsKey,
+    entitiesKey,
+  } = getEntityStateKeys(config);
 
   return signalStoreFeature(
     withState({
       [entityMapKey]: {},
       [idsKey]: [],
+      [selectedEntityIdKey]: null,
     }),
     withComputed((store: Record<string, Signal<unknown>>) => ({
       [entitiesKey]: computed(() => {
@@ -62,6 +69,15 @@ export function withEntities<Entity>(config?: {
         const ids = store[idsKey]() as EntityId[];
 
         return ids.map((id) => entityMap[id]);
+      }),
+      [selectedEntityKey]: computed(() => {
+        const selectedEntityId = store[selectedEntityIdKey]() as EntityId;
+        if (!selectedEntityId) return null;
+        return (
+          (store[entityMapKey]() as Record<EntityId, Entity>)[
+            selectedEntityId
+          ] ?? null
+        );
       }),
     }))
   );

--- a/projects/ngrx.io/content/guide/signals/signal-store/entity-management.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/entity-management.md
@@ -110,6 +110,34 @@ Replaces the current entity collection with the provided collection.
 patchState(store, setAllEntities([todo1, todo2, todo3]));
 ```
 
+### `selectEntity`
+
+Selects an entity given its ID.
+
+```ts
+patchState(
+  store,
+  selectEntity("exampleId")
+);
+
+store.selectedId(); // "exampleId"
+store.selectedEntity(); // {id: "exampleId", ...}
+```
+
+### `clearSelectedEntity`
+
+Deselects the currently selected id setting it as null.
+
+```ts
+patchState(
+  store,
+  clearSelectedEntity()
+);
+
+store.selectedId(); // null
+store.selectedEntity(); // null
+```
+
 ### `updateEntity`
 
 Updates an entity in the collection by ID. Supports partial updates. No error is thrown if an entity doesn't exist.


### PR DESCRIPTION
- Updated withEntities to add selectedId and selectedEntity (even for named collections);
- Created selectEntity helper to select an entity given its ID.
- Created clearSelectedEntity helper to remove the currently selected entity without caring about its ID.
- Added Unit Tests
- Added documentation

Issue reference: #4717

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The withEntities() store feature does not allow the user to have a built-in system to select an entity.

Closes #4717

## What is the new behavior?

Using withSignals() will expose a selectedId() signal and a selectedEntity() computed signal.
Two helpers can be used to update the selected entity: 
- selectEntity()
- clearSelectedEntity()

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
