### PR TITLE
feat(operators): tap response migration

### DIFF
--- a/modules/operators/migrations/20_0_0-beta_1-tap-response/index.spec.ts
+++ b/modules/operators/migrations/20_0_0-beta_1-tap-response/index.spec.ts
@@ -1,0 +1,142 @@
+import * as path from 'path';
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import { createWorkspace } from '@ngrx/schematics-core/testing';
+import { tags } from '@angular-devkit/core';
+import { visitCallExpression } from '@ngrx/schematics-core/utility/visitors';
+import * as ts from 'typescript';
+import * as prettier from 'prettier';
+
+describe('migrate tapResponse', () => {
+  const collectionPath = path.join(__dirname, '../migration.json');
+  const schematicRunner = new SchematicTestRunner('schematics', collectionPath);
+  let appTree: UnitTestTree;
+
+  beforeEach(async () => {
+    appTree = await createWorkspace(schematicRunner, appTree);
+  });
+
+  const verifySchematic = async (input: string, output: string) => {
+    appTree.create('main.ts', input);
+
+    const tree = await schematicRunner.runSchematic(
+      '20.0.0-beta_1-tap-response',
+      {},
+      appTree
+    );
+
+    const actual = prettier.format(tree.readContent('main.ts'), {
+      parser: 'typescript',
+    });
+
+    expect(actual).toBe(
+      prettier.format(output, {
+        parser: 'typescript',
+      })
+    );
+  };
+
+  it('should migrate basic tapResponse signature', async () => {
+    const input = tags.stripIndent`
+      import { tapResponse } from '@ngrx/component';
+      tapResponse(() => {}, () => {});
+    `;
+
+    const output = tags.stripIndent`
+      import { tapResponse } from '@ngrx/component';
+      tapResponse({
+        next: () => {},
+        error: () => {}
+      });
+    `;
+
+    await verifySchematic(input, output);
+  });
+
+  it('should migrate tapResponse with complete callback', async () => {
+    const input = tags.stripIndent`
+      tapResponse(() => next, () => error, () => complete);
+    `;
+
+    const output = tags.stripIndent`
+      tapResponse({
+        next: () => next,
+        error: () => error,
+        complete: () => complete
+      });
+    `;
+
+    await verifySchematic(input, output);
+  });
+
+  it('should migrate aliased tapResponse calls', async () => {
+    const input = tags.stripIndent`
+      const myTapResponse = tapResponse;
+      myTapResponse(() => next, () => error);
+    `;
+
+    const output = tags.stripIndent`
+      const myTapResponse = tapResponse;
+      myTapResponse({
+        next: () => next,
+        error: () => error
+      });
+    `;
+
+    await verifySchematic(input, output);
+  });
+
+  it('should migrate namespaced tapResponse calls', async () => {
+    const input = tags.stripIndent`
+      import * as operators from '@ngrx/component';
+      operators.tapResponse(() => next, () => error, () => complete);
+    `;
+
+    const output = tags.stripIndent`
+      import * as operators from '@ngrx/component';
+      operators.tapResponse({
+        next: () => next,
+        error: () => error,
+        complete: () => complete
+      });
+    `;
+
+    await verifySchematic(input, output);
+  });
+
+  it('should identify all call expressions including aliases and namespace calls', () => {
+    const code = tags.stripIndent`
+      import { tapResponse } from '@ngrx/component';
+      import * as operators from '@ngrx/component';
+      const myTapResponse = tapResponse;
+      const anotherAlias = operators;
+      tapResponse(() => {}, () => {});
+      myTapResponse(() => {}, () => {});
+      anotherAlias.tapResponse(() => {}, () => {});
+    `;
+
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      code,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS
+    );
+
+    const foundCalls: ts.CallExpression[] = [];
+
+    visitCallExpression(sourceFile, (node) => {
+      foundCalls.push(node);
+    });
+
+    expect(foundCalls.length).toBe(3);
+
+    const callTexts = foundCalls.map((call) => call.getText());
+
+    expect(callTexts).toContain('tapResponse(() => {}, () => {})');
+    expect(callTexts).toContain('myTapResponse(() => {}, () => {})');
+    expect(callTexts).toContain('anotherAlias.tapResponse(() => {}, () => {})');
+  });
+});

