### PR TITLE
feat(signals): add unprotected testing helper

### DIFF
--- a/modules/signals/spec/state-source.spec.ts
+++ b/modules/signals/spec/state-source.spec.ts
@@ -3,17 +3,21 @@ import {
   effect,
   EnvironmentInjector,
   Injectable,
+  signal,
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   getState,
+  isWritableStateSource,
   patchState,
   signalState,
   signalStore,
+  StateSource,
   watchState,
   withHooks,
   withMethods,
   withState,
+  WritableStateSource,
 } from '../src';
 import { STATE_SOURCE } from '../src/state-source';
 import { createLocalService } from './helpers';
@@ -31,6 +35,24 @@ describe('StateSource', () => {
     ngrx: 'signals',
     [SECRET]: 'secret',
   };
+
+  describe('isWritableStateSource', () => {
+    it('returns true for a writable StateSource', () => {
+      const stateSource: StateSource<typeof initialState> = {
+        [STATE_SOURCE]: signal(initialState),
+      };
+
+      expect(isWritableStateSource(stateSource)).toBe(true);
+    });
+
+    it('returns false for a readonly StateSource', () => {
+      const stateSource: StateSource<typeof initialState> = {
+        [STATE_SOURCE]: signal(initialState).asReadonly(),
+      };
+
+      expect(isWritableStateSource(stateSource)).toBe(false);
+    });
+  });
 
   describe('patchState', () => {
     [

--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from './signal-store-models';
 export {
   getState,
+  isWritableStateSource,
   PartialStateUpdater,
   patchState,
   StateSource,

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -3,6 +3,7 @@ import {
   DestroyRef,
   inject,
   Injector,
+  isSignal,
   Signal,
   untracked,
   WritableSignal,
@@ -28,6 +29,17 @@ export type PartialStateUpdater<State extends object> = (
 export type StateWatcher<State extends object> = (
   state: NoInfer<State>
 ) => void;
+
+export function isWritableStateSource<State extends object>(
+  stateSource: StateSource<State>
+): stateSource is WritableStateSource<State> {
+  return (
+    'set' in stateSource[STATE_SOURCE] &&
+    'update' in stateSource[STATE_SOURCE] &&
+    typeof stateSource[STATE_SOURCE].set === 'function' &&
+    typeof stateSource[STATE_SOURCE].update === 'function'
+  );
+}
 
 export function patchState<State extends object>(
   stateSource: WritableStateSource<State>,

--- a/modules/signals/testing/index.ts
+++ b/modules/signals/testing/index.ts
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/modules/signals/testing/ng-package.json
+++ b/modules/signals/testing/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/modules/signals/testing/spec/unprotected.spec.ts
+++ b/modules/signals/testing/spec/unprotected.spec.ts
@@ -1,0 +1,29 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { patchState, signalStore, StateSource, withState } from '@ngrx/signals';
+import { STATE_SOURCE } from '../../src/state-source';
+import { unprotected } from '../src';
+
+describe('unprotected', () => {
+  it('returns writable state source', () => {
+    const CounterStore = signalStore(
+      { providedIn: 'root' },
+      withState({ count: 0 })
+    );
+
+    const counterStore = TestBed.inject(CounterStore);
+    patchState(unprotected(counterStore), { count: 1 });
+
+    expect(counterStore.count()).toBe(1);
+  });
+
+  it('throws error when provided state source is not writable', () => {
+    const readonlySource: StateSource<{ count: number }> = {
+      [STATE_SOURCE]: signal({ count: 0 }).asReadonly(),
+    };
+
+    expect(() => unprotected(readonlySource)).toThrowError(
+      '@ngrx/signals: The provided source is not writable.'
+    );
+  });
+});

--- a/modules/signals/testing/src/index.ts
+++ b/modules/signals/testing/src/index.ts
@@ -1,0 +1,1 @@
+export { unprotected } from './unprotected';

--- a/modules/signals/testing/src/unprotected.ts
+++ b/modules/signals/testing/src/unprotected.ts
@@ -1,0 +1,23 @@
+import {
+  isWritableStateSource,
+  Prettify,
+  StateSource,
+  WritableStateSource,
+} from '@ngrx/signals';
+
+type UnprotectedSource<Source extends StateSource<object>> =
+  Source extends StateSource<infer State>
+    ? Prettify<
+        Omit<Source, keyof StateSource<State>> & WritableStateSource<State>
+      >
+    : never;
+
+export function unprotected<Source extends StateSource<object>>(
+  source: Source
+): UnprotectedSource<Source> {
+  if (isWritableStateSource(source)) {
+    return source as unknown as UnprotectedSource<Source>;
+  }
+
+  throw new Error('@ngrx/signals: The provided source is not writable.');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,7 @@
       "@ngrx/signals": ["./modules/signals"],
       "@ngrx/signals/entities": ["./modules/signals/entities"],
       "@ngrx/signals/rxjs-interop": ["./modules/signals/rxjs-interop"],
+      "@ngrx/signals/testing": ["./modules/signals/testing"],
       "@ngrx/signals/schematics-core": ["./modules/signals/schematics-core"],
       "@ngrx/store": ["./modules/store"],
       "@ngrx/store-devtools": ["./modules/store-devtools"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4540

## What is the new behavior?

The new `testing` plugin is added with `unprotected` helper:

```ts
import { unprotected } from '@ngrx/signals/testing';

const CounterStore = signalStore(
  { providedIn: 'root' },
  withState({ count: 0 }),
  withComputed(({ count }) => ({
    doubleCount: computed(() => count() * 2),
  })),
);

it('works', () => {
  const store = TestBed.inject(CounterStore);
  patchState(unprotected(store), { count: 1 });

  expect(store.doubleCount()).toBe(2);
});
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
