### PR TITLE
feat(signals): add ability to pass arrays of updaters to patchState

### DIFF
--- a/modules/signals/spec/state-source.spec.ts
+++ b/modules/signals/spec/state-source.spec.ts
@@ -17,7 +17,6 @@ import {
   withHooks,
   withMethods,
   withState,
-  WritableStateSource,
 } from '../src';
 import { STATE_SOURCE } from '../src/state-source';
 import { createLocalService } from './helpers';
@@ -95,6 +94,25 @@ describe('StateSource', () => {
             numbers: [...state.numbers, 4],
             ngrx: 'rocks',
           }));
+
+          expect(state[STATE_SOURCE]()).toEqual({
+            ...initialState,
+            numbers: [1, 2, 3, 4],
+            ngrx: 'rocks',
+          });
+        });
+
+        it('patches state via multiple updater functions', () => {
+          const state = stateFactory();
+
+          patchState(state, [
+            (state) => ({
+              numbers: [...state.numbers, 4],
+            }),
+            () => ({
+              ngrx: 'rocks',
+            }),
+          ]);
 
           expect(state[STATE_SOURCE]()).toEqual({
             ...initialState,

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -44,9 +44,15 @@ export function isWritableStateSource<State extends object>(
 export function patchState<State extends object>(
   stateSource: WritableStateSource<State>,
   ...updaters: Array<
-    Partial<Prettify<State>> | PartialStateUpdater<Prettify<State>>
+    | Partial<Prettify<State>>
+    | PartialStateUpdater<Prettify<State>>
+    | PartialStateUpdater<Prettify<State>>[]
   >
 ): void {
+  updaters = updaters.flat() as Array<
+    Partial<Prettify<State>> | PartialStateUpdater<Prettify<State>>
+  >;
+
   stateSource[STATE_SOURCE].update((currentState) =>
     updaters.reduce(
       (nextState: State, updater) => ({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

We should use spread operator to unwrap arrays of updaters.

Closes #4783

## What is the new behavior?

We can pass arrays of updaters as is.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