--- a/modules/operators/migrations/20_0_0-beta_1-tap-response/index.ts
+++ b/modules/operators/migrations/20_0_0-beta_1-tap-response/index.ts
@@ -1,0 +1,94 @@
+import { Rule, Tree, SchematicContext } from '@angular-devkit/schematics';
+import {
+  visitTSSourceFiles,
+  createReplaceChange,
+  commitChanges,
+  Change,
+} from '@ngrx/component/schematics-core';
+import { visitCallExpression } from '@ngrx/schematics-core/utility/visitors';
+import * as ts from 'typescript';
+
+export default function migrateTapResponse(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    visitTSSourceFiles(tree, (sourceFile) => {
+      const changes: Change[] = [];
+      const visited = new Set<number>();
+      const tapResponseIdentifiers = new Set(['tapResponse']);
+
+      // Track aliases like: const myTapResponse = tapResponse;
+      ts.forEachChild(sourceFile, (node) => {
+        if (ts.isVariableStatement(node)) {
+          node.declarationList.declarations.forEach((decl) => {
+            if (
+              ts.isIdentifier(decl.name) &&
+              decl.initializer &&
+              ts.isIdentifier(decl.initializer) &&
+              decl.initializer.text === 'tapResponse'
+            ) {
+              tapResponseIdentifiers.add(decl.name.text);
+            }
+          });
+        }
+      });
+
+      const printer = ts.createPrinter();
+
+      visitCallExpression(sourceFile, (node) => {
+        const { expression, arguments: args } = node;
+
+        // Avoid duplicates by tracking position
+        if (visited.has(node.getStart())) return;
+        visited.add(node.getStart());
+
+        let fnName = '';
+        if (ts.isIdentifier(expression)) {
+          fnName = expression.text;
+        } else if (ts.isPropertyAccessExpression(expression)) {
+          fnName = expression.name.text;
+        }
+
+        if (
+          tapResponseIdentifiers.has(fnName) &&
+          (args.length === 2 || args.length === 3) &&
+          args.every(
+            (arg) => ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)
+          )
+        ) {
+          const props: ts.PropertyAssignment[] = [
+            ts.factory.createPropertyAssignment('next', args[0]),
+            ts.factory.createPropertyAssignment('error', args[1]),
+          ];
+
+          if (args[2]) {
+            props.push(
+              ts.factory.createPropertyAssignment('complete', args[2])
+            );
+          }
+
+          const newCall = ts.factory.createCallExpression(
+            expression,
+            undefined,
+            [ts.factory.createObjectLiteralExpression(props, true)]
+          );
+
+          const newText = printer.printNode(
+            ts.EmitHint.Expression,
+            newCall,
+            sourceFile
+          );
+
+          changes.push(
+            createReplaceChange(sourceFile, node, node.getText(), newText)
+          );
+        }
+      });
+
+      if (changes.length) {
+        commitChanges(tree, sourceFile.fileName, changes);
+        context.logger.debug(
+          `[rxjs] Migrated deprecated tapResponse in ${sourceFile.fileName}`
+        );
+      }
+    });
+  };
+}

--- a/modules/operators/migrations/migration.json
+++ b/modules/operators/migrations/migration.json
@@ -1,4 +1,10 @@
 {
   "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
-  "schematics": {}
+  "schematics": {
+    "20.0.0-beta_1-tap-response": {
+      "description": "Update tapResponse signature",
+      "version": "20.0.0-beta.1",
+      "factory": "./20_0_0-beta_1-tap-response/index"
+    }
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4841 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

`toBe` and `toContain`  are always underlined and said not to exist.  However, the tests work.  Potential misconfiguration?  Known issue?  If this is expected behavior, I think a note somewhere would help. I didn't lose much time as I just decided to run the tests anyway.  You can run the tests with `(npx) nx run operators:test`.   Use `npx` if you are using a codespace or don't have Nx installed. 

The spec file imports `prettier` because I was dealing with inconsistencies.  Initially, I had everything on one line and then I moved to multi-line.

Don't know what you actually want to call the migration or what potential release.  You can freely edit it to whatever you want.

I am unsure of how robust this truly is, but I did a few passes to make it better.  