### PR TITLE
feat(signals): infer and narrow `EntityId` type in `withEntities`

### DIFF
--- a/modules/signals/entities/spec/types/entity-config.types.spec.ts
+++ b/modules/signals/entities/spec/types/entity-config.types.spec.ts
@@ -57,7 +57,7 @@ describe('entityConfig', () => {
         selectId: selectId2,
       });
 
-      const selectId3: SelectEntityId<User> = (user) => user.key;
+      const selectId3: SelectEntityId<User, number> = (user) => user.key;
       const userConfig3 = entityConfig({
         entity: type<User>(),
         selectId: selectId3,
@@ -67,15 +67,15 @@ describe('entityConfig', () => {
     expectSnippet(snippet).toSucceed();
     expectSnippet(snippet).toInfer(
       'userConfig1',
-      '{ entity: User; selectId: SelectEntityId<NoInfer<User>>; }'
+      '{ entity: User; selectId: SelectEntityId<NoInfer<User>, number>; }'
     );
     expectSnippet(snippet).toInfer(
       'userConfig2',
-      '{ entity: User; selectId: SelectEntityId<NoInfer<User>>; }'
+      '{ entity: User; selectId: SelectEntityId<NoInfer<User>, number>; }'
     );
     expectSnippet(snippet).toInfer(
       'userConfig3',
-      '{ entity: User; selectId: SelectEntityId<NoInfer<User>>; }'
+      '{ entity: User; selectId: SelectEntityId<NoInfer<User>, number>; }'
     );
   });
 
@@ -97,7 +97,7 @@ describe('entityConfig', () => {
     `).toFail(/No overload matches this call/);
 
     expectSnippet(`
-      const selectId: SelectEntityId<{ key: string }> = (entity) => entity.key;
+      const selectId: SelectEntityId<{ key: string }, string> = (entity) => entity.key;
 
       const userConfig = entityConfig({
         entity: type<User>(),
@@ -121,7 +121,7 @@ describe('entityConfig', () => {
         selectId: selectId2,
       });
 
-      const selectId3: SelectEntityId<User> = (user) => user.key;
+      const selectId3: SelectEntityId<User, number> = (user) => user.key;
       const userConfig3 = entityConfig({
         entity: type<User>(),
         collection: 'user',
@@ -132,15 +132,15 @@ describe('entityConfig', () => {
     expectSnippet(snippet).toSucceed();
     expectSnippet(snippet).toInfer(
       'userConfig1',
-      '{ entity: User; collection: "user"; selectId: SelectEntityId<NoInfer<User>>; }'
+      '{ entity: User; collection: "user"; selectId: SelectEntityId<NoInfer<User>, number>; }'
     );
     expectSnippet(snippet).toInfer(
       'userConfig2',
-      '{ entity: User; collection: "user"; selectId: SelectEntityId<NoInfer<User>>; }'
+      '{ entity: User; collection: "user"; selectId: SelectEntityId<NoInfer<User>, number>; }'
     );
     expectSnippet(snippet).toInfer(
       'userConfig3',
-      '{ entity: User; collection: "user"; selectId: SelectEntityId<NoInfer<User>>; }'
+      '{ entity: User; collection: "user"; selectId: SelectEntityId<NoInfer<User>, number>; }'
     );
   });
 
@@ -164,7 +164,7 @@ describe('entityConfig', () => {
     `).toFail(/No overload matches this call/);
 
     expectSnippet(`
-      const selectId: SelectEntityId<{ key: string }> = (entity) => entity.key;
+      const selectId: SelectEntityId<{ key: string }, string> = (entity) => entity.key;
 
       const userConfig = entityConfig({
         entity: type<User>(),

--- a/modules/signals/entities/src/entity-config.ts
+++ b/modules/signals/entities/src/entity-config.ts
@@ -1,23 +1,27 @@
-import { SelectEntityId } from './models';
+import { EntityId, SelectEntityId } from './models';
 
-export function entityConfig<Entity, Collection extends string>(config: {
+export function entityConfig<
+  Entity,
+  Collection extends string,
+  Id extends EntityId
+>(config: {
   entity: Entity;
   collection: Collection;
-  selectId: SelectEntityId<NoInfer<Entity>>;
+  selectId: SelectEntityId<NoInfer<Entity>, Id>;
 }): typeof config;
-export function entityConfig<Entity>(config: {
+export function entityConfig<Entity, Id extends EntityId>(config: {
   entity: Entity;
-  selectId: SelectEntityId<NoInfer<Entity>>;
+  selectId: SelectEntityId<NoInfer<Entity>, Id>;
 }): typeof config;
 export function entityConfig<Entity, Collection extends string>(config: {
   entity: Entity;
   collection: Collection;
 }): typeof config;
 export function entityConfig<Entity>(config: { entity: Entity }): typeof config;
-export function entityConfig<Entity>(config: {
+export function entityConfig<Entity, Id extends EntityId>(config: {
   entity: Entity;
   collection?: string;
-  selectId?: SelectEntityId<Entity>;
+  selectId?: SelectEntityId<Entity, Id>;
 }): typeof config {
   return config;
 }

--- a/modules/signals/entities/src/helpers.ts
+++ b/modules/signals/entities/src/helpers.ts
@@ -8,11 +8,12 @@ import {
 } from './models';
 
 declare const ngDevMode: unknown;
-const defaultSelectId: SelectEntityId<{ id: EntityId }> = (entity) => entity.id;
+const defaultSelectId: SelectEntityId<{ id: EntityId }, EntityId> = (entity) =>
+  entity.id;
 
 export function getEntityIdSelector(config?: {
-  selectId?: SelectEntityId<any>;
-}): SelectEntityId<any> {
+  selectId?: SelectEntityId<any, EntityId>;
+}): SelectEntityId<any, EntityId> {
   return config?.selectId ?? defaultSelectId;
 }
 
@@ -37,7 +38,7 @@ export function cloneEntityState(
     entityMapKey: string;
     idsKey: string;
   }
-): EntityState<any> {
+): EntityState<any, EntityId> {
   return {
     entityMap: { ...state[stateKeys.entityMapKey] },
     ids: [...state[stateKeys.idsKey]],
@@ -45,7 +46,7 @@ export function cloneEntityState(
 }
 
 export function getEntityUpdaterResult(
-  state: EntityState<any>,
+  state: EntityState<any, EntityId>,
   stateKeys: {
     entityMapKey: string;
     idsKey: string;
@@ -69,9 +70,9 @@ export function getEntityUpdaterResult(
 }
 
 export function addEntityMutably(
-  state: EntityState<any>,
+  state: EntityState<any, EntityId>,
   entity: any,
-  selectId: SelectEntityId<any>
+  selectId: SelectEntityId<any, EntityId>
 ): DidMutate {
   const id = selectId(entity);
 
@@ -86,9 +87,9 @@ export function addEntityMutably(
 }
 
 export function addEntitiesMutably(
-  state: EntityState<any>,
+  state: EntityState<any, EntityId>,
   entities: any[],
-  selectId: SelectEntityId<any>
+  selectId: SelectEntityId<any, EntityId>
 ): DidMutate {
   let didMutate = DidMutate.None;
 
@@ -104,9 +105,9 @@ export function addEntitiesMutably(
 }
 
 export function setEntityMutably(
-  state: EntityState<any>,
+  state: EntityState<any, EntityId>,
   entity: any,
-  selectId: SelectEntityId<any>
+  selectId: SelectEntityId<any, EntityId>
 ): DidMutate {
   const id = selectId(entity);
 
@@ -122,9 +123,9 @@ export function setEntityMutably(
 }
 
 export function setEntitiesMutably(
-  state: EntityState<any>,
+  state: EntityState<any, EntityId>,
   entities: any[],
-  selectId: SelectEntityId<any>
+  selectId: SelectEntityId<any, EntityId>
 ): DidMutate {
   let didMutate = DidMutate.None;
 
@@ -142,7 +143,7 @@ export function setEntitiesMutably(
 }
 
 export function removeEntitiesMutably(
-  state: EntityState<any>,
+  state: EntityState<any, EntityId>,
   idsOrPredicate: EntityId[] | EntityPredicate<any>
 ): DidMutate {
   const ids = Array.isArray(idsOrPredicate)
@@ -165,10 +166,10 @@ export function removeEntitiesMutably(
 }
 
 export function updateEntitiesMutably(
-  state: EntityState<any>,
+  state: EntityState<any, EntityId>,
   idsOrPredicate: EntityId[] | EntityPredicate<any>,
   changes: EntityChanges<any>,
-  selectId: SelectEntityId<any>
+  selectId: SelectEntityId<any, EntityId>
 ): DidMutate {
   const ids = Array.isArray(idsOrPredicate)
     ? idsOrPredicate

--- a/modules/signals/entities/src/models.ts
+++ b/modules/signals/entities/src/models.ts
@@ -2,15 +2,22 @@ import { Signal } from '@angular/core';
 
 export type EntityId = string | number;
 
-export type EntityMap<Entity> = Record<EntityId, Entity>;
+export type EntityMap<Entity, Id extends EntityId> = Record<Id, Entity>;
 
-export type EntityState<Entity> = {
-  entityMap: EntityMap<Entity>;
-  ids: EntityId[];
+export type EntityState<Entity, Id extends EntityId> = {
+  entityMap: EntityMap<Entity, Id>;
+  ids: Id[];
 };
 
-export type NamedEntityState<Entity, Collection extends string> = {
-  [K in keyof EntityState<Entity> as `${Collection}${Capitalize<K>}`]: EntityState<Entity>[K];
+export type NamedEntityState<
+  Entity,
+  Collection extends string,
+  Id extends EntityId
+> = {
+  [K in keyof EntityState<
+    Entity,
+    Id
+  > as `${Collection}${Capitalize<K>}`]: EntityState<Entity, Id>[K];
 };
 
 export type EntityProps<Entity> = {
@@ -21,7 +28,9 @@ export type NamedEntityProps<Entity, Collection extends string> = {
   [K in keyof EntityProps<Entity> as `${Collection}${Capitalize<K>}`]: EntityProps<Entity>[K];
 };
 
-export type SelectEntityId<Entity> = (entity: Entity) => EntityId;
+export type SelectEntityId<Entity, Id extends EntityId> = (
+  entity: Entity
+) => Id;
 
 export type EntityPredicate<Entity> = (entity: Entity) => boolean;
 

--- a/modules/signals/entities/src/updaters/add-entities.ts
+++ b/modules/signals/entities/src/updaters/add-entities.ts
@@ -13,28 +13,39 @@ import {
   getEntityUpdaterResult,
 } from '../helpers';
 
-export function addEntities<Entity extends { id: EntityId }>(
-  entities: Entity[]
-): PartialStateUpdater<EntityState<Entity>>;
-export function addEntities<Entity, Collection extends string>(
-  entities: Entity[],
-  config: { collection: Collection; selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
 export function addEntities<
   Entity extends { id: EntityId },
-  Collection extends string
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(entities: Entity[]): PartialStateUpdater<EntityState<Entity, Id>>;
+export function addEntities<
+  Entity,
+  Collection extends string,
+  Id extends EntityId
+>(
+  entities: Entity[],
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>, Id>;
+  }
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function addEntities<
+  Entity extends { id: EntityId },
+  Collection extends string,
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
 >(
   entities: Entity[],
   config: { collection: Collection }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
-export function addEntities<Entity>(
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function addEntities<Entity, Id extends EntityId>(
   entities: Entity[],
-  config: { selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<EntityState<Entity>>;
+  config: { selectId: SelectEntityId<NoInfer<Entity>, Id> }
+): PartialStateUpdater<EntityState<Entity, Id>>;
 export function addEntities(
   entities: any[],
-  config?: { collection?: string; selectId?: SelectEntityId<any> }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  config?: { collection?: string; selectId?: SelectEntityId<any, EntityId> }
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
 

--- a/modules/signals/entities/src/updaters/add-entity.ts
+++ b/modules/signals/entities/src/updaters/add-entity.ts
@@ -13,28 +13,39 @@ import {
   getEntityUpdaterResult,
 } from '../helpers';
 
-export function addEntity<Entity extends { id: EntityId }>(
-  entity: Entity
-): PartialStateUpdater<EntityState<Entity>>;
-export function addEntity<Entity, Collection extends string>(
-  entity: Entity,
-  config: { collection: Collection; selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
 export function addEntity<
   Entity extends { id: EntityId },
-  Collection extends string
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(entity: Entity): PartialStateUpdater<EntityState<Entity, Id>>;
+export function addEntity<
+  Entity,
+  Collection extends string,
+  Id extends EntityId
+>(
+  entity: Entity,
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>, Id>;
+  }
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function addEntity<
+  Entity extends { id: EntityId },
+  Collection extends string,
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
 >(
   entity: Entity,
   config: { collection: Collection }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
-export function addEntity<Entity>(
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function addEntity<Entity, Id extends EntityId>(
   entity: Entity,
-  config: { selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<EntityState<Entity>>;
+  config: { selectId: SelectEntityId<NoInfer<Entity>, Id> }
+): PartialStateUpdater<EntityState<Entity, Id>>;
 export function addEntity(
   entity: any,
-  config?: { collection?: string; selectId?: SelectEntityId<any> }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  config?: { collection?: string; selectId?: SelectEntityId<any, EntityId> }
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
 

--- a/modules/signals/entities/src/updaters/remove-all-entities.ts
+++ b/modules/signals/entities/src/updaters/remove-all-entities.ts
@@ -1,14 +1,16 @@
 import { PartialStateUpdater } from '@ngrx/signals';
-import { EntityState, NamedEntityState } from '../models';
+import { EntityId, EntityState, NamedEntityState } from '../models';
 import { getEntityStateKeys } from '../helpers';
 
-export function removeAllEntities(): PartialStateUpdater<EntityState<any>>;
+export function removeAllEntities(): PartialStateUpdater<EntityState<any, any>>;
 export function removeAllEntities<Collection extends string>(config: {
   collection: Collection;
-}): PartialStateUpdater<NamedEntityState<any, Collection>>;
+}): PartialStateUpdater<NamedEntityState<any, Collection, any>>;
 export function removeAllEntities(config?: {
   collection?: string;
-}): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+}): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const stateKeys = getEntityStateKeys(config);
 
   return () => ({

--- a/modules/signals/entities/src/updaters/remove-entities.ts
+++ b/modules/signals/entities/src/updaters/remove-entities.ts
@@ -12,20 +12,20 @@ import {
   removeEntitiesMutably,
 } from '../helpers';
 
-export function removeEntities(
-  ids: EntityId[]
-): PartialStateUpdater<EntityState<any>>;
+export function removeEntities<Id extends EntityId>(
+  ids: Id[]
+): PartialStateUpdater<EntityState<any, Id>>;
 export function removeEntities<Entity>(
   predicate: EntityPredicate<Entity>
-): PartialStateUpdater<EntityState<Entity>>;
-export function removeEntities<Collection extends string>(
-  ids: EntityId[],
+): PartialStateUpdater<EntityState<Entity, any>>;
+export function removeEntities<Collection extends string, Id extends EntityId>(
+  ids: Id[],
   config: { collection: Collection }
-): PartialStateUpdater<NamedEntityState<any, Collection>>;
+): PartialStateUpdater<NamedEntityState<any, Collection, Id>>;
 export function removeEntities<
   Collection extends string,
-  State extends NamedEntityState<any, Collection>,
-  Entity = State extends NamedEntityState<infer E, Collection> ? E : never
+  State extends NamedEntityState<any, Collection, any>,
+  Entity = State extends NamedEntityState<infer E, Collection, any> ? E : never
 >(
   predicate: EntityPredicate<Entity>,
   config: { collection: Collection }
@@ -33,7 +33,9 @@ export function removeEntities<
 export function removeEntities(
   idsOrPredicate: EntityId[] | EntityPredicate<any>,
   config?: { collection?: string }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const stateKeys = getEntityStateKeys(config);
 
   return (state) => {

--- a/modules/signals/entities/src/updaters/remove-entity.ts
+++ b/modules/signals/entities/src/updaters/remove-entity.ts
@@ -7,17 +7,19 @@ import {
   removeEntitiesMutably,
 } from '../helpers';
 
-export function removeEntity(
-  id: EntityId
-): PartialStateUpdater<EntityState<any>>;
-export function removeEntity<Collection extends string>(
-  id: EntityId,
+export function removeEntity<Id extends EntityId>(
+  id: Id
+): PartialStateUpdater<EntityState<any, Id>>;
+export function removeEntity<Collection extends string, Id extends EntityId>(
+  id: Id,
   config: { collection: Collection }
-): PartialStateUpdater<NamedEntityState<any, Collection>>;
+): PartialStateUpdater<NamedEntityState<any, Collection, Id>>;
 export function removeEntity(
   id: EntityId,
   config?: { collection?: string }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const stateKeys = getEntityStateKeys(config);
 
   return (state) => {

--- a/modules/signals/entities/src/updaters/set-all-entities.ts
+++ b/modules/signals/entities/src/updaters/set-all-entities.ts
@@ -11,33 +11,44 @@ import {
   setEntitiesMutably,
 } from '../helpers';
 
-export function setAllEntities<Entity extends { id: EntityId }>(
-  entities: Entity[]
-): PartialStateUpdater<EntityState<Entity>>;
-export function setAllEntities<Entity, Collection extends string>(
-  entities: Entity[],
-  config: { collection: Collection; selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
 export function setAllEntities<
   Entity extends { id: EntityId },
-  Collection extends string
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(entities: Entity[]): PartialStateUpdater<EntityState<Entity, Id>>;
+export function setAllEntities<
+  Entity,
+  Collection extends string,
+  Id extends EntityId
+>(
+  entities: Entity[],
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>, Id>;
+  }
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function setAllEntities<
+  Entity extends { id: EntityId },
+  Collection extends string,
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
 >(
   entities: Entity[],
   config: { collection: Collection }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
-export function setAllEntities<Entity>(
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function setAllEntities<Entity, Id extends EntityId>(
   entities: Entity[],
-  config: { selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<EntityState<Entity>>;
+  config: { selectId: SelectEntityId<NoInfer<Entity>, Id> }
+): PartialStateUpdater<EntityState<Entity, Id>>;
 export function setAllEntities(
   entities: any[],
-  config?: { collection?: string; selectId?: SelectEntityId<any> }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  config?: { collection?: string; selectId?: SelectEntityId<any, EntityId> }
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
 
   return () => {
-    const state: EntityState<any> = { entityMap: {}, ids: [] };
+    const state: EntityState<any, EntityId> = { entityMap: {}, ids: [] };
     setEntitiesMutably(state, entities, selectId);
 
     return {

--- a/modules/signals/entities/src/updaters/set-entities.ts
+++ b/modules/signals/entities/src/updaters/set-entities.ts
@@ -13,28 +13,39 @@ import {
   setEntitiesMutably,
 } from '../helpers';
 
-export function setEntities<Entity extends { id: EntityId }>(
-  entities: Entity[]
-): PartialStateUpdater<EntityState<Entity>>;
-export function setEntities<Entity, Collection extends string>(
-  entities: Entity[],
-  config: { collection: Collection; selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
 export function setEntities<
   Entity extends { id: EntityId },
-  Collection extends string
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(entities: Entity[]): PartialStateUpdater<EntityState<Entity, Id>>;
+export function setEntities<
+  Entity,
+  Collection extends string,
+  Id extends EntityId
+>(
+  entities: Entity[],
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>, Id>;
+  }
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function setEntities<
+  Entity extends { id: EntityId },
+  Collection extends string,
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
 >(
   entities: Entity[],
   config: { collection: Collection }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
-export function setEntities<Entity>(
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function setEntities<Entity, Id extends EntityId>(
   entities: Entity[],
-  config: { selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<EntityState<Entity>>;
+  config: { selectId: SelectEntityId<NoInfer<Entity>, Id> }
+): PartialStateUpdater<EntityState<Entity, Id>>;
 export function setEntities(
   entities: any[],
-  config?: { collection?: string; selectId?: SelectEntityId<any> }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  config?: { collection?: string; selectId?: SelectEntityId<any, EntityId> }
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
 

--- a/modules/signals/entities/src/updaters/set-entity.ts
+++ b/modules/signals/entities/src/updaters/set-entity.ts
@@ -13,28 +13,39 @@ import {
   setEntityMutably,
 } from '../helpers';
 
-export function setEntity<Entity extends { id: EntityId }>(
-  entity: Entity
-): PartialStateUpdater<EntityState<Entity>>;
-export function setEntity<Entity, Collection extends string>(
-  entity: Entity,
-  config: { collection: Collection; selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
 export function setEntity<
   Entity extends { id: EntityId },
-  Collection extends string
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(entity: Entity): PartialStateUpdater<EntityState<Entity, Id>>;
+export function setEntity<
+  Entity,
+  Collection extends string,
+  Id extends EntityId
+>(
+  entity: Entity,
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>, Id>;
+  }
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function setEntity<
+  Entity extends { id: EntityId },
+  Collection extends string,
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
 >(
   entity: Entity,
   config: { collection: Collection }
-): PartialStateUpdater<NamedEntityState<Entity, Collection>>;
-export function setEntity<Entity>(
+): PartialStateUpdater<NamedEntityState<Entity, Collection, Id>>;
+export function setEntity<Entity, Id extends EntityId>(
   entity: Entity,
-  config: { selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<EntityState<Entity>>;
+  config: { selectId: SelectEntityId<NoInfer<Entity>, Id> }
+): PartialStateUpdater<EntityState<Entity, Id>>;
 export function setEntity(
   entity: any,
-  config?: { collection?: string; selectId?: SelectEntityId<any> }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  config?: { collection?: string; selectId?: SelectEntityId<any, EntityId> }
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
 

--- a/modules/signals/entities/src/updaters/update-all-entities.ts
+++ b/modules/signals/entities/src/updaters/update-all-entities.ts
@@ -16,39 +16,55 @@ import {
 
 export function updateAllEntities<
   Collection extends string,
-  State extends NamedEntityState<any, Collection>,
-  Entity = State extends NamedEntityState<infer E, Collection> ? E : never
+  State extends NamedEntityState<any, Collection, Id>,
+  Id extends EntityId,
+  Entity = State extends NamedEntityState<infer E, Collection, Id> ? E : never
 >(
   changes: EntityChanges<NoInfer<Entity>>,
   config: {
     collection: Collection;
-    selectId: SelectEntityId<NoInfer<Entity>>;
+    selectId: SelectEntityId<NoInfer<Entity>, Id>;
   }
 ): PartialStateUpdater<State>;
 export function updateAllEntities<
   Collection extends string,
-  State extends NamedEntityState<any, Collection>,
+  State extends NamedEntityState<any, Collection, Id>,
   Entity = State extends NamedEntityState<
     infer E extends { id: EntityId },
-    Collection
+    Collection,
+    EntityId
   >
     ? E
+    : never,
+  Id extends EntityId = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection,
+    EntityId
+  >
+    ? E extends { id: infer T }
+      ? T
+      : never
     : never
 >(
   changes: EntityChanges<NoInfer<Entity>>,
   config: { collection: Collection }
 ): PartialStateUpdater<State>;
-export function updateAllEntities<Entity>(
+export function updateAllEntities<Entity, Id extends EntityId>(
   changes: EntityChanges<NoInfer<Entity>>,
-  config: { selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<EntityState<Entity>>;
-export function updateAllEntities<Entity extends { id: EntityId }>(
+  config: { selectId: SelectEntityId<NoInfer<Entity>, Id> }
+): PartialStateUpdater<EntityState<Entity, Id>>;
+export function updateAllEntities<
+  Entity extends { id: EntityId },
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(
   changes: EntityChanges<NoInfer<Entity>>
-): PartialStateUpdater<EntityState<Entity>>;
+): PartialStateUpdater<EntityState<Entity, Id>>;
 export function updateAllEntities(
   changes: EntityChanges<any>,
-  config?: { collection?: string; selectId?: SelectEntityId<any> }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  config?: { collection?: string; selectId?: SelectEntityId<any, EntityId> }
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
 

--- a/modules/signals/entities/src/updaters/update-entities.ts
+++ b/modules/signals/entities/src/updaters/update-entities.ts
@@ -17,92 +17,132 @@ import {
 
 export function updateEntities<
   Collection extends string,
-  State extends NamedEntityState<any, Collection>,
-  Entity = State extends NamedEntityState<infer E, Collection> ? E : never
+  State extends NamedEntityState<any, Collection, Id>,
+  Id extends EntityId,
+  Entity = State extends NamedEntityState<infer E, Collection, Id> ? E : never
 >(
   update: {
-    ids: EntityId[];
+    ids: Id[];
     changes: EntityChanges<NoInfer<Entity>>;
   },
   config: {
     collection: Collection;
-    selectId: SelectEntityId<NoInfer<Entity>>;
+    selectId: SelectEntityId<NoInfer<Entity>, Id>;
   }
 ): PartialStateUpdater<State>;
 export function updateEntities<
   Collection extends string,
-  State extends NamedEntityState<any, Collection>,
-  Entity = State extends NamedEntityState<infer E, Collection> ? E : never
->(
-  update: {
-    predicate: EntityPredicate<Entity>;
-    changes: EntityChanges<NoInfer<Entity>>;
-  },
-  config: {
-    collection: Collection;
-    selectId: SelectEntityId<NoInfer<Entity>>;
-  }
-): PartialStateUpdater<State>;
-export function updateEntities<
-  Collection extends string,
-  State extends NamedEntityState<any, Collection>,
-  Entity = State extends NamedEntityState<
-    infer E extends { id: EntityId },
-    Collection
-  >
+  State extends NamedEntityState<any, Collection, Id>,
+  Entity = State extends NamedEntityState<infer E, Collection, EntityId>
     ? E
-    : never
->(
-  update: {
-    ids: EntityId[];
-    changes: EntityChanges<NoInfer<Entity>>;
-  },
-  config: { collection: Collection }
-): PartialStateUpdater<State>;
-export function updateEntities<
-  Collection extends string,
-  State extends NamedEntityState<any, Collection>,
-  Entity = State extends NamedEntityState<
-    infer E extends { id: EntityId },
-    Collection
+    : never,
+  Id extends EntityId = State extends NamedEntityState<
+    infer E,
+    Collection,
+    EntityId
   >
-    ? E
+    ? E extends { id: infer T }
+      ? T
+      : never
     : never
 >(
   update: {
     predicate: EntityPredicate<Entity>;
     changes: EntityChanges<NoInfer<Entity>>;
   },
-  config: { collection: Collection }
+  config: {
+    collection: Collection;
+    selectId: SelectEntityId<NoInfer<Entity>, Id>;
+  }
 ): PartialStateUpdater<State>;
-export function updateEntities<Entity>(
+export function updateEntities<
+  Collection extends string,
+  State extends NamedEntityState<any, Collection, Id>,
+  Entity = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection,
+    EntityId
+  >
+    ? E
+    : never,
+  Id extends EntityId = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection,
+    EntityId
+  >
+    ? E extends { id: infer T }
+      ? T
+      : never
+    : never
+>(
   update: {
-    ids: EntityId[];
+    ids: Id[];
     changes: EntityChanges<NoInfer<Entity>>;
   },
-  config: { selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<EntityState<Entity>>;
-export function updateEntities<Entity>(
+  config: { collection: Collection }
+): PartialStateUpdater<State>;
+export function updateEntities<
+  Collection extends string,
+  State extends NamedEntityState<any, Collection, Id>,
+  Entity = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection,
+    EntityId
+  >
+    ? E
+    : never,
+  Id extends EntityId = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection,
+    EntityId
+  >
+    ? E extends { id: infer T }
+      ? T
+      : never
+    : never
+>(
   update: {
     predicate: EntityPredicate<Entity>;
     changes: EntityChanges<NoInfer<Entity>>;
   },
-  config: { selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<EntityState<Entity>>;
-export function updateEntities<Entity extends { id: EntityId }>(update: {
-  ids: EntityId[];
+  config: { collection: Collection }
+): PartialStateUpdater<State>;
+export function updateEntities<Entity, Id extends EntityId>(
+  update: {
+    ids: Id[];
+    changes: EntityChanges<NoInfer<Entity>>;
+  },
+  config: { selectId: SelectEntityId<NoInfer<Entity>, Id> }
+): PartialStateUpdater<EntityState<Entity, Id>>;
+export function updateEntities<Entity, Id extends EntityId>(
+  update: {
+    predicate: EntityPredicate<Entity>;
+    changes: EntityChanges<NoInfer<Entity>>;
+  },
+  config: { selectId: SelectEntityId<NoInfer<Entity>, Id> }
+): PartialStateUpdater<EntityState<Entity, Id>>;
+export function updateEntities<
+  Entity extends { id: EntityId },
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(update: {
+  ids: Id[];
   changes: EntityChanges<NoInfer<Entity>>;
-}): PartialStateUpdater<EntityState<Entity>>;
-export function updateEntities<Entity extends { id: EntityId }>(update: {
+}): PartialStateUpdater<EntityState<Entity, Id>>;
+export function updateEntities<
+  Entity extends { id: EntityId },
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(update: {
   predicate: EntityPredicate<Entity>;
   changes: EntityChanges<NoInfer<Entity>>;
-}): PartialStateUpdater<EntityState<Entity>>;
+}): PartialStateUpdater<EntityState<Entity, Id>>;
 export function updateEntities(
   update: ({ ids: EntityId[] } | { predicate: EntityPredicate<any> }) & {
     changes: EntityChanges<any>;
   },
-  config?: { collection?: string; selectId?: SelectEntityId<any> }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  config?: { collection?: string; selectId?: SelectEntityId<any, EntityId> }
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
   const idsOrPredicate = 'ids' in update ? update.ids : update.predicate;

--- a/modules/signals/entities/src/updaters/update-entity.ts
+++ b/modules/signals/entities/src/updaters/update-entity.ts
@@ -16,52 +16,68 @@ import {
 
 export function updateEntity<
   Collection extends string,
-  State extends NamedEntityState<any, Collection>,
-  Entity = State extends NamedEntityState<infer E, Collection> ? E : never
+  State extends NamedEntityState<any, Collection, Id>,
+  Id extends EntityId,
+  Entity = State extends NamedEntityState<infer E, Collection, Id> ? E : never
 >(
   update: {
-    id: EntityId;
+    id: Id;
     changes: EntityChanges<NoInfer<Entity>>;
   },
   config: {
     collection: Collection;
-    selectId: SelectEntityId<NoInfer<Entity>>;
+    selectId: SelectEntityId<NoInfer<Entity>, Id>;
   }
 ): PartialStateUpdater<State>;
 export function updateEntity<
   Collection extends string,
-  State extends NamedEntityState<any, Collection>,
+  State extends NamedEntityState<any, Collection, Id>,
   Entity = State extends NamedEntityState<
     infer E extends { id: EntityId },
-    Collection
+    Collection,
+    EntityId
   >
     ? E
+    : never,
+  Id extends EntityId = State extends NamedEntityState<
+    infer E extends { id: EntityId },
+    Collection,
+    EntityId
+  >
+    ? E extends { id: infer T }
+      ? T
+      : never
     : never
 >(
   update: {
-    id: EntityId;
+    id: Id;
     changes: EntityChanges<NoInfer<Entity>>;
   },
   config: { collection: Collection }
 ): PartialStateUpdater<State>;
-export function updateEntity<Entity>(
+export function updateEntity<Entity, Id extends EntityId>(
   update: {
-    id: EntityId;
+    id: Id;
     changes: EntityChanges<NoInfer<Entity>>;
   },
-  config: { selectId: SelectEntityId<NoInfer<Entity>> }
-): PartialStateUpdater<EntityState<Entity>>;
-export function updateEntity<Entity extends { id: EntityId }>(update: {
-  id: EntityId;
+  config: { selectId: SelectEntityId<NoInfer<Entity>, Id> }
+): PartialStateUpdater<EntityState<Entity, Id>>;
+export function updateEntity<
+  Entity extends { id: EntityId },
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(update: {
+  id: Id;
   changes: EntityChanges<NoInfer<Entity>>;
-}): PartialStateUpdater<EntityState<Entity>>;
+}): PartialStateUpdater<EntityState<Entity, Id>>;
 export function updateEntity(
   update: {
     id: EntityId;
     changes: EntityChanges<any>;
   },
-  config?: { collection?: string; selectId?: SelectEntityId<any> }
-): PartialStateUpdater<EntityState<any> | NamedEntityState<any, string>> {
+  config?: { collection?: string; selectId?: SelectEntityId<any, EntityId> }
+): PartialStateUpdater<
+  EntityState<any, EntityId> | NamedEntityState<any, string, EntityId>
+> {
   const selectId = getEntityIdSelector(config);
   const stateKeys = getEntityStateKeys(config);
 

--- a/modules/signals/entities/src/with-entities.ts
+++ b/modules/signals/entities/src/with-entities.ts
@@ -13,34 +13,72 @@ import {
   EntityState,
   NamedEntityProps,
   NamedEntityState,
+  SelectEntityId,
 } from './models';
 import { getEntityStateKeys } from './helpers';
 
-export function withEntities<Entity>(): SignalStoreFeature<
+export function withEntities<
+  Entity extends { id: EntityId },
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(): SignalStoreFeature<
   EmptyFeatureResult,
   {
-    state: EntityState<Entity>;
+    state: EntityState<Entity, Id>;
     props: EntityProps<Entity>;
     methods: {};
   }
 >;
-export function withEntities<Entity, Collection extends string>(config: {
+export function withEntities<
+  Entity,
+  Collection extends string,
+  Id extends EntityId
+>(config: {
+  entity: Entity;
+  collection: Collection;
+  selectId: SelectEntityId<NoInfer<Entity>, Id>;
+}): SignalStoreFeature<
+  EmptyFeatureResult,
+  {
+    state: NamedEntityState<Entity, Collection, Id>;
+    props: NamedEntityProps<Entity, Collection>;
+    methods: {};
+  }
+>;
+export function withEntities<
+  Entity extends { id: EntityId },
+  Collection extends string,
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(config: {
   entity: Entity;
   collection: Collection;
 }): SignalStoreFeature<
   EmptyFeatureResult,
   {
-    state: NamedEntityState<Entity, Collection>;
+    state: NamedEntityState<Entity, Collection, Id>;
     props: NamedEntityProps<Entity, Collection>;
     methods: {};
   }
 >;
-export function withEntities<Entity>(config: {
+export function withEntities<Entity, Id extends EntityId>(config: {
+  entity: Entity;
+  selectId: SelectEntityId<NoInfer<Entity>, Id>;
+}): SignalStoreFeature<
+  EmptyFeatureResult,
+  {
+    state: EntityState<Entity, Id>;
+    props: EntityProps<Entity>;
+    methods: {};
+  }
+>;
+export function withEntities<
+  Entity extends { id: EntityId },
+  Id extends EntityId = Entity extends { id: infer E } ? E : never
+>(config: {
   entity: Entity;
 }): SignalStoreFeature<
   EmptyFeatureResult,
   {
-    state: EntityState<Entity>;
+    state: EntityState<Entity, Id>;
     props: EntityProps<Entity>;
     methods: {};
   }
@@ -58,7 +96,7 @@ export function withEntities<Entity>(config?: {
     }),
     withComputed((store: Record<string, Signal<unknown>>) => ({
       [entitiesKey]: computed(() => {
-        const entityMap = store[entityMapKey]() as EntityMap<Entity>;
+        const entityMap = store[entityMapKey]() as EntityMap<Entity, EntityId>;
         const ids = store[idsKey]() as EntityId[];
 
         return ids.map((id) => entityMap[id]);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

Closes https://github.com/ngrx/platform/issues/4570

## Does this PR introduce a breaking change?

```
[X] Yes
[ ] No
```

## Additional info

I have already submitted [this PR](https://github.com/ngrx/platform/pull/4735), but after further consideration, I came up with an alternative solution. I prefer this new approach because `EntityId` is more narrowly typed and properly inferred. However, it introduces breaking changes...