### PR TITLE
fix(www): remove duplicate scrollbar

### DIFF
--- a/projects/www/src/app/components/docs/symbol-excerpt-group.component.ts
+++ b/projects/www/src/app/components/docs/symbol-excerpt-group.component.ts
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         flex-direction: column;
         padding: 8px;
         gap: 2px;
-        overflow-x: scroll;
+        overflow-x: auto;
       }
     `,
   ],

--- a/projects/www/src/app/components/docs/symbol-excerpt.component.ts
+++ b/projects/www/src/app/components/docs/symbol-excerpt.component.ts
@@ -59,6 +59,7 @@ import { CodeHighlightPipe } from './code-highlight.pipe';
 
       pre {
         margin: 0;
+        overflow-x: initial;
       }
 
       .deprecated {


### PR DESCRIPTION
Closes #4828

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When viewing API documentation pages, code blocks (especially those with long function signatures) show a double horizontal scrollbar. This occurs due to nested scrollable containers within the code rendering components.
On macOS, when system scrollbar visibility is set to "When scrolling", the inner scrollbar becomes inaccessible — trackpad scrolling doesn't work inside the code blocks, effectively making the content unreadable in some cases.

Closes #4828

## What is the new behavior?

Code blocks now render with a single horizontal scrollbar. More importantly, scrolling now works properly on macOS trackpads when the system is set to show scrollbars only while scrolling.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
