### PR TITLE
feat(entity): strengthen typing of getInitialState

### DIFF
--- a/modules/entity/spec/types/entity_state.types.spec.ts
+++ b/modules/entity/spec/types/entity_state.types.spec.ts
@@ -1,0 +1,63 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('EntityState Types', () => {
+  const expectSnippet = expecter(
+    (code) => `
+        import { EntityState, createEntityAdapter, EntityAdapter } from '@ngrx/entity';
+
+        interface Book {
+          id: string;
+          title: string;
+        }
+
+        interface BookState extends EntityState<Book> {
+          selectedBookId: string | null;
+        }
+
+        export const adapter: EntityAdapter<Book> = createEntityAdapter<Book>();
+        ${code}
+      `,
+    compilerOptions()
+  );
+
+  describe('getInitialState', () => {
+    it('can set the initial state', () => {
+      expectSnippet(`
+        export const initialState: BookState = adapter.getInitialState({
+          selectedBookId: '1',
+        });
+
+      `).toSucceed();
+    });
+
+    it('can set the initial state with additional properties', () => {
+      expectSnippet(`
+        export const initialState: BookState = adapter.getInitialState({
+          selectedBookId: '1',
+        });
+
+      `).toSucceed();
+    });
+
+    it('throws when setting the initial state with unknown properties', () => {
+      expectSnippet(`
+        export const initialState: BookState = adapter.getInitialState({
+          selectedBookId: '1',
+          otherProperty: 'value',
+        });
+      `).toFail(
+        /Object literal may only specify known properties, and 'otherProperty' does not exist in type 'Omit<BookState, keyof EntityState<T>>'/i
+      );
+    });
+
+    it('can set the initial state with unknown properties when the state is untyped', () => {
+      expectSnippet(`
+        export const initialState = adapter.getInitialState({
+          selectedBookId: '1',
+          otherProperty: 'value',
+        });
+      `).toSucceed();
+    });
+  });
+});

--- a/modules/entity/src/entity_state.ts
+++ b/modules/entity/src/entity_state.ts
@@ -9,9 +9,9 @@ export function getInitialEntityState<V>(): EntityState<V> {
 
 export function createInitialStateFactory<V>() {
   function getInitialState(): EntityState<V>;
-  function getInitialState<S extends object>(
-    additionalState: S
-  ): EntityState<V> & S;
+  function getInitialState<S extends EntityState<V>>(
+    additionalState: Omit<S, keyof EntityState<V>>
+  ): S;
   function getInitialState(additionalState: any = {}): any {
     return Object.assign(getInitialEntityState(), additionalState);
   }

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -110,7 +110,9 @@ export interface EntityAdapter<T> extends EntityStateAdapter<T> {
   selectId: IdSelector<T>;
   sortComparer: false | Comparer<T>;
   getInitialState(): EntityState<T>;
-  getInitialState<S extends object>(state: S): EntityState<T> & S;
+  getInitialState<S extends EntityState<T>>(
+    state: Omit<S, keyof EntityState<T>>
+  ): S;
   getSelectors(): EntitySelectors<T, EntityState<T>>;
   getSelectors<V>(
     selectState: (state: V) => EntityState<T>

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -73,7 +73,7 @@ export function defaultMemoize(
   isResultEqual = isEqualCheck
 ): MemoizedProjection {
   let lastArguments: null | IArguments = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, , , , ,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let lastResult: any = null;
   let overrideResult: any;
 

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -2,8 +2,6 @@ import { Selector, SelectorWithProps } from './models';
 import { isDevMode } from '@angular/core';
 import { isNgrxMockEnvironment } from './flags';
 
-// test change
-
 export type AnyFn = (...args: any[]) => any;
 
 export type MemoizedProjection = {

--- a/modules/store/src/selector.ts
+++ b/modules/store/src/selector.ts
@@ -2,6 +2,8 @@ import { Selector, SelectorWithProps } from './models';
 import { isDevMode } from '@angular/core';
 import { isNgrxMockEnvironment } from './flags';
 
+// test change
+
 export type AnyFn = (...args: any[]) => any;
 
 export type MemoizedProjection = {

--- a/nx.json
+++ b/nx.json
@@ -47,7 +47,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"],
-      "cache": false
+      "cache": true
     },
     "e2e": {
       "inputs": ["default", "^production"],

--- a/nx.json
+++ b/nx.json
@@ -47,7 +47,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"],
-      "cache": true
+      "cache": false
     },
     "e2e": {
       "inputs": ["default", "^production"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4422

When initializing an EntityAdapter<T> and subsequently setting the initialState using ...adapter.getInitialState({ <additional state here>}), it is possible, given the current interface, to introduce unknown variables that do not conform to the user's specified state. This could result in bugs related to mistyped variable names, resulting in confusing user error scenarios.

## What is the new behavior?

This small change modifies the interface to require that the input state S extends EntityState<T>, requires that the additionalState state argument conforms to an Omit version of this S type, which removes the 'id' and 'entities' properties by way of keyof EntityState<T>, and then finally, since the argument now already extends EntityState<T>, we can now simply return S.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This reopens #4423 (with an update of the branch) - with the upcoming release this is a good timing imho.