### PR TITLE
feat(signals): disallow user-defined signals in withState and signalState

### DIFF
--- a/modules/signals/spec/state-source.spec.ts
+++ b/modules/signals/spec/state-source.spec.ts
@@ -1,12 +1,8 @@
 import {
-  computed,
   createEnvironmentInjector,
   effect,
   EnvironmentInjector,
   Injectable,
-  isSignal,
-  linkedSignal,
-  resource,
   signal,
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
@@ -55,7 +51,7 @@ describe('StateSource', () => {
     });
 
     it('returns false for a readonly StateSource', () => {
-      const stateSource: StateSource<{ vaulue: typeof initialState }> = {
+      const stateSource: StateSource<{ value: typeof initialState }> = {
         [STATE_SOURCE]: { value: signal(initialState).asReadonly() },
       };
 
@@ -212,41 +208,42 @@ describe('StateSource', () => {
     });
 
     it('sets only root properties which values have changed (equal check)', () => {
-      let updateCounter = 0;
-      const userSignal = signal(
-        {
-          firstName: 'John',
-          lastName: 'Smith',
-        },
-        {
-          equal: (a, b) => {
-            updateCounter++;
-            return a === b;
-          },
-        }
-      );
-
       const UserStore = signalStore(
         { providedIn: 'root', protectedState: false },
-        withState({ user: userSignal, city: 'Changan' })
+        withState({
+          user: { firstName: 'John', lastName: 'Smith' },
+          city: 'Changan',
+        })
       );
       const store = TestBed.inject(UserStore);
+      let userChangedCount = 0;
+      TestBed.runInInjectionContext(() => {
+        effect(() => {
+          store.user();
+          userChangedCount++;
+        });
+      });
 
-      expect(updateCounter).toBe(0);
+      TestBed.tick();
+      expect(userChangedCount).toBe(1);
 
       patchState(store, { city: 'Xian' });
-      expect(updateCounter).toBe(0);
+      TestBed.tick();
+      expect(userChangedCount).toBe(1);
 
       patchState(store, (state) => state);
-      expect(updateCounter).toBe(0);
+      TestBed.tick();
+      expect(userChangedCount).toBe(1);
 
       patchState(store, ({ user }) => ({ user }));
-      expect(updateCounter).toBe(0);
+      TestBed.tick();
+      expect(userChangedCount).toBe(1);
 
       patchState(store, ({ user }) => ({
         user: { ...user, firstName: 'Jane' },
       }));
-      expect(updateCounter).toBe(1);
+      TestBed.tick();
+      expect(userChangedCount).toBe(2);
     });
   });
 
@@ -465,127 +462,6 @@ describe('StateSource', () => {
         store.increment();
 
         expect(stateHistory).toEqual([0, 1, 2, 3]);
-      });
-    });
-  });
-
-  describe('user-defined signals as state slices', () => {
-    [
-      {
-        name: 'signalStore',
-        setup<State extends object>(state: State) {
-          const Store = signalStore(
-            { providedIn: 'root', protectedState: false },
-            withState(state)
-          );
-          return TestBed.inject(Store);
-        },
-      },
-      {
-        name: 'signalState',
-        setup<State extends object>(state: State) {
-          return signalState(state);
-        },
-      },
-    ].forEach(({ name, setup }) => {
-      describe(name, () => {
-        it('integrates writable Signals as-is', () => {
-          const user = {
-            id: 1,
-            name: 'John Doe',
-          };
-          const userSignal = signal(user);
-
-          const store = setup({ user: userSignal });
-          const prettyName = computed(
-            () => `${store.user().name} ${store.user().id}`
-          );
-
-          expect(store.user()).toBe(user);
-          expect(prettyName()).toBe('John Doe 1');
-
-          userSignal.set({ id: 2, name: 'Jane Doe' });
-          expect(store.user()).toEqual({ id: 2, name: 'Jane Doe' });
-
-          patchState(store, { user: { id: 3, name: 'Jack Doe' } });
-          expect(store.user()).toEqual({ id: 3, name: 'Jack Doe' });
-        });
-
-        it('integrates a linkedSignal and its update mechanism', () => {
-          const triggerSignal = signal(1);
-          const userLinkedSignal = linkedSignal({
-            source: triggerSignal,
-            computation: () => ({ id: 1, name: 'John Doe' }),
-          });
-
-          const store = setup({ user: userLinkedSignal });
-          const prettyName = computed(
-            () => `${store.user().name} ${store.user().id}`
-          );
-
-          expect(store.user()).toEqual({ id: 1, name: 'John Doe' });
-          expect(prettyName()).toBe('John Doe 1');
-
-          patchState(store, { user: { id: 2, name: 'Jane Doe' } });
-          expect(prettyName()).toBe('Jane Doe 2');
-
-          triggerSignal.set(2);
-          expect(prettyName()).toBe('John Doe 1');
-        });
-
-        it('supports a resource', async () => {
-          const resourceTrigger = signal(1);
-          const userResource = TestBed.runInInjectionContext(() =>
-            resource({
-              request: resourceTrigger,
-              loader: (params) =>
-                Promise.resolve({ id: params.request, name: 'John Doe' }),
-              defaultValue: { id: 0, name: 'Loading...' },
-            })
-          );
-
-          const store = setup({ user: userResource.value });
-          expect(store.user()).toEqual({ id: 0, name: 'Loading...' });
-
-          await new Promise((resolve) => setTimeout(resolve));
-          expect(store.user()).toEqual({ id: 1, name: 'John Doe' });
-
-          resourceTrigger.set(2);
-          await new Promise((resolve) => setTimeout(resolve));
-          expect(store.user()).toEqual({ id: 2, name: 'John Doe' });
-        });
-
-        it('allows mixing signals and plain values', () => {
-          const user = {
-            id: 1,
-            name: 'John Doe',
-          };
-          const userSignal = signal(user);
-          const product = { id: 1, name: 'Product A' };
-
-          const store = setup({ user: userSignal, product });
-
-          expect(store.user()).toBe(user);
-          expect(store.product()).toBe(product);
-        });
-
-        it('does not strip a readonly Signal', () => {
-          const store = setup({ n: signal(1).asReadonly() });
-
-          expect(isSignal(store.n())).toBe(true);
-          expect(store.n()()).toBe(1);
-        });
-
-        it('does not strip a nested writable Signal', () => {
-          const user = {
-            id: 1,
-            name: 'John Doe',
-          };
-          const userSignal = signal(user);
-          const store = setup({ data: { user: userSignal } });
-
-          expect(isSignal(store.data.user())).toBe(true);
-        });
       });
     });
   });

