### PR TITLE
feat(signals): enhance `withComputed` to accept computation functions

### DIFF
--- a/modules/signals/spec/types/with-computed.types.spec.ts
+++ b/modules/signals/spec/types/with-computed.types.spec.ts
@@ -19,7 +19,7 @@ describe('withComputed', () => {
     compilerOptions()
   );
 
-  it('creates a Signal automtically', () => {
+  it('creates a Signal automatically', () => {
     const snippet = `
       const Store = signalStore(
         withComputed(() => ({

--- a/modules/signals/spec/types/with-computed.types.spec.ts
+++ b/modules/signals/spec/types/with-computed.types.spec.ts
@@ -3,7 +3,7 @@ import { compilerOptions } from './helpers';
 import { signalStore, withComputed } from 'modules/signals/src';
 import { TestBed } from '@angular/core/testing';
 
-describe('patchState', () => {
+describe('withComputed', () => {
   const expectSnippet = expecter(
     (code) => `
         import {

--- a/modules/signals/spec/types/with-computed.types.spec.ts
+++ b/modules/signals/spec/types/with-computed.types.spec.ts
@@ -1,0 +1,90 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './helpers';
+import { signalStore, withComputed } from 'modules/signals/src';
+import { TestBed } from '@angular/core/testing';
+
+describe('patchState', () => {
+  const expectSnippet = expecter(
+    (code) => `
+        import {
+          deepComputed,
+          signalStore,
+          withComputed,
+        } from '@ngrx/signals';
+        import { TestBed } from '@angular/core/testing';
+        import { signal } from '@angular/core';
+        
+        ${code}
+      `,
+    compilerOptions()
+  );
+
+  it('creates a Signal automtically', () => {
+    const snippet = `
+      const Store = signalStore(
+        withComputed(() => ({
+          user: () => ({ firstName: 'John', lastName: 'Doe' })
+        }))
+      );
+
+      const store = TestBed.inject(Store);
+      const user = store.user;
+    `;
+
+    expectSnippet(snippet).toSucceed();
+    expectSnippet(snippet).toInfer(
+      'user',
+      'Signal<{ firstName: string; lastName: string; }>'
+    );
+  });
+
+  it('keeps a WritableSignal intact, if passed', () => {
+    const snippet = `
+      const user = signal({ firstName: 'John', lastName: 'Doe' });
+
+      const Store = signalStore(
+        withComputed(() => ({
+          user,
+        }))
+      );
+
+      const store = TestBed.inject(Store);
+      const userSignal = store.user;
+    `;
+
+    expectSnippet(snippet).toSucceed();
+    expectSnippet(snippet).toInfer(
+      'userSignal',
+      'WritableSignal<{ firstName: string; lastName: string; }>'
+    );
+  });
+
+  it('keeps a DeepSignal intact, if passed', () => {
+    const snippet = `
+    const user = deepComputed(
+      signal({
+        name: 'John Doe',
+        address: {
+          street: '123 Main St',
+          city: 'Anytown',
+        },
+      })
+    );
+
+    const Store = signalStore(
+      withComputed(() => ({
+        user,
+      }))
+    );
+
+    const store = TestBed.inject(Store);
+    const userSignal = store.user;
+  `;
+
+    expectSnippet(snippet).toSucceed();
+    expectSnippet(snippet).toInfer(
+      'userSignal',
+      'DeepSignal<{ name: string; address: { street: string; city: string; }; }>'
+    );
+  });
+});

--- a/modules/signals/spec/with-computed.spec.ts
+++ b/modules/signals/spec/with-computed.spec.ts
@@ -1,5 +1,10 @@
-import { signal } from '@angular/core';
-import { withComputed, withMethods, withState } from '../src';
+import { computed, signal } from '@angular/core';
+import {
+  signalStoreFeature,
+  withComputed,
+  withMethods,
+  withState,
+} from '../src';
 import { getInitialInnerStore } from '../src/signal-store';
 
 describe('withComputed', () => {
@@ -53,5 +58,35 @@ describe('withComputed', () => {
       'Trying to override:',
       'p1, s2, m1, Symbol(computed_secret)'
     );
+  });
+
+  it('adds computed automatically if the value is function', () => {
+    const initialStore = getInitialInnerStore();
+
+    const store = signalStoreFeature(
+      withState({ a: 2, b: 3 }),
+      withComputed(({ a, b }) => ({
+        sum: () => a() + b(),
+        product: () => a() * b(),
+      }))
+    )(initialStore);
+
+    expect(store.props.sum()).toBe(5);
+    expect(store.props.product()).toBe(6);
+  });
+
+  it('allows to mix user-provided computeds and automatically computed ones', () => {
+    const initialStore = getInitialInnerStore();
+
+    const store = signalStoreFeature(
+      withState({ a: 2, b: 3 }),
+      withComputed(({ a, b }) => ({
+        sum: () => a() + b(),
+        product: computed(() => a() * b()),
+      }))
+    )(initialStore);
+
+    expect(store.props.sum()).toBe(5);
+    expect(store.props.product()).toBe(6);
   });
 });

--- a/modules/signals/spec/with-computed.spec.ts
+++ b/modules/signals/spec/with-computed.spec.ts
@@ -62,7 +62,7 @@ describe('withComputed', () => {
     );
   });
 
-  it('adds computed automatically if the value is function', () => {
+  it('adds computed automatically if the value is a function', () => {
     const initialStore = getInitialInnerStore();
 
     const store = signalStoreFeature(

--- a/modules/signals/spec/with-computed.spec.ts
+++ b/modules/signals/spec/with-computed.spec.ts
@@ -1,11 +1,13 @@
 import { computed, signal } from '@angular/core';
 import {
+  deepComputed,
   signalStoreFeature,
   withComputed,
   withMethods,
   withState,
 } from '../src';
-import { getInitialInnerStore } from '../src/signal-store';
+import { getInitialInnerStore, signalStore } from '../src/signal-store';
+import { TestBed } from '@angular/core/testing';
 
 describe('withComputed', () => {
   it('adds computed signals to the store immutably', () => {
@@ -88,5 +90,58 @@ describe('withComputed', () => {
 
     expect(store.props.sum()).toBe(5);
     expect(store.props.product()).toBe(6);
+  });
+
+  it('does not change a WritableSignal', () => {
+    const user = signal({ firstName: 'John', lastName: 'Doe' });
+
+    const Store = signalStore(
+      { providedIn: 'root' },
+      withComputed(() => ({
+        user,
+      }))
+    );
+
+    const store = TestBed.inject(Store);
+
+    expect(store.user).toBe(user);
+  });
+
+  it('does not change a DeepSignal', () => {
+    const user = deepComputed(
+      signal({
+        name: 'John Doe',
+        address: {
+          street: '123 Main St',
+          city: 'Anytown',
+        },
+      })
+    );
+
+    const Store = signalStore(
+      { providedIn: 'root' },
+      withComputed(() => ({
+        user,
+      }))
+    );
+
+    const store = TestBed.inject(Store);
+
+    expect(store.user).toBe(user);
+  });
+
+  it('does not change a Signal', () => {
+    const user = computed(() => ({ firstName: 'John', lastName: 'Doe' }));
+
+    const Store = signalStore(
+      { providedIn: 'root' },
+      withComputed(() => ({
+        user,
+      }))
+    );
+
+    const store = TestBed.inject(Store);
+
+    expect(store.user).toBe(user);
   });
 });

--- a/modules/signals/src/with-computed.ts
+++ b/modules/signals/src/with-computed.ts
@@ -1,5 +1,5 @@
+import { computed, isSignal, Signal } from '@angular/core';
 import {
-  SignalsDictionary,
   SignalStoreFeature,
   SignalStoreFeatureResult,
   StateSignals,
@@ -7,16 +7,43 @@ import {
 import { Prettify } from './ts-helpers';
 import { withProps } from './with-props';
 
+type ComputedResult<
+  ComputedSignals extends Record<
+    string | symbol,
+    Signal<unknown> | (() => unknown)
+  >
+> = {
+  [P in keyof ComputedSignals]: ComputedSignals[P] extends () => infer V
+    ? Signal<V>
+    : ComputedSignals[P];
+};
+
 export function withComputed<
   Input extends SignalStoreFeatureResult,
-  ComputedSignals extends SignalsDictionary
+  ComputedSignals extends Record<
+    string | symbol,
+    Signal<unknown> | (() => unknown)
+  >
 >(
   signalsFactory: (
     store: Prettify<StateSignals<Input['state']> & Input['props']>
   ) => ComputedSignals
 ): SignalStoreFeature<
   Input,
-  { state: {}; props: ComputedSignals; methods: {} }
+  { state: {}; props: ComputedResult<ComputedSignals>; methods: {} }
 > {
-  return withProps(signalsFactory);
+  return withProps((store) => {
+    const signals = signalsFactory(store);
+    const stateKeys = Reflect.ownKeys(signals);
+
+    return stateKeys.reduce((prev, key) => {
+      const signalOrFunction = signals[key];
+      return {
+        ...prev,
+        [key]: isSignal(signalOrFunction)
+          ? signalOrFunction
+          : computed(signalOrFunction),
+      };
+    }, {} as ComputedResult<ComputedSignals>);
+  });
 }

--- a/modules/signals/src/with-computed.ts
+++ b/modules/signals/src/with-computed.ts
@@ -36,14 +36,14 @@ export function withComputed<
     const computedResult = computedFactory(store);
     const stateKeys = Reflect.ownKeys(signals);
 
-    return stateKeys.reduce((prev, key) => {
-      const signalOrFunction = signals[key];
+    return computedResultKeys.reduce((prev, key) => {
+      const signalOrComputation = computationResult[key];
       return {
         ...prev,
-        [key]: isSignal(signalOrFunction)
-          ? signalOrFunction
-          : computed(signalOrFunction),
+        [key]: isSignal(signalOrComputation)
+          ? signalOrComputation
+          : computed(signalOrComputation),
       };
-    }, {} as ComputedResult<ComputedSignals>);
+    }, {} as ComputedResult<ComputedDictionary>);
   });
 }

--- a/modules/signals/src/with-computed.ts
+++ b/modules/signals/src/with-computed.ts
@@ -25,7 +25,7 @@ export function withComputed<
     Signal<unknown> | (() => unknown)
   >
 >(
-  signalsFactory: (
+  computedFactory: (
     store: Prettify<StateSignals<Input['state']> & Input['props']>
   ) => ComputedSignals
 ): SignalStoreFeature<

--- a/modules/signals/src/with-computed.ts
+++ b/modules/signals/src/with-computed.ts
@@ -33,7 +33,7 @@ export function withComputed<
   { state: {}; props: ComputedResult<ComputedSignals>; methods: {} }
 > {
   return withProps((store) => {
-    const signals = signalsFactory(store);
+    const computedResult = computedFactory(store);
     const stateKeys = Reflect.ownKeys(signals);
 
     return stateKeys.reduce((prev, key) => {

--- a/modules/signals/src/with-computed.ts
+++ b/modules/signals/src/with-computed.ts
@@ -20,7 +20,7 @@ type ComputedResult<
 
 export function withComputed<
   Input extends SignalStoreFeatureResult,
-  ComputedSignals extends Record<
+  ComputedDictionary extends Record<
     string | symbol,
     Signal<unknown> | (() => unknown)
   >

--- a/modules/signals/src/with-computed.ts
+++ b/modules/signals/src/with-computed.ts
@@ -8,7 +8,7 @@ import { Prettify } from './ts-helpers';
 import { withProps } from './with-props';
 
 type ComputedResult<
-  ComputedSignals extends Record<
+  ComputedInput extends Record<
     string | symbol,
     Signal<unknown> | (() => unknown)
   >

--- a/projects/ngrx.io/content/guide/signals/signal-store/index.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/index.md
@@ -145,7 +145,7 @@ export class BookSearch {
 
 Computed signals can be added to the store using the `withComputed` feature.
 This feature accepts a factory function as an input argument, which is executed within the injection context.
-The factory should return a dictionary of computed signals, utilizing previously defined state signals and properties that are accessible through its input argument.
+The factory should return a dictionary containing either computed signals or functions that return values (which will automatically be wrapped in computed signals), utilizing previously defined state signals and properties that are accessible through its input argument.
 
 <code-example header="book-search-store.ts">
 
@@ -162,13 +162,14 @@ export const BookSearchStore = signalStore(
   // 👇 Accessing previously defined state signals and properties.
   withComputed(({ books, filter }) => ({
     booksCount: computed(() => books().length),
-    sortedBooks: computed(() => {
+    // 👇 Adds computed automatically
+    sortedBooks: () => {
       const direction = filter.order() === 'asc' ? 1 : -1;
 
       return books().toSorted((a, b) =>
         direction * a.title.localeCompare(b.title)
       );
-    }),
+    },
   }))
 );
 

--- a/projects/ngrx.io/content/guide/signals/signal-store/index.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/index.md
@@ -145,7 +145,7 @@ export class BookSearch {
 
 Computed signals can be added to the store using the `withComputed` feature.
 This feature accepts a factory function as an input argument, which is executed within the injection context.
-The factory should return a dictionary containing either computed signals or functions that return values (which will automatically be wrapped in computed signals), utilizing previously defined state signals and properties that are accessible through its input argument.
+The factory should return a dictionary containing either computed signals or functions that return values (which are automatically wrapped in computed signals), utilizing previously defined state signals and properties that are accessible through its input argument.
 
 <code-example header="book-search-store.ts">
 


### PR DESCRIPTION
Example:

```ts
const CounterStore = signalStore(
  withState({ count: 0 }),
  withComputed(({ count }) => ({
    doubleCount: () => count() * 2,
  })),
);
```

- Updated withComputed to automatically wrap functions in computed signals.
- Added tests to verify automatic computation and mixing user-defined computeds.
- Improved documentation to clarify the factory function's return type.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Closes #4782

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

