### PR TITLE
feat(signals): allow access to methods in `withComputed`

### DIFF
--- a/modules/signals/spec/types/with-computed.types.spec.ts
+++ b/modules/signals/spec/types/with-computed.types.spec.ts
@@ -1,15 +1,17 @@
 import { expecter } from 'ts-snippet';
 import { compilerOptions } from './helpers';
-import { signalStore, withComputed } from 'modules/signals/src';
-import { TestBed } from '@angular/core/testing';
 
 describe('withComputed', () => {
   const expectSnippet = expecter(
     (code) => `
         import {
           deepComputed,
+          patchState,
           signalStore,
           withComputed,
+          withMethods,
+          withProps,
+          withState,
         } from '@ngrx/signals';
         import { TestBed } from '@angular/core/testing';
         import { signal } from '@angular/core';
@@ -18,6 +20,49 @@ describe('withComputed', () => {
       `,
     compilerOptions()
   );
+
+  it('has access to props, state signals and methods', () => {
+    const snippet = `
+      signalStore(
+        withState({
+          a: 1,
+        }),
+        withProps(() => {
+          return {
+            b: 2,
+          };
+        }),
+        withMethods(({ a, b }) => ({
+          sum: () => a() + b,
+        })),
+        withComputed(({ a, b, sum }) => ({
+          prettySum: () => \`Sum: \${a()} + \${b} = \${sum()}\`,
+        }))
+      );
+    `;
+
+    expectSnippet(snippet).toSucceed();
+  });
+
+  it('has no access to the state', () => {
+    const snippet = `
+      signalStore(
+        withState({
+          a: 1,
+        }),
+        withComputed((store) => ({
+          prettySum: () => {
+            patchState(store, { a: 2 });
+            return store.a();
+          },
+        }))
+      );
+    `;
+
+    expectSnippet(snippet).toFail(
+      /not assignable to parameter of type 'WritableStateSource<{ a: number; }>'/
+    );
+  });
 
   it('creates a Signal automatically', () => {
     const snippet = `

--- a/modules/signals/spec/types/with-computed.types.spec.ts
+++ b/modules/signals/spec/types/with-computed.types.spec.ts
@@ -44,7 +44,7 @@ describe('withComputed', () => {
     expectSnippet(snippet).toSucceed();
   });
 
-  it('has no access to the state', () => {
+  it('has no access to the state source', () => {
     const snippet = `
       signalStore(
         withState({

--- a/modules/signals/spec/types/with-computed.types.spec.ts
+++ b/modules/signals/spec/types/with-computed.types.spec.ts
@@ -60,7 +60,7 @@ describe('withComputed', () => {
     `;
 
     expectSnippet(snippet).toFail(
-      /not assignable to parameter of type 'WritableStateSource<{ a: number; }>'/
+      /not assignable to parameter of type 'WritableStateSource<object>'/
     );
   });
 

--- a/modules/signals/spec/with-computed.spec.ts
+++ b/modules/signals/spec/with-computed.spec.ts
@@ -1,4 +1,5 @@
 import { computed, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import {
   deepComputed,
   signalStoreFeature,
@@ -7,7 +8,6 @@ import {
   withState,
 } from '../src';
 import { getInitialInnerStore, signalStore } from '../src/signal-store';
-import { TestBed } from '@angular/core/testing';
 
 describe('withComputed', () => {
   it('adds computed signals to the store immutably', () => {

--- a/modules/signals/src/with-computed.ts
+++ b/modules/signals/src/with-computed.ts
@@ -28,7 +28,9 @@ export function withComputed<
   >
 >(
   computedFactory: (
-    store: Prettify<StateSignals<Input['state']> & Input['props']>
+    store: Prettify<
+      StateSignals<Input['state']> & Input['props'] & Input['methods']
+    >
   ) => ComputedDictionary
 ): SignalStoreFeature<
   Input,

--- a/projects/ngrx.io/content/guide/signals/signal-store/index.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/index.md
@@ -167,7 +167,7 @@ export class BookSearch {
 
 Computed signals can be added to the store using the `withComputed` feature.
 This feature accepts a factory function as an input argument, which is executed within the injection context.
-The factory should return a dictionary containing either computed signals or functions that return values (which are automatically wrapped in computed signals), utilizing previously defined state signals and properties that are accessible through its input argument.
+The factory should return a dictionary containing either computed signals or functions that return values (which are automatically wrapped in computed signals), utilizing previously defined state signals, properties and methods that are accessible through its input argument.
 
 <code-example header="book-search-store.ts">
 

--- a/projects/ngrx.io/content/guide/signals/signal-store/index.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/index.md
@@ -167,7 +167,7 @@ export class BookSearch {
 
 Computed signals can be added to the store using the `withComputed` feature.
 This feature accepts a factory function as an input argument, which is executed within the injection context.
-The factory should return a dictionary containing either computed signals or functions that return values (which are automatically wrapped in computed signals), utilizing previously defined state signals, properties and methods that are accessible through its input argument.
+The factory should return a dictionary containing either computed signals or functions that return values (which are automatically wrapped in computed signals), utilizing previously defined state signals, properties, and methods that are accessible through its input argument.
 
 <code-example header="book-search-store.ts">
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`withComputed` doesn't have access to `methods`

Closes #4846

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