--- a/modules/signals/spec/types/signal-state.types.spec.ts
+++ b/modules/signals/spec/types/signal-state.types.spec.ts
@@ -145,7 +145,7 @@ describe('signalState', () => {
       'unique symbol | unique symbol'
     );
 
-    expectSnippet(snippet).toInfer('setStateValue', 'StateResult<Set<number>>');
+    expectSnippet(snippet).toInfer('setStateValue', 'Set<number>');
     expectSnippet(snippet).toInfer(
       'setStateKeys',
       'unique symbol | unique symbol'
@@ -153,7 +153,7 @@ describe('signalState', () => {
 
     expectSnippet(snippet).toInfer(
       'mapStateValue',
-      'StateResult<Map<number, { bar: boolean; }>>'
+      'Map<number, { bar: boolean; }>'
     );
     expectSnippet(snippet).toInfer(
       'mapStateKeys',
@@ -162,7 +162,7 @@ describe('signalState', () => {
 
     expectSnippet(snippet).toInfer(
       'uintArrayStateValue',
-      'StateResult<Uint8ClampedArray<ArrayBuffer>>'
+      'Uint8ClampedArray<ArrayBuffer>'
     );
     expectSnippet(snippet).toInfer(
       'uintArrayStateKeys',
@@ -193,26 +193,26 @@ describe('signalState', () => {
 
     expectSnippet(snippet).toInfer(
       'weakSetStateValue',
-      'StateResult<WeakSet<{ foo: string; }>>'
+      'WeakSet<{ foo: string; }>'
     );
     expectSnippet(snippet).toInfer(
       'weakSetStateKeys',
       'unique symbol | unique symbol'
     );
 
-    expectSnippet(snippet).toInfer('dateStateValue', 'StateResult<Date>');
+    expectSnippet(snippet).toInfer('dateStateValue', 'Date');
     expectSnippet(snippet).toInfer(
       'dateStateKeys',
       'unique symbol | unique symbol'
     );
 
-    expectSnippet(snippet).toInfer('errorStateValue', 'StateResult<Error>');
+    expectSnippet(snippet).toInfer('errorStateValue', 'Error');
     expectSnippet(snippet).toInfer(
       'errorStateKeys',
       'unique symbol | unique symbol'
     );
 
-    expectSnippet(snippet).toInfer('regExpStateValue', 'StateResult<RegExp>');
+    expectSnippet(snippet).toInfer('regExpStateValue', 'RegExp');
     expectSnippet(snippet).toInfer(
       'regExpStateKeys',
       'unique symbol | unique symbol'
@@ -228,7 +228,7 @@ describe('signalState', () => {
 
     expectSnippet(snippet).toSucceed();
 
-    expectSnippet(snippet).toInfer('stateValue', 'StateResult<() => void>');
+    expectSnippet(snippet).toInfer('stateValue', '() => void');
     expectSnippet(snippet).toInfer(
       'stateKeys',
       'unique symbol | unique symbol'

--- a/modules/signals/spec/types/signal-store.types.spec.ts
+++ b/modules/signals/spec/types/signal-store.types.spec.ts
@@ -4,7 +4,7 @@ import { compilerOptions } from './helpers';
 describe('signalStore', () => {
   const expectSnippet = expecter(
     (code) => `
-        import { computed, inject, Signal, signal } from '@angular/core';
+        import { computed, inject, Signal } from '@angular/core';
         import {
           getState,
           patchState,
@@ -858,47 +858,6 @@ describe('signalStore', () => {
       ${snippet}
       patchState(store, { count1: 1, _count2: 1 });
     `).toFail(/'_count2' does not exist in type/);
-  });
-
-  it('exposes a writable Signal as readonly', () => {
-    const snippet = `
-      type User = {
-        id: number;
-        name: string;
-        location: {
-          city: string;
-          country: string;
-        }
-      }
-
-      const userSignal = signal({
-        id: 1,
-        name: 'John Doe',
-        location: {
-          city: 'New York',
-          country: 'USA'
-        }
-      });
-
-      const Store = signalStore(
-        withState({
-          user: userSignal,
-          foo: signal('bar')
-        })
-      );
-
-      const store = new Store();
-      const user = store.user;
-      const foo = store.foo;
-    `;
-
-    expectSnippet(snippet).toSucceed();
-
-    expectSnippet(snippet).toInfer(
-      'user',
-      'DeepSignal<{ id: number; name: string; location: { city: string; country: string; }; }>'
-    );
-    expectSnippet(snippet).toInfer('foo', 'Signal<string>');
   });
 
   describe('custom features', () => {

--- a/modules/signals/spec/types/with-linked-state.types.spec.ts
+++ b/modules/signals/spec/types/with-linked-state.types.spec.ts
@@ -59,7 +59,7 @@ describe('withLinkedState', () => {
     );
   });
 
-  it('resolves to a normal state signal with automatic linkedSignal', () => {
+  it('adds state slice with computation function', () => {
     const snippet = `
       const UserStore = signalStore(
         { providedIn: 'root' },
@@ -78,7 +78,7 @@ describe('withLinkedState', () => {
     expectSnippet(snippet).toInfer('lastname', 'Signal<string>');
   });
 
-  it('resolves to a normal state signal with manual linkedSignal', () => {
+  it('adds state slice with explicit linkedSignal', () => {
     const snippet = `
       const UserStore = signalStore(
         { providedIn: 'root' },
@@ -100,7 +100,7 @@ describe('withLinkedState', () => {
     expectSnippet(snippet).toInfer('lastname', 'Signal<string>');
   });
 
-  it('sets stateSignals as DeepSignal for automatic linkedSignal', () => {
+  it('creates deep signals with computation functions', () => {
     const snippet = `
       const UserStore = signalStore(
         { providedIn: 'root' },
@@ -128,7 +128,7 @@ describe('withLinkedState', () => {
     );
   });
 
-  it('sets stateSignals as DeepSignal for manual linkedSignal', () => {
+  it('creates deep signals with explicit linked signals', () => {
     const snippet = `
       const UserStore = signalStore(
         { providedIn: 'root' },
@@ -163,6 +163,7 @@ describe('withLinkedState', () => {
         withLinkedState(({ foo }) => ({
           bar: () => foo(),
           baz: linkedSignal(() => foo()),
+          qux: signal({ x: 1 }),
         }))
       );
 
@@ -170,11 +171,13 @@ describe('withLinkedState', () => {
 
       const bar = store.bar;
       const baz = store.baz;
+      const qux = store.qux;
     `;
 
     expectSnippet(snippet).toSucceed();
 
     expectSnippet(snippet).toInfer('bar', 'Signal<string>');
     expectSnippet(snippet).toInfer('baz', 'Signal<string>');
+    expectSnippet(snippet).toInfer('qux', 'DeepSignal<{ x: number; }>');
   });
 });

--- a/modules/signals/spec/with-state.spec.ts
+++ b/modules/signals/spec/with-state.spec.ts
@@ -1,7 +1,6 @@
-import { computed, isSignal, linkedSignal, signal } from '@angular/core';
-import { withComputed, withMethods, withState } from '../src';
+import { isSignal, signal } from '@angular/core';
+import { getState, withComputed, withMethods, withState } from '../src';
 import { getInitialInnerStore } from '../src/signal-store';
-import { getState, STATE_SOURCE } from '../src/state-source';
 
 describe('withState', () => {
   it('patches state source and updates slices immutably', () => {
@@ -91,39 +90,5 @@ describe('withState', () => {
       'Trying to override:',
       'p2, s2, m2, Symbol(computed_secret), Symbol(method_secret)'
     );
-  });
-
-  it('allows to pass user-defined WritableSignals', () => {
-    const user = signal({ firstName: 'John', lastName: 'Doe' });
-    const initialStore = getInitialInnerStore();
-
-    const store = withState(() => ({
-      user,
-    }))(initialStore);
-
-    expect(store[STATE_SOURCE]['user']).toBe(user);
-  });
-
-  it('allows to pass mixed signals and plain values', () => {
-    const user = signal({ firstName: 'John', lastName: 'Doe' });
-    const address = computed(() => ({
-      street: '123 Main St',
-      city: 'Anytown',
-    }));
-    const age = linkedSignal(() => 30);
-
-    const initialStore = getInitialInnerStore();
-
-    const store = withState(() => ({
-      user,
-      address,
-      age,
-      isAdmin: false,
-    }))(initialStore);
-
-    expect(store[STATE_SOURCE]['user']).toBe(user);
-    expect(store[STATE_SOURCE]['address']).not.toBe(address);
-    expect(store[STATE_SOURCE]['age']).toBe(age);
-    expect(store[STATE_SOURCE]['isAdmin']()).toBe(false);
   });
 });

--- a/modules/signals/src/signal-store.ts
+++ b/modules/signals/src/signal-store.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, inject, Injectable, signal, Type } from '@angular/core';
+import { DestroyRef, inject, Injectable, Type } from '@angular/core';
 import { STATE_SOURCE, StateSource, WritableStateSource } from './state-source';
 import {
   EmptyFeatureResult,

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -16,19 +16,11 @@ const STATE_WATCHERS = new WeakMap<object, Array<StateWatcher<any>>>();
 export const STATE_SOURCE = Symbol('STATE_SOURCE');
 
 export type WritableStateSource<State extends object> = {
-  [STATE_SOURCE]: {
-    [Property in keyof State]: WritableSignal<State[Property]>;
-  };
+  [STATE_SOURCE]: { [K in keyof State]: WritableSignal<State[K]> };
 };
 
 export type StateSource<State extends object> = {
-  [STATE_SOURCE]: { [Property in keyof State]: Signal<State[Property]> };
-};
-
-export type StateResult<StateInput extends object> = {
-  [K in keyof StateInput]: StateInput[K] extends WritableSignal<infer V>
-    ? V
-    : StateInput[K];
+  [STATE_SOURCE]: { [K in keyof State]: Signal<State[K]> };
 };
 
 export type PartialStateUpdater<State extends object> = (
@@ -77,26 +69,22 @@ export function patchState<State extends object>(
 
   const signals = stateSource[STATE_SOURCE];
   const stateKeys = Reflect.ownKeys(stateSource[STATE_SOURCE]);
+
   for (const key of Reflect.ownKeys(newState)) {
-    if (!stateKeys.includes(key)) {
-      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
-        console.warn(
-          `@ngrx/signals: patchState was called with an unknown state slice '${String(
-            key
-          )}'.`,
-          'Ensure that all state properties are explicitly defined in the initial state.',
-          'Updates to properties not present in the initial state will be ignored.'
-        );
+    if (stateKeys.includes(key)) {
+      const signalKey = key as keyof State;
+      if (currentState[signalKey] !== newState[signalKey]) {
+        signals[signalKey].set(newState[signalKey]);
       }
-      continue;
+    } else if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      console.warn(
+        `@ngrx/signals: patchState was called with an unknown state slice '${String(
+          key
+        )}'.`,
+        'Ensure that all state properties are explicitly defined in the initial state.',
+        'Updates to properties not present in the initial state will be ignored.'
+      );
     }
-    const signalKey = key as keyof State;
-
-    if (currentState[signalKey] === newState[signalKey]) {
-      continue;
-    }
-
-    signals[signalKey].set(newState[signalKey]);
   }
 
   notifyWatchers(stateSource);

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -44,7 +44,7 @@ type LinkedStateResult<
  * This returns a state of type `{ options: number[], selectedOption: number | undefined }`.
  * When the `options` signal changes, the `selectedOption` automatically updates.
  *
- * For advanced use cases, `linkedSignal` can be called within `withLinkedState`:
+ * For advanced use cases, `linkedSignal` or any other `WritableSignal` instance can be used within `withLinkedState`:
  *
  * ```typescript
  * type Option = { id: number; label: string };

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -1,5 +1,4 @@
 import { linkedSignal, WritableSignal } from '@angular/core';
-
 import { toDeepSignal } from './deep-signal';
 import {
   InnerSignalStore,
@@ -27,11 +26,12 @@ type LinkedStateResult<
 };
 
 /**
- *
  * @description
+ *
  * Adds linked state slices to a SignalStore.
  *
  * @usageNotes
+ *
  * ```typescript
  * const OptionsStore = signalStore(
  *   withState({ options: [1, 2, 3] }),
@@ -43,7 +43,6 @@ type LinkedStateResult<
  *
  * This returns a state of type `{ options: number[], selectedOption: number | undefined }`.
  * When the `options` signal changes, the `selectedOption` automatically updates.
- * Whenever the `options` signal changes, the `selectedOption` will automatically update.
  *
  * For advanced use cases, `linkedSignal` can be called within `withLinkedState`:
  *
@@ -90,10 +89,10 @@ export function withLinkedState<
     const stateSignals = {} as SignalsDictionary;
 
     for (const key of stateKeys) {
-      const signalOrFunction = linkedState[key];
-      stateSource[key] = isWritableSignal(signalOrFunction)
-        ? signalOrFunction
-        : linkedSignal(signalOrFunction);
+      const signalOrComputationFn = linkedState[key];
+      stateSource[key] = isWritableSignal(signalOrComputationFn)
+        ? signalOrComputationFn
+        : linkedSignal(signalOrComputationFn);
       stateSignals[key] = toDeepSignal(stateSource[key]);
     }
 

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -8,29 +8,30 @@ import {
   SignalStoreFeature,
   SignalStoreFeatureResult,
 } from './signal-store-models';
-import { isWritableSignal, STATE_SOURCE, StateResult } from './state-source';
+import { STATE_SOURCE } from './state-source';
 
 export function withState<State extends object>(
   stateFactory: () => State
 ): SignalStoreFeature<
   EmptyFeatureResult,
-  { state: StateResult<State>; props: {}; methods: {} }
+  { state: State; props: {}; methods: {} }
 >;
 export function withState<State extends object>(
   state: State
 ): SignalStoreFeature<
   EmptyFeatureResult,
-  { state: StateResult<State>; props: {}; methods: {} }
+  { state: State; props: {}; methods: {} }
 >;
 export function withState<State extends object>(
   stateOrFactory: State | (() => State)
 ): SignalStoreFeature<
   SignalStoreFeatureResult,
-  { state: StateResult<State>; props: {}; methods: {} }
+  { state: State; props: {}; methods: {} }
 > {
   return (store) => {
-    const state =
-      typeof stateOrFactory === 'function' ? stateOrFactory() : stateOrFactory;
+    const state = (
+      typeof stateOrFactory === 'function' ? stateOrFactory() : stateOrFactory
+    ) as Record<string | symbol, unknown>;
     const stateKeys = Reflect.ownKeys(state);
 
     assertUniqueStoreMembers(store, stateKeys);
@@ -39,18 +40,16 @@ export function withState<State extends object>(
       string | symbol,
       Signal<unknown>
     >;
-    const stateSignals = {} as SignalsDictionary;
+    const stateSignals: SignalsDictionary = {};
+
     for (const key of stateKeys) {
-      const signalOrValue = (state as Record<string | symbol, unknown>)[key];
-      stateSource[key] = isWritableSignal(signalOrValue)
-        ? signalOrValue
-        : signal(signalOrValue);
+      stateSource[key] = signal(state[key]);
       stateSignals[key] = toDeepSignal(stateSource[key]);
     }
 
     return {
       ...store,
       stateSignals: { ...store.stateSignals, ...stateSignals },
-    } as InnerSignalStore<StateResult<State>>;
+    } as InnerSignalStore<State>;
   };
 }

--- a/projects/ngrx.io/content/guide/migration/v20.md
+++ b/projects/ngrx.io/content/guide/migration/v20.md
@@ -46,20 +46,7 @@ const store = new Store();
 getState(store) === initialState; // true
 ```
 
-2. Top-level `WritableSignal`s are wrapped with `Signal`s:
-
-```ts
-// signalState:
-const state = signalState({ ngrx: signal('rocks') });
-state.ngrx // type: Signal<WritableSignal<string>>
-
-// withState:
-const Store = signalStore(withState({ ngrx: signal('rocks') }));
-const store = new Store();
-store.ngrx // type: Signal<WritableSignal<string>>
-```
-
-3. Root state properties can be added dynamically:
+2. Root state properties can be added dynamically:
 
 ```ts
 // signalState:
@@ -98,20 +85,7 @@ const store = new Store();
 getState(store) === initialState; // false
 ```
 
-2. Top-level `WritableSignal`s are not wrapped with `Signal`s:
-
-```ts
-// signalState:
-const state = signalState({ ngrx: signal('rocks') });
-state.ngrx // type: Signal<string>
-
-// withState:
-const Store = signalStore(withState({ ngrx: signal('rocks') }));
-const store = new Store();
-store.ngrx // type: Signal<string>
-```
-
-3. Root state properties can not be added dynamically:
+2. Root state properties can not be added dynamically:
 
 ```ts
 // signalState:

--- a/projects/ngrx.io/content/guide/signals/signal-state.md
+++ b/projects/ngrx.io/content/guide/signals/signal-state.md
@@ -117,34 +117,6 @@ patchState(userState, (state) => ({
 patchState(userState, setFirstName('Stevie'), setAdmin());
 ```
 
-## Using User-Defined Signals
-
-The `signalState` function supports integrating user-defined `WritableSignal` instances as part of the state.
-
-If a root state property is a `WritableSignal`, its value becomes an integral part of the state.
-The SignalState instance and the original signal remain synchronized - updating one will immediately reflect in the other.
-
-```ts
-const name = signal('Jimi Hendrix');
-const userState = signalState({
-  // 👇 Providing an external signal as part of the initial state.
-  name,
-  isAdmin: false,
-});
-
-console.log(userState.name()); // logs: Jimi Hendrix
-
-// Updating the external signal
-name.set('Brian May');
-// reflects the value in the SignalState instance.
-console.log(userState.name()); // logs: Brian May
-
-// Updating the SignalState instance
-patchState(userState, { name: 'Eric Clapton' });
-// reflects the value in the external signal.
-console.log(name()); // logs: Eric Clapton
-```
-
 ## Usage
 
 ### Example 1: SignalState in a Component

--- a/projects/ngrx.io/content/guide/signals/signal-store/index.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/index.md
@@ -49,28 +49,6 @@ The `BookSearchStore` instance will contain the following properties:
 
 <div class="alert is-helpful">
 
-In addition to plain values, the `withState` feature also accepts user-defined `WritableSignal` instances as part of the state.
-In this case, the SignalStore's state and the original signal remain synchronized - updating one will immediately reflect in the other.
-
-```ts
-import { signalStore, withState } from '@ngrx/signals';
-import { Book } from './book';
-
-const books = signal<Book[]>([]);
-
-const BookSearchStore = signalStore(
-  withState({
-    // 👇 Providing an external signal as part of the initial state.
-    books,
-    isLoading: false,
-  })
-);
-```
-
-</div>
-
-<div class="alert is-helpful">
-
 The `withState` feature also has a signature that takes the initial state factory as an input argument.
 The factory is executed within the injection context, allowing initial state to be obtained from a service or injection token.
 

--- a/projects/ngrx.io/content/guide/signals/signal-store/linked-state.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/linked-state.md
@@ -61,7 +61,7 @@ export class OptionList {
 
 The `withLinkedState` feature also supports providing `WritableSignal` instances as linked state slices.
 This can include signals created using `linkedSignal()` with `source` and `computation` options, as well as any other `WritableSignal` instances.
-In both cases, the SignalStore and the original signal remain fully synchronized - updating one will immediately reflect in the other.
+In both cases, the SignalStore and the original signal remain fully synchronized - updating one immediately reflects in the other.
 
 <code-example header="options-store.ts">
 

--- a/projects/ngrx.io/content/guide/signals/signal-store/linked-state.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/linked-state.md
@@ -60,7 +60,7 @@ export class OptionList {
 ## Explicit Linking
 
 The `withLinkedState` feature also supports providing `WritableSignal` instances as linked state slices.
-This can include signals created using `linkedSignal()` with `source` and `computation` options, as well as any other user-defined `WritableSignal` instances.
+This can include signals created using `linkedSignal()` with `source` and `computation` options, as well as any other `WritableSignal` instances.
 In both cases, the SignalStore and the original signal remain fully synchronized - updating one will immediately reflect in the other.
 
 <code-example header="options-store.ts">

--- a/projects/ngrx.io/content/guide/signals/signal-store/linked-state.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/linked-state.md
@@ -1,33 +1,67 @@
 # Linked State
 
-The `withLinkedState` feature enables the creation of state slices that depend on other parts of the state. It supports both implicit and explicit linking.
-
-In the context of the SignalStore, `withLinkedState()` serves as the equivalent to Angular's `linkedSignal()`.
-
-Linked state can be added to the store using the `withLinkedState()` feature. This feature accepts a factory function as an input argument, which is executed within the injection context. The factory should return a dictionary containing:
-- Functions that return values, which the SignalStore wraps automatically into a `linkedSignal()`, or
-- `WritableSignal`, which the user can create with `linkedSignal()`.
+The `withLinkedState` feature enables the creation of state slices that depend on other signals.
+This feature accepts a factory function as an input argument, which is executed within the injection context.
+The factory should return a dictionary containing linked state slices, defined as either computation functions or `WritableSignal` instances.
+These linked state slices become an integral part of the SignalStore's state and are treated the same as regular state slices - `DeepSignal`s are created for each of them, and they can be updated using `patchState`.
 
 ## Implicit Linking
 
-The following example shows the implicit notation, where a function returns a value. That function is wrapped into a `linkedSignal()`, which means it is tracked, and if one of the tracked Signals changes, the function is re-executed synchronously.
+When a computation function is provided, the SignalStore wraps it in a `linkedSignal()`.
+As a result, the linked state slice is updated automatically whenever any of its dependent signals change.
 
-<code-example header="options-store.ts">
+<code-tabs linenums="true">
+<code-pane header="options-store.ts">
 
-import { signalStore, withLinkedState, withState } from '@ngrx/signals';
+import { patchState, signalStore, withLinkedState, withState } from '@ngrx/signals';
 
 export const OptionsStore = signalStore(
   withState({ options: [1, 2, 3] }),
   withLinkedState(({ options }) => ({
+    // 👇 Defining a linked state slice.
     selectedOption: () => options()[0] ?? undefined,
-  }))
+  })),
+  withMethods((store) => ({
+    setOptions(options: number[]): void {
+      patchState(store, { options });
+    },
+    setSelectedOption(selectedOption: number): void {
+      // 👇 Updating a linked state slice.
+      patchState(store, { selectedOption });
+    },
+  }),
 );
 
-</code-example>
+</code-pane>
+
+<code-pane header="option-list.ts">
+
+@Component({
+  // ... other metadata
+  providers: [OptionsStore],
+})
+export class OptionList {
+  readonly store = inject(OptionsStore);
+
+  constructor() {
+    console.log(this.store.selectedOption()); // logs: 1
+
+    this.store.setSelectedOption(2);
+    console.log(this.store.selectedOption()); // logs: 2
+
+    this.store.setOptions([4, 5, 6]);
+    console.log(this.store.selectedOption()); // logs: 4
+  }
+}
+
+</code-pane>
+</code-tabs>
 
 ## Explicit Linking
 
-The explicit notation requires users to execute `linkedSignal()` manually; however, it offers the advantage of using the more powerful version of `linkedSignal()`, which includes the `source` and `computation` options.
+The `withLinkedState` feature also supports providing `WritableSignal` instances as linked state slices.
+This can include signals created using `linkedSignal()` with `source` and `computation` options, as well as any other user-defined `WritableSignal` instances.
+In both cases, the SignalStore and the original signal remain fully synchronized - updating one will immediately reflect in the other.
 
 <code-example header="options-store.ts">
 
@@ -43,7 +77,7 @@ export const OptionsStore = signalStore(
         const option = newOptions.find((o) => o.id === previous?.value.id);
         return option ?? newOptions[0];
       },
-    })
+    }),
   }))
 );
 

--- a/projects/www/src/app/pages/guide/migration/v20.md
+++ b/projects/www/src/app/pages/guide/migration/v20.md
@@ -46,20 +46,7 @@ const store = new Store();
 getState(store) === initialState; // true
 ```
 
-2. Top-level `WritableSignal`s are wrapped with `Signal`s:
-
-```ts
-// signalState:
-const state = signalState({ ngrx: signal('rocks') });
-state.ngrx; // type: Signal<WritableSignal<string>>
-
-// withState:
-const Store = signalStore(withState({ ngrx: signal('rocks') }));
-const store = new Store();
-store.ngrx; // type: Signal<WritableSignal<string>>
-```
-
-3. Root state properties can be added dynamically:
+2. Root state properties can be added dynamically:
 
 ```ts
 // signalState:
@@ -98,20 +85,7 @@ const store = new Store();
 getState(store) === initialState; // false
 ```
 
-2. Top-level `WritableSignal`s are not wrapped with `Signal`s:
-
-```ts
-// signalState:
-const state = signalState({ ngrx: signal('rocks') });
-state.ngrx; // type: Signal<string>
-
-// withState:
-const Store = signalStore(withState({ ngrx: signal('rocks') }));
-const store = new Store();
-store.ngrx; // type: Signal<string>
-```
-
-3. Root state properties can not be added dynamically:
+2. Root state properties can not be added dynamically:
 
 ```ts
 // signalState:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

Closes #4863

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

```
BREAKING CHANGES:

User-defined `WritableSignal`s are not allowed in `withState` and `signalState` anymore.

BEFORE:

// signalState:
const state = signalState({ ngrx: signal('rocks') });
state.ngrx // type: Signal<string>

// withState:
const Store = signalStore(withState({ ngrx: signal('rocks') })); const store = new Store();
store.ngrx // type: Signal<string>

AFTER:

// signalState:
const state = signalState({ ngrx: signal('rocks') });
state.ngrx // type: Signal<WritableSignal<string>>

// withState:
const Store = signalStore(withState({ ngrx: signal('rocks') })); const store = new Store();
store.ngrx // type: Signal<WritableSignal<string>>
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
