### PR TITLE
test(signals): improve signalMethod injector tests

### DIFF
--- a/modules/signals/spec/signal-method.spec.ts
+++ b/modules/signals/spec/signal-method.spec.ts
@@ -103,11 +103,11 @@ describe('signalMethod', () => {
       childInjector.destroy();
 
       summand1.set(2);
-      summand2.set(2);
+      summand2.set(3);
       TestBed.flushEffects();
 
       adder.destroy();
-      expect(a).toBe(4);
+      expect(a).toBe(7);
     });
 
     it('uses the provided injector (source injector) on creation', () => {
@@ -123,6 +123,7 @@ describe('signalMethod', () => {
 
       adder(value);
       TestBed.flushEffects();
+      expect(a).toBe(2);
 
       sourceInjector.destroy();
       value.set(2);


### PR DESCRIPTION
Small improvements in signal method tests:
- Test "does not cause issues if destroyed signalMethodFn contains destroyed effectRefs" - summand2 should be set with different value so the effect is triggered for summand2 and it is not triggered for summand1, which uses the detroyed Injector. Otherwise it causes confusion that may be also the second summand is not "observed" from the effect. It is, but the set is called with the same value.
- Test "uses the provided injector (source injector) on creation" - one small additional same expect to show that after the destroy of Injector, the signal is not tracked in the effect.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
