### PR TITLE
feat(signals): add `withLinkedState()`

### DIFF
--- a/modules/signals/spec/signal-store.spec.ts
+++ b/modules/signals/spec/signal-store.spec.ts
@@ -3,14 +3,18 @@ import {
   inject,
   InjectionToken,
   isSignal,
+  linkedSignal,
   signal,
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
+  getState,
   patchState,
   signalStore,
+  signalStoreFeature,
   withComputed,
   withHooks,
+  withLinkedState,
   withMethods,
   withProps,
   withState,
@@ -563,6 +567,231 @@ describe('signalStore', () => {
       expect(secretStore.reveil()).toBe('not your business');
       expect(secretStore.secret()).toBe('not your business');
       expect(secretStore[SECRET]).toBe('not your business');
+    });
+  });
+
+  describe('withLinkedState', () => {
+    describe('updates automatically if the source changes', () =>
+      [
+        {
+          name: 'automatic',
+          linkedStateFeature: signalStoreFeature(
+            withState({ userId: 1 }),
+
+            withLinkedState(({ userId }) => ({
+              books: () => {
+                userId();
+
+                return [] as string[];
+              },
+            }))
+          ),
+        },
+        {
+          name: 'manual',
+          linkedStateFeature: signalStoreFeature(
+            withState({ userId: 1 }),
+            withLinkedState(({ userId }) => ({
+              books: linkedSignal({
+                source: userId,
+                computation: () => [] as string[],
+              }),
+            }))
+          ),
+        },
+      ].forEach(({ name, linkedStateFeature }) => {
+        it(name, () => {
+          const BookStore = signalStore(
+            { providedIn: 'root', protectedState: false },
+            linkedStateFeature,
+            withState({ version: 1 }),
+            withMethods((store) => ({
+              updateUser() {
+                patchState(store, (value) => value);
+                patchState(store, ({ userId }) => ({ userId: userId + 1 }));
+              },
+              addBook(title: string) {
+                patchState(store, ({ books }) => ({
+                  books: [...books, title],
+                }));
+              },
+              increaseVersion() {
+                patchState(store, ({ version }) => ({ version: version + 1 }));
+              },
+            }))
+          );
+
+          const bookStore = TestBed.inject(BookStore);
+          bookStore.addBook('The Neverending Story');
+          bookStore.increaseVersion();
+          expect(bookStore.books()).toEqual(['The Neverending Story']);
+          expect(bookStore.version()).toEqual(2);
+
+          patchState(bookStore, { userId: 2 });
+          expect(bookStore.books()).toEqual([]);
+          expect(bookStore.version()).toEqual(2);
+        });
+      }));
+
+    describe('updates also a spread linkedSignal', () => {
+      [
+        {
+          name: 'automatic',
+          linkedStateFeature: signalStoreFeature(
+            withState({ userId: 1 }),
+            withLinkedState(({ userId }) => ({
+              user: () => {
+                userId();
+                return { name: 'John Doe' };
+              },
+              location: () => {
+                userId();
+                return { city: 'Berlin', country: 'Germany' };
+              },
+            }))
+          ),
+        },
+        {
+          name: 'manual',
+          linkedStateFeature: signalStoreFeature(
+            withState({ userId: 1 }),
+            withLinkedState(({ userId }) => ({
+              user: linkedSignal({
+                source: userId,
+                computation: () => ({ name: 'John Doe' }),
+              }),
+              location: linkedSignal({
+                source: userId,
+                computation: () => ({ city: 'Berlin', country: 'Germany' }),
+              }),
+            }))
+          ),
+        },
+      ].forEach(({ name, linkedStateFeature }) => {
+        it(name, () => {
+          const UserStore = signalStore(
+            { providedIn: 'root', protectedState: false },
+            linkedStateFeature,
+            withMethods((store) => ({
+              updateUser(name: string) {
+                patchState(store, () => ({
+                  user: { name },
+                }));
+              },
+              updateLocation(city: string, country: string) {
+                patchState(store, () => ({
+                  location: { city, country },
+                }));
+              },
+            }))
+          );
+
+          const userStore = TestBed.inject(UserStore);
+
+          userStore.updateUser('Jane Doe');
+          userStore.updateLocation('London', 'UK');
+
+          expect(getState(userStore)).toEqual({
+            userId: 1,
+            user: { name: 'Jane Doe' },
+            location: { city: 'London', country: 'UK' },
+          });
+
+          patchState(userStore, { userId: 2 });
+          expect(getState(userStore)).toEqual({
+            userId: 2,
+            user: { name: 'John Doe' },
+            location: { city: 'Berlin', country: 'Germany' },
+          });
+        });
+      });
+    });
+
+    describe('can depend on a Signal from another SignalStore', () => {
+      const UserStore = signalStore(
+        { providedIn: 'root', protectedState: false },
+        withState({ userId: 1 })
+      );
+
+      [
+        {
+          name: 'automatic',
+          linkedStateFeature: signalStoreFeature(
+            withLinkedState(() => ({
+              books: () => {
+                TestBed.inject(UserStore).userId();
+
+                return [] as string[];
+              },
+            }))
+          ),
+        },
+        {
+          name: 'manual',
+          linkedStateFeature: signalStoreFeature(
+            withLinkedState(() => {
+              const userStore = TestBed.inject(UserStore);
+
+              return {
+                books: linkedSignal({
+                  source: userStore.userId,
+                  computation: () => [] as string[],
+                }),
+              };
+            })
+          ),
+        },
+      ].forEach(({ name, linkedStateFeature }) => {
+        it(name, () => {
+          const BookStore = signalStore(
+            { providedIn: 'root' },
+            linkedStateFeature,
+            withMethods((store) => ({
+              addBook(title: string) {
+                patchState(store, ({ books }) => ({
+                  books: [...books, title],
+                }));
+              },
+            }))
+          );
+
+          const userStore = TestBed.inject(UserStore);
+          const bookStore = TestBed.inject(BookStore);
+
+          bookStore.addBook('The Neverending Story');
+          expect(bookStore.books()).toEqual(['The Neverending Story']);
+
+          patchState(userStore, { userId: 2 });
+
+          expect(bookStore.books()).toEqual([]);
+        });
+      });
+    });
+
+    describe('InnerSignalStore access', () => {
+      it('can access the state signals', () => {
+        const UserStore = signalStore(
+          { providedIn: 'root' },
+          withState({ userId: 1 }),
+          withLinkedState(({ userId }) => ({ value: userId }))
+        );
+
+        const userStore = TestBed.inject(UserStore);
+
+        expect(userStore.value()).toBe(1);
+      });
+
+      it('can access the props', () => {
+        const UserStore = signalStore(
+          { providedIn: 'root' },
+          withProps(() => ({ userId: 1 })),
+          withLinkedState(({ userId }) => ({ value: () => userId }))
+        );
+
+        const userStore = TestBed.inject(UserStore);
+
+        expect(userStore.value()).toBe(1);
+      });
     });
   });
 });

