### PR TITLE
docs(ngrx/signals): mention re-use of `withComputed/withMethods`

### DIFF
--- a/projects/ngrx.io/content/guide/signals/signal-store/index.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/index.md
@@ -285,6 +285,38 @@ export const BooksStore = signalStore(
 
 </code-example>
 
+<div class="alert is-helpful">
+
+It may be necessary for a computed in a `withComputed` feature to need to reference another computed value, 
+or a method in a `withMethods` feature to refer to another method. To do so, either: 
+
+(A) Create another `withComputed` feature  or `withMethods` feature, or 
+
+(B) Break out the common piece with a helper `const`.
+
+```ts
+export const BooksStore = signalStore(
+  withState(initialState),
+  // 👇 Accessing previously defined state signals and properties.
+  withComputed(({ books, filter }) => ({
+    booksCount: computed(() => books().length),
+    sortDirection: computed(() => filter.order() === 'asc' ? 1 : -1),
+  })),
+  // 👇 (A) Also access previously defined computed properties (or functions).
+  withComputed(({ books, sortDirection }) => {
+    // 👇 (B) Define helper functions (or computeds).
+    const sortBooks = (direction: number) =>
+      books().toSorted((a, b) => direction * a.title.localeCompare(b.title));
+
+    return {
+      sortedBooks: computed(() => sortBooks(sortDirection())),
+      reversedBooks: computed(() => sortBooks(-1 * sortDirection())),
+    };
+  }),
+);
+```
+</div>
+
 ### Reactive Store Methods
 
 In more complex scenarios, opting for RxJS to handle asynchronous side effects is advisable.


### PR DESCRIPTION
Issue: https://github.com/ngrx/platform/issues/4669

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue: [docs(@ngrx/signals): add a mention of restructuring withComputed or withMethods for re-use in those features](https://github.com/ngrx/platform/issues/4669)

Closes #4669

## What is the new behavior?

Documentation mentions how to re-use a computed or function across or within a `withComputed` or `withMethods`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```