### PR TITLE
fix(signals): do not create deep signals for empty objects and unknown records with symbol keys

### DIFF
--- a/modules/signals/spec/types/signal-state.types.spec.ts
+++ b/modules/signals/spec/types/signal-state.types.spec.ts
@@ -298,6 +298,14 @@ describe('signalState', () => {
       });
       const bar = state5.bar;
       const baz = bar.baz;
+
+      const state6 = signalState({
+        x: {} as Record<symbol, string>
+      });
+      const x = state6.x;
+
+      const state7 = signalState({ y: {} });
+      const y = state7.y;
     `;
 
     expectSnippet(snippet).toSucceed();
@@ -353,6 +361,17 @@ describe('signalState', () => {
     );
 
     expectSnippet(snippet).toInfer('baz', 'Signal<Record<number, unknown>>');
+
+    expectSnippet(snippet).toInfer(
+      'state6',
+      'SignalState<{ x: Record<symbol, string>; }>'
+    );
+
+    expectSnippet(snippet).toInfer('x', 'Signal<Record<symbol, string>>');
+
+    expectSnippet(snippet).toInfer('state7', 'SignalState<{ y: {}; }>');
+
+    expectSnippet(snippet).toInfer('y', 'Signal<{}>');
   });
 
   it('succeeds when state is an empty object', () => {

--- a/modules/signals/src/ts-helpers.ts
+++ b/modules/signals/src/ts-helpers.ts
@@ -18,7 +18,11 @@ export type IsRecord<T> = T extends object
     : true
   : false;
 
-export type IsUnknownRecord<T> = string extends keyof T
+export type IsUnknownRecord<T> = keyof T extends never
+  ? true
+  : string extends keyof T
+  ? true
+  : symbol extends keyof T
   ? true
   : number extends keyof T
   ? true


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`DeepSignal` is created for empty objects and unknown records with symbol keys.

## What is the new behavior?

`Signal` is created for empty objects and unknown records with symbol keys.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