--- a/modules/signals/spec/state-source.spec.ts
+++ b/modules/signals/spec/state-source.spec.ts
@@ -211,7 +211,7 @@ describe('StateSource', () => {
       });
     });
 
-    it("sets all root properties and relies on the Signal's equals function", () => {
+    it('sets only root properties which values have changed (equal check)', () => {
       let updateCounter = 0;
       const userSignal = signal(
         {
@@ -235,18 +235,18 @@ describe('StateSource', () => {
       expect(updateCounter).toBe(0);
 
       patchState(store, { city: 'Xian' });
-      expect(updateCounter).toBe(1);
+      expect(updateCounter).toBe(0);
 
       patchState(store, (state) => state);
-      expect(updateCounter).toBe(2);
+      expect(updateCounter).toBe(0);
 
       patchState(store, ({ user }) => ({ user }));
-      expect(updateCounter).toBe(3);
+      expect(updateCounter).toBe(0);
 
       patchState(store, ({ user }) => ({
         user: { ...user, firstName: 'Jane' },
       }));
-      expect(updateCounter).toBe(4);
+      expect(updateCounter).toBe(1);
     });
   });
 

--- a/modules/signals/spec/state-source.spec.ts
+++ b/modules/signals/spec/state-source.spec.ts
@@ -294,6 +294,27 @@ describe('StateSource', () => {
         TestBed.tick();
         expect(executionCount).toBe(2);
       });
+
+      it('does not support a dynamic type as state', () => {
+        const Store = signalStore(
+          { providedIn: 'root' },
+          withState<Record<number, number>>({}),
+          withMethods((store) => ({
+            addNumber(num: number): void {
+              patchState(store, {
+                [num]: num,
+              });
+            },
+          }))
+        );
+        const store = TestBed.inject(Store);
+
+        store.addNumber(1);
+        store.addNumber(2);
+        store.addNumber(3);
+
+        expect(getState(store)).toEqual({});
+      });
     });
 
     it('does not support a dynamic dictionary as state', () => {

--- a/modules/signals/spec/types/with-linked-state.types.spec.ts
+++ b/modules/signals/spec/types/with-linked-state.types.spec.ts
@@ -1,0 +1,158 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './helpers';
+
+describe('patchState', () => {
+  const expectSnippet = expecter(
+    (code) => `
+        import { computed, inject, linkedSignal, Signal, signal } from '@angular/core';
+        import {
+          patchState,
+          signalStore,
+          withState,
+          withLinkedState,
+          withMethods
+        } from '@ngrx/signals';
+
+        ${code}
+      `,
+    compilerOptions()
+  );
+
+  it('does not have access to methods', () => {
+    const snippet = `
+      signalStore(
+        withMethods(() => ({
+          foo: () => 'bar',
+        })),
+        withLinkedState(({ foo }) => ({ value: foo() }))
+      );
+      `;
+
+    expectSnippet(snippet).toFail(/Property 'foo' does not exist on type '{}'/);
+  });
+
+  it('does not have access to STATE_SOURCE', () => {
+    const snippet = `
+      signalStore(
+        withState({ foo: 'bar' }),
+        withLinkedState((store) => {
+          patchState(store, { foo: 'baz' });
+          return { bar: 'foo' };
+        })
+      )
+      `;
+
+    expectSnippet(snippet).toFail(
+      /is not assignable to parameter of type 'WritableStateSource<object>'./
+    );
+  });
+
+  it('cannot return a primitive value', () => {
+    const snippet = `
+      signalStore(
+        withLinkedState(() => ({ foo: 'bar' }))
+      )
+      `;
+
+    expectSnippet(snippet).toFail(
+      /Type 'string' is not assignable to type 'WritableSignal<unknown> | (() => unknown)'./
+    );
+  });
+
+  it('resolves to a normal state signal with automatic linkedSignal', () => {
+    const snippet = `
+      const UserStore = signalStore(
+        { providedIn: 'root' },
+        withLinkedState(() => ({ firstname: () => 'John', lastname: () => 'Doe' }))
+      );
+
+      const userStore = new UserStore();
+
+      const firstname = userStore.firstname;
+      const lastname = userStore.lastname;
+    `;
+
+    expectSnippet(snippet).toSucceed();
+
+    expectSnippet(snippet).toInfer('firstname', 'Signal<string>');
+    expectSnippet(snippet).toInfer('lastname', 'Signal<string>');
+  });
+
+  it('resolves to a normal state signal with manual linkedSignal', () => {
+    const snippet = `
+      const UserStore = signalStore(
+        { providedIn: 'root' },
+        withLinkedState(() => ({
+          firstname: linkedSignal(() => 'John'),
+          lastname: linkedSignal(() => 'Doe')
+        }))
+      );
+
+      const userStore = new UserStore();
+
+      const firstname = userStore.firstname;
+      const lastname = userStore.lastname;
+    `;
+
+    expectSnippet(snippet).toSucceed();
+
+    expectSnippet(snippet).toInfer('firstname', 'Signal<string>');
+    expectSnippet(snippet).toInfer('lastname', 'Signal<string>');
+  });
+
+  it('should set stateSignals as DeepSignal for automatic linkedSignal', () => {
+    const snippet = `
+      const UserStore = signalStore(
+        { providedIn: 'root' },
+        withLinkedState(() => ({
+          user: () => ({ id: 1, name: 'John Doe' }),
+          location: () => ({ city: 'Berlin', country: 'Germany' }),
+        }))
+      );
+
+      const userStore = new UserStore();
+
+      const location = userStore.location;
+      const user = userStore.user;
+    `;
+
+    expectSnippet(snippet).toSucceed();
+
+    expectSnippet(snippet).toInfer(
+      'location',
+      'DeepSignal<{ city: string; country: string; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'user',
+      'DeepSignal<{ id: number; name: string; }>'
+    );
+  });
+
+  it('should set stateSignals as DeepSignal for manual linkedSignal', () => {
+    const snippet = `
+      const UserStore = signalStore(
+        { providedIn: 'root' },
+        withLinkedState(() => ({
+          user: linkedSignal(() => ({ id: 1, name: 'John Doe' })),
+          location: linkedSignal(() => ({ city: 'Berlin', country: 'Germany' })),
+        }))
+      );
+
+      const userStore = new UserStore();
+
+      const location = userStore.location;
+      const user = userStore.user;
+    `;
+
+    expectSnippet(snippet).toSucceed();
+
+    expectSnippet(snippet).toInfer(
+      'location',
+      'DeepSignal<{ city: string; country: string; }>'
+    );
+    expectSnippet(snippet).toInfer(
+      'user',
+      'DeepSignal<{ id: number; name: string; }>'
+    );
+  });
+});

--- a/modules/signals/spec/types/with-linked-state.types.spec.ts
+++ b/modules/signals/spec/types/with-linked-state.types.spec.ts
@@ -1,7 +1,7 @@
 import { expecter } from 'ts-snippet';
 import { compilerOptions } from './helpers';
 
-describe('patchState', () => {
+describe('withLinkedState', () => {
   const expectSnippet = expecter(
     (code) => `
         import { computed, inject, linkedSignal, Signal, signal } from '@angular/core';

--- a/modules/signals/spec/types/with-linked-state.types.spec.ts
+++ b/modules/signals/spec/types/with-linked-state.types.spec.ts
@@ -1,5 +1,6 @@
 import { expecter } from 'ts-snippet';
 import { compilerOptions } from './helpers';
+import { signalStore, withLinkedState, withState } from '@ngrx/signals';
 
 describe('withLinkedState', () => {
   const expectSnippet = expecter(
@@ -100,7 +101,7 @@ describe('withLinkedState', () => {
     expectSnippet(snippet).toInfer('lastname', 'Signal<string>');
   });
 
-  it('should set stateSignals as DeepSignal for automatic linkedSignal', () => {
+  it('sets stateSignals as DeepSignal for automatic linkedSignal', () => {
     const snippet = `
       const UserStore = signalStore(
         { providedIn: 'root' },
@@ -128,7 +129,7 @@ describe('withLinkedState', () => {
     );
   });
 
-  it('should set stateSignals as DeepSignal for manual linkedSignal', () => {
+  it('sets stateSignals as DeepSignal for manual linkedSignal', () => {
     const snippet = `
       const UserStore = signalStore(
         { providedIn: 'root' },
@@ -154,5 +155,27 @@ describe('withLinkedState', () => {
       'user',
       'DeepSignal<{ id: number; name: string; }>'
     );
+  });
+
+  it('infers the types for a mixed setting', () => {
+    const snippet = `
+      const Store = signalStore(
+        withState({ foo: 'bar' }),
+        withLinkedState(({ foo }) => ({
+          bar: () => foo(),
+          baz: linkedSignal(() => foo()),
+        }))
+      );
+
+      const store = new Store();
+
+      const bar = store.bar;
+      const baz = store.baz;
+    `;
+
+    expectSnippet(snippet).toSucceed();
+
+    expectSnippet(snippet).toInfer('bar', 'Signal<string>');
+    expectSnippet(snippet).toInfer('baz', 'Signal<string>');
   });
 });

--- a/modules/signals/spec/types/with-linked-state.types.spec.ts
+++ b/modules/signals/spec/types/with-linked-state.types.spec.ts
@@ -1,6 +1,5 @@
 import { expecter } from 'ts-snippet';
 import { compilerOptions } from './helpers';
-import { signalStore, withLinkedState, withState } from '@ngrx/signals';
 
 describe('withLinkedState', () => {
   const expectSnippet = expecter(

--- a/modules/signals/spec/with-linked-state.spec.ts
+++ b/modules/signals/spec/with-linked-state.spec.ts
@@ -1,0 +1,417 @@
+import { TestBed } from '@angular/core/testing';
+import { withMethods, withState } from '../src';
+import { signalStore } from '../src/signal-store';
+import {
+  getState,
+  isWritableSignal,
+  patchState,
+  STATE_SOURCE,
+} from '../src/state-source';
+import { withLinkedState } from '../src/with-linked-state';
+import { withProps } from '../src/with-props';
+import { linkedSignal } from '@angular/core';
+import { signalStoreFeature } from '@ngrx/signals';
+
+describe('withLinkedState', () => {
+  describe('sets linkedSignal as WritableSignals of STATE_SOURCE', () => {
+    [
+      {
+        name: 'automatic',
+        linkedStateFeature: signalStoreFeature(
+          withLinkedState(() => ({
+            user: () => ({ id: 1, name: 'John Doe' }),
+            location: () => ({ city: 'Berlin', country: 'Germany' }),
+          }))
+        ),
+      },
+      {
+        name: 'manual',
+        linkedStateFeature: signalStoreFeature(
+          withLinkedState(() => ({
+            user: linkedSignal(() => ({ id: 1, name: 'John Doe' })),
+            location: linkedSignal(() => ({
+              city: 'Berlin',
+              country: 'Germany',
+            })),
+          }))
+        ),
+      },
+    ].forEach(({ name, linkedStateFeature }) => {
+      it(name, () => {
+        const UserStore = signalStore(
+          { providedIn: 'root', protectedState: false },
+          linkedStateFeature
+        );
+        const userStore = TestBed.inject(UserStore);
+
+        const stateSource = userStore[STATE_SOURCE];
+
+        expect(isWritableSignal(stateSource.location)).toBe(true);
+        expect(isWritableSignal(stateSource.user)).toBe(true);
+      });
+    });
+  });
+
+  describe('spreads the linkedSignal properties to the state', () =>
+    [
+      {
+        name: 'automatic',
+        linkedStateFeature: signalStoreFeature(
+          withLinkedState(() => ({
+            user: () => ({ id: 1, name: 'John Doe' }),
+            location: () => ({ city: 'Berlin', country: 'Germany' }),
+          }))
+        ),
+      },
+      {
+        name: 'manual',
+        linkedStateFeature: signalStoreFeature(
+          withLinkedState(() => ({
+            user: linkedSignal(() => ({ id: 1, name: 'John Doe' })),
+            location: linkedSignal(() => ({
+              city: 'Berlin',
+              country: 'Germany',
+            })),
+          }))
+        ),
+      },
+    ].forEach(({ name, linkedStateFeature }) => {
+      it(name, () => {
+        const UserStore = signalStore(
+          { providedIn: 'root' },
+          linkedStateFeature
+        );
+
+        const userStore = TestBed.inject(UserStore);
+
+        const state = getState(userStore);
+        expect(state).toEqual({
+          user: { id: 1, name: 'John Doe' },
+          location: { city: 'Berlin', country: 'Germany' },
+        });
+      });
+    }));
+
+  describe('updates automatically if the source changes', () =>
+    [
+      {
+        name: 'automatic',
+        linkedStateFeature: signalStoreFeature(
+          withState({ userId: 1 }),
+
+          withLinkedState(({ userId }) => ({
+            books: () => {
+              userId();
+
+              return [] as string[];
+            },
+          }))
+        ),
+      },
+      {
+        name: 'manual',
+        linkedStateFeature: signalStoreFeature(
+          withState({ userId: 1 }),
+          withLinkedState(({ userId }) => ({
+            books: linkedSignal({
+              source: userId,
+              computation: () => [] as string[],
+            }),
+          }))
+        ),
+      },
+    ].forEach(({ name, linkedStateFeature }) => {
+      it(name, () => {
+        const BookStore = signalStore(
+          { providedIn: 'root', protectedState: false },
+          linkedStateFeature,
+          withState({ version: 1 }),
+          withMethods((store) => ({
+            updateUser() {
+              patchState(store, (value) => value);
+              patchState(store, ({ userId }) => ({ userId: userId + 1 }));
+            },
+            addBook(title: string) {
+              patchState(store, ({ books }) => ({ books: [...books, title] }));
+            },
+            increaseVersion() {
+              patchState(store, ({ version }) => ({ version: version + 1 }));
+            },
+          }))
+        );
+
+        const bookStore = TestBed.inject(BookStore);
+        bookStore.addBook('The Neverending Story');
+        bookStore.increaseVersion();
+        expect(bookStore.books()).toEqual(['The Neverending Story']);
+        expect(bookStore.version()).toEqual(2);
+
+        patchState(bookStore, { userId: 2 });
+        expect(bookStore.books()).toEqual([]);
+        expect(bookStore.version()).toEqual(2);
+      });
+    }));
+
+  describe('updates also a spread linkedSignal', () => {
+    [
+      {
+        name: 'automatic',
+        linkedStateFeature: signalStoreFeature(
+          withState({ userId: 1 }),
+          withLinkedState(({ userId }) => ({
+            user: () => {
+              userId();
+              return { name: 'John Doe' };
+            },
+            location: () => {
+              userId();
+              return { city: 'Berlin', country: 'Germany' };
+            },
+          }))
+        ),
+      },
+      {
+        name: 'manual',
+        linkedStateFeature: signalStoreFeature(
+          withState({ userId: 1 }),
+          withLinkedState(({ userId }) => ({
+            user: linkedSignal({
+              source: userId,
+              computation: () => ({ name: 'John Doe' }),
+            }),
+            location: linkedSignal({
+              source: userId,
+              computation: () => ({ city: 'Berlin', country: 'Germany' }),
+            }),
+          }))
+        ),
+      },
+    ].forEach(({ name, linkedStateFeature }) => {
+      it(name, () => {
+        const UserStore = signalStore(
+          { providedIn: 'root', protectedState: false },
+          linkedStateFeature,
+          withMethods((store) => ({
+            updateUser(name: string) {
+              patchState(store, () => ({
+                user: { name },
+              }));
+            },
+            updateLocation(city: string, country: string) {
+              patchState(store, () => ({
+                location: { city, country },
+              }));
+            },
+          }))
+        );
+
+        const userStore = TestBed.inject(UserStore);
+
+        userStore.updateUser('Jane Doe');
+        userStore.updateLocation('London', 'UK');
+
+        expect(getState(userStore)).toEqual({
+          userId: 1,
+          user: { name: 'Jane Doe' },
+          location: { city: 'London', country: 'UK' },
+        });
+
+        patchState(userStore, { userId: 2 });
+        expect(getState(userStore)).toEqual({
+          userId: 2,
+          user: { name: 'John Doe' },
+          location: { city: 'Berlin', country: 'Germany' },
+        });
+      });
+    });
+  });
+
+  describe('can depend on another linkedState (chained)', () => {
+    [
+      {
+        name: 'automatic',
+        linkedStateFeature: signalStoreFeature(
+          withState({ id: 1 }),
+          withLinkedState(({ id }) => ({
+            level1: () => id() * 2,
+          })),
+          withLinkedState(({ level1 }) => ({
+            level2: () => level1() * 10,
+          }))
+        ),
+      },
+      {
+        name: 'manual',
+        linkedStateFeature: signalStoreFeature(
+          withState({ id: 1 }),
+          withLinkedState(({ id }) => ({
+            level1: linkedSignal({
+              source: id,
+              computation: () => id() * 2,
+            }),
+          })),
+          withLinkedState(({ level1 }) => ({
+            level2: linkedSignal({
+              source: level1,
+              computation: () => level1() * 10,
+            }),
+          }))
+        ),
+      },
+    ].forEach(({ name, linkedStateFeature }) => {
+      it(name, () => {
+        const NumberStore = signalStore(
+          { providedIn: 'root', protectedState: false },
+          linkedStateFeature
+        );
+
+        const numberStore = TestBed.inject(NumberStore);
+        expect(getState(numberStore)).toEqual({ id: 1, level1: 2, level2: 20 });
+
+        patchState(numberStore, { id: 2 });
+        expect(getState(numberStore)).toEqual({ id: 2, level1: 4, level2: 40 });
+
+        patchState(numberStore, { level1: 5 });
+        expect(getState(numberStore)).toEqual({ id: 2, level1: 5, level2: 50 });
+
+        patchState(numberStore, { level2: 100 });
+        expect(getState(numberStore)).toEqual({
+          id: 2,
+          level1: 5,
+          level2: 100,
+        });
+
+        patchState(numberStore, { id: 3 });
+        expect(getState(numberStore)).toEqual({ id: 3, level1: 6, level2: 60 });
+      });
+    });
+  });
+
+  describe('can depend on a Signal from another SignalStore', () => {
+    const UserStore = signalStore(
+      { providedIn: 'root', protectedState: false },
+      withState({ userId: 1 })
+    );
+
+    [
+      {
+        name: 'automatic',
+        linkedStateFeature: signalStoreFeature(
+          withLinkedState(() => ({
+            books: () => {
+              TestBed.inject(UserStore).userId();
+
+              return [] as string[];
+            },
+          }))
+        ),
+      },
+      {
+        name: 'manual',
+        linkedStateFeature: signalStoreFeature(
+          withLinkedState(() => {
+            const userStore = TestBed.inject(UserStore);
+
+            return {
+              books: linkedSignal({
+                source: userStore.userId,
+                computation: () => [] as string[],
+              }),
+            };
+          })
+        ),
+      },
+    ].forEach(({ name, linkedStateFeature }) => {
+      it(name, () => {
+        const BookStore = signalStore(
+          { providedIn: 'root' },
+          linkedStateFeature,
+          withMethods((store) => ({
+            addBook(title: string) {
+              patchState(store, ({ books }) => ({ books: [...books, title] }));
+            },
+          }))
+        );
+
+        const userStore = TestBed.inject(UserStore);
+        const bookStore = TestBed.inject(BookStore);
+
+        bookStore.addBook('The Neverending Story');
+        expect(bookStore.books()).toEqual(['The Neverending Story']);
+
+        patchState(userStore, { userId: 2 });
+
+        expect(bookStore.books()).toEqual([]);
+      });
+    });
+  });
+
+  describe('keeps DeepSignal updated', () => {
+    [
+      {
+        name: 'automatic',
+        linkedStateFeature: signalStoreFeature(
+          withState({ userId: 1 }),
+          withLinkedState(({ userId }) => ({
+            user: () => ({ id: userId(), name: 'John Doe' }),
+          }))
+        ),
+      },
+      {
+        name: 'manual',
+        linkedStateFeature: signalStoreFeature(
+          withState({ userId: 1 }),
+          withLinkedState(({ userId }) => ({
+            user: linkedSignal({
+              source: userId,
+              computation: (id) => ({ id, name: 'John Doe' }),
+            }),
+          }))
+        ),
+      },
+    ].forEach(({ name, linkedStateFeature }) => {
+      it(name, () => {
+        const UserStore = signalStore(
+          { providedIn: 'root', protectedState: false },
+          linkedStateFeature
+        );
+
+        const userStore = TestBed.inject(UserStore);
+        const name = userStore.user.name;
+        expect(name()).toEqual('John Doe');
+
+        patchState(userStore, { user: { id: 2, name: 'Tom Smith' } });
+        expect(name()).toEqual('Tom Smith');
+
+        patchState(userStore, { userId: 2 });
+        expect(name()).toEqual('John Doe');
+      });
+    });
+  });
+
+  describe('InnerSignalStore access', () => {
+    it('can access the state signals', () => {
+      const UserStore = signalStore(
+        { providedIn: 'root' },
+        withState({ userId: 1 }),
+        withLinkedState(({ userId }) => ({ value: userId }))
+      );
+
+      const userStore = TestBed.inject(UserStore);
+
+      expect(userStore.value()).toBe(1);
+    });
+
+    it('can access the props', () => {
+      const UserStore = signalStore(
+        { providedIn: 'root' },
+        withProps(() => ({ userId: 1 })),
+        withLinkedState(({ userId }) => ({ value: () => userId }))
+      );
+
+      const userStore = TestBed.inject(UserStore);
+
+      expect(userStore.value()).toBe(1);
+    });
+  });
+});

--- a/modules/signals/spec/with-linked-state.spec.ts
+++ b/modules/signals/spec/with-linked-state.spec.ts
@@ -1,48 +1,40 @@
-import { TestBed } from '@angular/core/testing';
-import { withMethods, withState } from '../src';
-import { signalStore } from '../src/signal-store';
+import { linkedSignal } from '@angular/core';
 import {
   getState,
-  isWritableSignal,
   patchState,
-  STATE_SOURCE,
-} from '../src/state-source';
-import { withLinkedState } from '../src/with-linked-state';
-import { withProps } from '../src/with-props';
-import { linkedSignal } from '@angular/core';
-import { signalStoreFeature } from '@ngrx/signals';
+  signalStoreFeature,
+  withLinkedState,
+  withState,
+} from '../src';
+import { getInitialInnerStore } from '../src/signal-store';
+import { isWritableSignal, STATE_SOURCE } from '../src/state-source';
 
 describe('withLinkedState', () => {
   describe('sets linkedSignal as WritableSignals of STATE_SOURCE', () => {
     [
       {
         name: 'automatic',
-        linkedStateFeature: signalStoreFeature(
+        linkedStateFeature: () =>
           withLinkedState(() => ({
             user: () => ({ id: 1, name: 'John Doe' }),
             location: () => ({ city: 'Berlin', country: 'Germany' }),
-          }))
-        ),
+          })),
       },
       {
         name: 'manual',
-        linkedStateFeature: signalStoreFeature(
+        linkedStateFeature: () =>
           withLinkedState(() => ({
             user: linkedSignal(() => ({ id: 1, name: 'John Doe' })),
             location: linkedSignal(() => ({
               city: 'Berlin',
               country: 'Germany',
             })),
-          }))
-        ),
+          })),
       },
     ].forEach(({ name, linkedStateFeature }) => {
       it(name, () => {
-        const UserStore = signalStore(
-          { providedIn: 'root', protectedState: false },
-          linkedStateFeature
-        );
-        const userStore = TestBed.inject(UserStore);
+        const initialStore = getInitialInnerStore();
+        const userStore = linkedStateFeature()(initialStore);
 
         const stateSource = userStore[STATE_SOURCE];
 
@@ -56,33 +48,27 @@ describe('withLinkedState', () => {
     [
       {
         name: 'automatic',
-        linkedStateFeature: signalStoreFeature(
+        linkedStateFeature: () =>
           withLinkedState(() => ({
             user: () => ({ id: 1, name: 'John Doe' }),
             location: () => ({ city: 'Berlin', country: 'Germany' }),
-          }))
-        ),
+          })),
       },
       {
         name: 'manual',
-        linkedStateFeature: signalStoreFeature(
+        linkedStateFeature: () =>
           withLinkedState(() => ({
             user: linkedSignal(() => ({ id: 1, name: 'John Doe' })),
             location: linkedSignal(() => ({
               city: 'Berlin',
               country: 'Germany',
             })),
-          }))
-        ),
+          })),
       },
     ].forEach(({ name, linkedStateFeature }) => {
       it(name, () => {
-        const UserStore = signalStore(
-          { providedIn: 'root' },
-          linkedStateFeature
-        );
-
-        const userStore = TestBed.inject(UserStore);
+        const initialStore = getInitialInnerStore();
+        const userStore = linkedStateFeature()(initialStore);
 
         const state = getState(userStore);
         expect(state).toEqual({
@@ -92,180 +78,45 @@ describe('withLinkedState', () => {
       });
     }));
 
-  describe('updates automatically if the source changes', () =>
-    [
-      {
-        name: 'automatic',
-        linkedStateFeature: signalStoreFeature(
-          withState({ userId: 1 }),
-
-          withLinkedState(({ userId }) => ({
-            books: () => {
-              userId();
-
-              return [] as string[];
-            },
-          }))
-        ),
-      },
-      {
-        name: 'manual',
-        linkedStateFeature: signalStoreFeature(
-          withState({ userId: 1 }),
-          withLinkedState(({ userId }) => ({
-            books: linkedSignal({
-              source: userId,
-              computation: () => [] as string[],
-            }),
-          }))
-        ),
-      },
-    ].forEach(({ name, linkedStateFeature }) => {
-      it(name, () => {
-        const BookStore = signalStore(
-          { providedIn: 'root', protectedState: false },
-          linkedStateFeature,
-          withState({ version: 1 }),
-          withMethods((store) => ({
-            updateUser() {
-              patchState(store, (value) => value);
-              patchState(store, ({ userId }) => ({ userId: userId + 1 }));
-            },
-            addBook(title: string) {
-              patchState(store, ({ books }) => ({ books: [...books, title] }));
-            },
-            increaseVersion() {
-              patchState(store, ({ version }) => ({ version: version + 1 }));
-            },
-          }))
-        );
-
-        const bookStore = TestBed.inject(BookStore);
-        bookStore.addBook('The Neverending Story');
-        bookStore.increaseVersion();
-        expect(bookStore.books()).toEqual(['The Neverending Story']);
-        expect(bookStore.version()).toEqual(2);
-
-        patchState(bookStore, { userId: 2 });
-        expect(bookStore.books()).toEqual([]);
-        expect(bookStore.version()).toEqual(2);
-      });
-    }));
-
-  describe('updates also a spread linkedSignal', () => {
-    [
-      {
-        name: 'automatic',
-        linkedStateFeature: signalStoreFeature(
-          withState({ userId: 1 }),
-          withLinkedState(({ userId }) => ({
-            user: () => {
-              userId();
-              return { name: 'John Doe' };
-            },
-            location: () => {
-              userId();
-              return { city: 'Berlin', country: 'Germany' };
-            },
-          }))
-        ),
-      },
-      {
-        name: 'manual',
-        linkedStateFeature: signalStoreFeature(
-          withState({ userId: 1 }),
-          withLinkedState(({ userId }) => ({
-            user: linkedSignal({
-              source: userId,
-              computation: () => ({ name: 'John Doe' }),
-            }),
-            location: linkedSignal({
-              source: userId,
-              computation: () => ({ city: 'Berlin', country: 'Germany' }),
-            }),
-          }))
-        ),
-      },
-    ].forEach(({ name, linkedStateFeature }) => {
-      it(name, () => {
-        const UserStore = signalStore(
-          { providedIn: 'root', protectedState: false },
-          linkedStateFeature,
-          withMethods((store) => ({
-            updateUser(name: string) {
-              patchState(store, () => ({
-                user: { name },
-              }));
-            },
-            updateLocation(city: string, country: string) {
-              patchState(store, () => ({
-                location: { city, country },
-              }));
-            },
-          }))
-        );
-
-        const userStore = TestBed.inject(UserStore);
-
-        userStore.updateUser('Jane Doe');
-        userStore.updateLocation('London', 'UK');
-
-        expect(getState(userStore)).toEqual({
-          userId: 1,
-          user: { name: 'Jane Doe' },
-          location: { city: 'London', country: 'UK' },
-        });
-
-        patchState(userStore, { userId: 2 });
-        expect(getState(userStore)).toEqual({
-          userId: 2,
-          user: { name: 'John Doe' },
-          location: { city: 'Berlin', country: 'Germany' },
-        });
-      });
-    });
-  });
-
   describe('can depend on another linkedState (chained)', () => {
     [
       {
         name: 'automatic',
-        linkedStateFeature: signalStoreFeature(
-          withState({ id: 1 }),
-          withLinkedState(({ id }) => ({
-            level1: () => id() * 2,
-          })),
-          withLinkedState(({ level1 }) => ({
-            level2: () => level1() * 10,
-          }))
-        ),
+        linkedStateFeature: () =>
+          signalStoreFeature(
+            withState({ id: 1 }),
+            withLinkedState(({ id }) => ({
+              level1: () => id() * 2,
+            })),
+            withLinkedState(({ level1 }) => ({
+              level2: () => level1() * 10,
+            }))
+          ),
       },
       {
         name: 'manual',
-        linkedStateFeature: signalStoreFeature(
-          withState({ id: 1 }),
-          withLinkedState(({ id }) => ({
-            level1: linkedSignal({
-              source: id,
-              computation: () => id() * 2,
-            }),
-          })),
-          withLinkedState(({ level1 }) => ({
-            level2: linkedSignal({
-              source: level1,
-              computation: () => level1() * 10,
-            }),
-          }))
-        ),
+        linkedStateFeature: () =>
+          signalStoreFeature(
+            withState({ id: 1 }),
+            withLinkedState(({ id }) => ({
+              level1: linkedSignal({
+                source: id,
+                computation: () => id() * 2,
+              }),
+            })),
+            withLinkedState(({ level1 }) => ({
+              level2: linkedSignal({
+                source: level1,
+                computation: () => level1() * 10,
+              }),
+            }))
+          ),
       },
     ].forEach(({ name, linkedStateFeature }) => {
       it(name, () => {
-        const NumberStore = signalStore(
-          { providedIn: 'root', protectedState: false },
-          linkedStateFeature
-        );
+        const initialStore = getInitialInnerStore();
+        const numberStore = linkedStateFeature()(initialStore);
 
-        const numberStore = TestBed.inject(NumberStore);
         expect(getState(numberStore)).toEqual({ id: 1, level1: 2, level2: 20 });
 
         patchState(numberStore, { id: 2 });
@@ -287,97 +138,37 @@ describe('withLinkedState', () => {
     });
   });
 
-  describe('can depend on a Signal from another SignalStore', () => {
-    const UserStore = signalStore(
-      { providedIn: 'root', protectedState: false },
-      withState({ userId: 1 })
-    );
-
-    [
-      {
-        name: 'automatic',
-        linkedStateFeature: signalStoreFeature(
-          withLinkedState(() => ({
-            books: () => {
-              TestBed.inject(UserStore).userId();
-
-              return [] as string[];
-            },
-          }))
-        ),
-      },
-      {
-        name: 'manual',
-        linkedStateFeature: signalStoreFeature(
-          withLinkedState(() => {
-            const userStore = TestBed.inject(UserStore);
-
-            return {
-              books: linkedSignal({
-                source: userStore.userId,
-                computation: () => [] as string[],
-              }),
-            };
-          })
-        ),
-      },
-    ].forEach(({ name, linkedStateFeature }) => {
-      it(name, () => {
-        const BookStore = signalStore(
-          { providedIn: 'root' },
-          linkedStateFeature,
-          withMethods((store) => ({
-            addBook(title: string) {
-              patchState(store, ({ books }) => ({ books: [...books, title] }));
-            },
-          }))
-        );
-
-        const userStore = TestBed.inject(UserStore);
-        const bookStore = TestBed.inject(BookStore);
-
-        bookStore.addBook('The Neverending Story');
-        expect(bookStore.books()).toEqual(['The Neverending Story']);
-
-        patchState(userStore, { userId: 2 });
-
-        expect(bookStore.books()).toEqual([]);
-      });
-    });
-  });
-
   describe('keeps DeepSignal updated', () => {
     [
       {
         name: 'automatic',
-        linkedStateFeature: signalStoreFeature(
-          withState({ userId: 1 }),
-          withLinkedState(({ userId }) => ({
-            user: () => ({ id: userId(), name: 'John Doe' }),
-          }))
-        ),
+        linkedStateFeature: () =>
+          signalStoreFeature(
+            withState({ userId: 1 }),
+            withLinkedState(({ userId }) => ({
+              user: () => ({ id: userId(), name: 'John Doe' }),
+            }))
+          ),
       },
       {
         name: 'manual',
-        linkedStateFeature: signalStoreFeature(
-          withState({ userId: 1 }),
-          withLinkedState(({ userId }) => ({
-            user: linkedSignal({
-              source: userId,
-              computation: (id) => ({ id, name: 'John Doe' }),
-            }),
-          }))
-        ),
+        linkedStateFeature: () =>
+          signalStoreFeature(
+            withState({ userId: 1 }),
+            withLinkedState(({ userId }) => ({
+              user: linkedSignal({
+                source: userId,
+                computation: (id) => ({ id, name: 'John Doe' }),
+              }),
+            }))
+          ),
       },
     ].forEach(({ name, linkedStateFeature }) => {
       it(name, () => {
-        const UserStore = signalStore(
-          { providedIn: 'root', protectedState: false },
-          linkedStateFeature
-        );
+        const initialStore = getInitialInnerStore();
+        const userStore = linkedStateFeature()(initialStore);
 
-        const userStore = TestBed.inject(UserStore);
-        const name = userStore.user.name;
+        const name = userStore.stateSignals.user.name;
         expect(name()).toEqual('John Doe');
 
         patchState(userStore, { user: { id: 2, name: 'Tom Smith' } });
@@ -386,32 +177,6 @@ describe('withLinkedState', () => {
         patchState(userStore, { userId: 2 });
         expect(name()).toEqual('John Doe');
       });
-    });
-  });
-
-  describe('InnerSignalStore access', () => {
-    it('can access the state signals', () => {
-      const UserStore = signalStore(
-        { providedIn: 'root' },
-        withState({ userId: 1 }),
-        withLinkedState(({ userId }) => ({ value: userId }))
-      );
-
-      const userStore = TestBed.inject(UserStore);
-
-      expect(userStore.value()).toBe(1);
-    });
-
-    it('can access the props', () => {
-      const UserStore = signalStore(
-        { providedIn: 'root' },
-        withProps(() => ({ userId: 1 })),
-        withLinkedState(({ userId }) => ({ value: () => userId }))
-      );
-
-      const userStore = TestBed.inject(UserStore);
-
-      expect(userStore.value()).toBe(1);
     });
   });
 });

--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -25,6 +25,7 @@ export { Prettify } from './ts-helpers';
 export { withComputed } from './with-computed';
 export { withFeature } from './with-feature';
 export { withHooks } from './with-hooks';
+export { withLinkedState } from './with-linked-state';
 export { withMethods } from './with-methods';
 export { withProps } from './with-props';
 export { withState } from './with-state';

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -94,6 +94,10 @@ export function patchState<State extends object>(
     }
     const signalKey = key as keyof State;
 
+    if (currentState[signalKey] === newState[signalKey]) {
+      continue;
+    }
+
     signals[signalKey].set(newState[signalKey]);
   }
 

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -1,0 +1,101 @@
+import { linkedSignal, WritableSignal } from '@angular/core';
+
+import { toDeepSignal } from './deep-signal';
+import {
+  EmptyFeatureResult,
+  InnerSignalStore,
+  SignalsDictionary,
+  SignalStoreFeature,
+  SignalStoreFeatureResult,
+  StateSignals,
+} from './signal-store-models';
+import { isWritableSignal, STATE_SOURCE } from './state-source';
+import { Prettify } from './ts-helpers';
+
+type LinkedStateResult<
+  LinkedStateInput extends Record<
+    string | symbol,
+    WritableSignal<unknown> | (() => unknown)
+  >
+> = {
+  [K in keyof LinkedStateInput]: LinkedStateInput[K] extends WritableSignal<
+    infer V
+  >
+    ? V
+    : LinkedStateInput[K] extends () => infer V
+    ? V
+    : never;
+};
+
+/**
+ *
+ * @description
+ * Generates and adds the properties of a `linkedSignal`
+ * to the store's state.
+ *
+ * @usageNotes
+ * ```typescript
+ * const UserStore = signalStore(
+ *   withState({ options: [1, 2, 3] }),
+ *   withLinkedState(({ options }) => ({ selectOption: () => options()[0] ?? undefined }))
+ * );
+ * ```
+ *
+ * The resulting state is of type `{ options: number[], selectOption: number | undefined }`.
+ * Whenever the `options` signal changes, the `selectOption` will automatically update.
+ *
+ * For advanced use cases, `linkedSignal` can be called within `withLinkedState`:
+ *
+ * ```typescript
+ * const UserStore = signalStore(
+ *   withState({ id: 1 }),
+ *   withLinkedState(({ id }) => ({
+ *     user: linkedSignal({
+ *       source: id,
+ *       computation: () => ({ firstname: '', lastname: '' })
+ *     })
+ *   }))
+ * )
+ * ```
+ *
+ * @param linkedStateFactory A function that returns a an object literal with properties container an actual `linkedSignal` or the computation function.
+ */
+export function withLinkedState<
+  State extends Record<
+    string | symbol,
+    WritableSignal<unknown> | (() => unknown)
+  >,
+  Input extends SignalStoreFeatureResult
+>(
+  linkedStateFactory: (
+    store: Prettify<StateSignals<Input['state']> & Input['props']>
+  ) => State
+): SignalStoreFeature<
+  Input,
+  EmptyFeatureResult & {
+    state: LinkedStateResult<State>;
+  }
+> {
+  return (store) => {
+    const linkedState = linkedStateFactory({
+      ...store.stateSignals,
+      ...store.props,
+    });
+    const stateKeys = Reflect.ownKeys(linkedState);
+    const stateSource = store[STATE_SOURCE] as SignalsDictionary;
+    const stateSignals = {} as SignalsDictionary;
+
+    for (const key of stateKeys) {
+      const signalOrFunction = linkedState[key];
+      stateSource[key] = isWritableSignal(signalOrFunction)
+        ? signalOrFunction
+        : linkedSignal(signalOrFunction);
+      stateSignals[key] = toDeepSignal(stateSource[key]);
+    }
+
+    return {
+      ...store,
+      stateSignals: { ...store.stateSignals, ...stateSignals },
+    } as InnerSignalStore<LinkedStateResult<State>>;
+  };
+}

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -46,12 +46,17 @@ type LinkedStateResult<
  * For advanced use cases, `linkedSignal` can be called within `withLinkedState`:
  *
  * ```typescript
+ * type Option = { id: number; label: string };
+ *
  * const UserStore = signalStore(
- *   withState({ id: 1 }),
- *   withLinkedState(({ id }) => ({
- *     user: linkedSignal({
- *       source: id,
- *       computation: () => ({ firstname: '', lastname: '' })
+ *   withState({ options: new Array<Option>() }),
+ *   withLinkedState(({ options }) => ({
+ *     selectedOption: linkedSignal<Option[], Option>({
+ *       source: options,
+ *       computation: (newOptions, previous) => {
+ *         const option = newOptions.find((o) => o.id=== previous?.value.id);
+ *         return option ?? newOptions[0];
+ *       },
  *     })
  *   }))
  * )

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -72,9 +72,7 @@ export function withLinkedState<
   ) => State
 ): SignalStoreFeature<
   Input,
-  EmptyFeatureResult & {
-    state: LinkedStateResult<State>;
-  }
+  { state: LinkedStateResult<State>; props: {}; methods: {} }
 > {
   return (store) => {
     const linkedState = linkedStateFactory({

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -29,8 +29,7 @@ type LinkedStateResult<
 /**
  *
  * @description
- * Generates and adds the properties of a `linkedSignal`
- * to the store's state.
+ * Adds linked state slices to a SignalStore.
  *
  * @usageNotes
  * ```typescript

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -58,7 +58,7 @@ type LinkedStateResult<
  * )
  * ```
  *
- * @param linkedStateFactory A function that returns an object literal with properties container an actual `linkedSignal` or the computation function.
+ * @param linkedStateFactory A function that returns an object literal with properties containing an actual `linkedSignal` or the computation function.
  */
 export function withLinkedState<
   State extends Record<

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -2,7 +2,6 @@ import { linkedSignal, WritableSignal } from '@angular/core';
 
 import { toDeepSignal } from './deep-signal';
 import {
-  EmptyFeatureResult,
   InnerSignalStore,
   SignalsDictionary,
   SignalStoreFeature,

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -58,7 +58,7 @@ type LinkedStateResult<
  * )
  * ```
  *
- * @param linkedStateFactory A function that returns a an object literal with properties container an actual `linkedSignal` or the computation function.
+ * @param linkedStateFactory A function that returns an object literal with properties container an actual `linkedSignal` or the computation function.
  */
 export function withLinkedState<
   State extends Record<


### PR DESCRIPTION
This is a non-breaking feature to support `linkedSignal`.

This branch is based on #4795 which **has to be merged first**.

**Please read the comment in #4781**

---

`withLinkedState` generates and adds the properties of a `linkedSignal` to the store's state.

## Usage Notes:

```typescript
const UserStore = signalStore(
  withState({ options: [1, 2, 3] }),
  withLinkedState(({ options }) => ({ selectOption: options()[0] ?? undefined }))
);
```

The resulting state is of type `{ options: number[], selectOption: number | undefined }`.
Whenever the `options` signal changes, the `selectOption` will automatically update.

For advanced use cases, `linkedSignal` can be called within `withLinkedState`:

```typescript
const UserStore = signalStore(
  withState({ id: 1 }),
  withLinkedState(({ id }) => linkedSignal({
    source: id,
    computation: () => ({ firstname: '', lastname: '' })
  }))
)
```

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4781

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
