### PR TITLE
test(signals): improve tests with mockImplementation without param

### DIFF
--- a/modules/signals/spec/with-computed.spec.ts
+++ b/modules/signals/spec/with-computed.spec.ts
@@ -36,7 +36,7 @@ describe('withComputed', () => {
       })),
     ].reduce((acc, feature) => feature(acc), getInitialInnerStore());
     const s2 = signal(10).asReadonly();
-    vi.spyOn(console, 'warn').mockImplementation();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     withComputed(() => ({
       p: signal(0).asReadonly(),

--- a/modules/signals/spec/with-methods.spec.ts
+++ b/modules/signals/spec/with-methods.spec.ts
@@ -38,7 +38,7 @@ describe('withMethods', () => {
       })),
     ].reduce((acc, feature) => feature(acc), getInitialInnerStore());
     const m2 = () => 10;
-    vi.spyOn(console, 'warn').mockImplementation();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     withMethods(() => ({
       p() {},

--- a/modules/signals/spec/with-props.spec.ts
+++ b/modules/signals/spec/with-props.spec.ts
@@ -35,7 +35,7 @@ describe('withProps', () => {
         [METHOD_SECRET]() {},
       })),
     ].reduce((acc, feature) => feature(acc), getInitialInnerStore());
-    vi.spyOn(console, 'warn').mockImplementation();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     withProps(() => ({
       s1: { foo: 'bar' },

--- a/modules/signals/spec/with-state.spec.ts
+++ b/modules/signals/spec/with-state.spec.ts
@@ -73,7 +73,7 @@ describe('withState', () => {
         [METHOD_SECRET]() {},
       })),
     ].reduce((acc, feature) => feature(acc), getInitialInnerStore());
-    vi.spyOn(console, 'warn').mockImplementation();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     withState(() => ({
       p2: 100,


### PR DESCRIPTION
Small improvements in tests - after migration from jest to vitest, there are still calls to mockImplementation without corresponding param, which is required. It should have respective param, otherwise IDEs (mine is VS Code) shows errors. The tests run successfully also without this fix, but the code base would be cleaner.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Tests run successfully, but IDEs show errors.

Closes #

## What is the new behavior?

Tests run successfully and no error in IDEs.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
