### PR TITLE
docs(www): add code tabs and copy functionality

### DIFF
--- a/projects/www/src/app/app.component.ts
+++ b/projects/www/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { MenuComponent } from './components/menu.component';
 import { MarkdownSymbolLinkComponent } from './components/docs/markdown-symbol-link.component';
 import { AlertComponent } from './components/docs/alert.component';
 import { CodeExampleComponent } from './components/docs/code-example.component';
+import { CodeTabsComponent } from './components/docs/code-tabs.component';
 import { StackblitzComponent } from './components/docs/stackblitz.component';
 import { FooterComponent } from './components/footer.component';
 
@@ -73,6 +74,11 @@ export class AppComponent {
       injector: this.injector,
     });
     customElements.define('ngrx-code-example', codeExampleElement);
+
+    const codeTabsElement = createCustomElement(CodeTabsComponent, {
+      injector: this.injector,
+    });
+    customElements.define('ngrx-code-tabs', codeTabsElement);
 
     const stackblitzElement = createCustomElement(StackblitzComponent, {
       injector: this.injector,

--- a/projects/www/src/app/components/docs/code-example.component.ts
+++ b/projects/www/src/app/components/docs/code-example.component.ts
@@ -1,12 +1,34 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ElementRef, signal, viewChild } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
   selector: 'ngrx-code-example',
   standalone: true,
+  imports: [MatIcon],
   template: `
+    @if (header) {
     <div class="header">{{ header }}</div>
+    }
+
     <div class="body">
-      <ng-content></ng-content>
+      <button
+        class="copy-button"
+        [class.copied]="copied()"
+        (click)="copyCode()"
+        (animationend)="onAnimationEnd($event)"
+        [title]="copied() ? 'Copied!' : 'Copy code'"
+        [attr.aria-label]="
+          copied() ? 'Code copied to clipboard' : 'Copy code to clipboard'
+        "
+      >
+        @if(copied()) {
+        <mat-icon>done</mat-icon>} @else {
+        <mat-icon>content_copy</mat-icon>
+        }
+      </button>
+      <div #codeBody>
+        <ng-content></ng-content>
+      </div>
     </div>
   `,
   styles: [
@@ -30,9 +52,81 @@ import { Component, Input } from '@angular/core';
         padding: 0 0px;
         overflow-x: wrap;
       }
+
+      .copy-button {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        cursor: pointer;
+        padding: 3px;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .copy-button.copied {
+        animation: copyFeedback 2s ease-in-out;
+      }
+
+      @keyframes copyFeedback {
+        0% {
+          background: rgba(207, 143, 197, 0.8);
+          border-color: rgba(207, 143, 197, 0.6);
+          color: rgba(255, 255, 255, 1);
+          transform: scale(1);
+        }
+        15% {
+          background: rgba(207, 143, 197, 0.8);
+          border-color: rgba(207, 143, 197, 0.6);
+          color: rgba(255, 255, 255, 1);
+          transform: scale(1.1);
+        }
+        30% {
+          background: rgba(207, 143, 197, 0.8);
+          border-color: rgba(207, 143, 197, 0.6);
+          color: rgba(255, 255, 255, 1);
+          transform: scale(1);
+        }
+        80% {
+          background: rgba(207, 143, 197, 0.8);
+          border-color: rgba(207, 143, 197, 0.6);
+          color: rgba(255, 255, 255, 1);
+          transform: scale(1);
+        }
+        100% {
+          background: rgba(0, 0, 0, 0.7);
+          border-color: rgba(255, 255, 255, 0.2);
+          color: rgba(255, 255, 255, 0.8);
+          transform: scale(1);
+        }
+      }
+
+      .copy-button:hover {
+        border-color: rgba(255, 255, 255, 0.4);
+        color: rgba(255, 255, 255, 1);
+      }
+
+      .copy-button:active {
+        transform: scale(0.95);
+      }
     `,
   ],
 })
 export class CodeExampleComponent {
   @Input() header: string = '';
+  codeBody = viewChild.required<ElementRef>('codeBody');
+  copied = signal(false);
+
+  copyCode() {
+    if (navigator.clipboard && window.isSecureContext) {
+      const codeText = this.codeBody().nativeElement.textContent?.trim() || '';
+      navigator.clipboard.writeText(codeText);
+      this.copied.set(true);
+    }
+  }
+
+  onAnimationEnd(event: AnimationEvent) {
+    this.copied.set(false);
+  }
 }

--- a/projects/www/src/app/components/docs/code-tabs.component.ts
+++ b/projects/www/src/app/components/docs/code-tabs.component.ts
@@ -1,0 +1,64 @@
+import {
+  Component,
+  OnInit,
+  ElementRef,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTabsModule } from '@angular/material/tabs';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { CodeExampleComponent } from './code-example.component';
+
+@Component({
+  selector: 'ngrx-code-tabs',
+  standalone: true,
+  imports: [CommonModule, MatTabsModule, CodeExampleComponent],
+  template: `
+    <div #content style="display: none"><ng-content></ng-content></div>
+
+    <mat-tab-group [preserveContent]="true">
+      @for (tab of tabs(); track tab) {
+      <mat-tab [label]="tab.header">
+        <ngrx-code-example [innerHTML]="tab.code"> </ngrx-code-example>
+      </mat-tab>
+      }
+    </mat-tab-group>
+  `,
+  styles: [
+    `
+      ngrx-code-example {
+        margin: 0;
+      }
+    `,
+  ],
+})
+export class CodeTabsComponent implements OnInit {
+  private domSanitizer = inject(DomSanitizer);
+  private content = viewChild.required<ElementRef>('content');
+  protected tabs = signal<TabInfo[]>([]);
+
+  ngOnInit() {
+    const codeExamples =
+      this.content().nativeElement.querySelectorAll('ngrx-code-example') ?? [];
+    const examples: TabInfo[] = [...codeExamples].map((example) =>
+      this.extractTabInfo(example)
+    );
+    this.tabs.set(examples);
+  }
+
+  private extractTabInfo(tabContent: HTMLElement): TabInfo {
+    return {
+      code: this.domSanitizer.bypassSecurityTrustHtml(
+        tabContent.querySelector('pre')?.parentElement?.innerHTML ?? ''
+      ),
+      header: tabContent.getAttribute('header') || '',
+    };
+  }
+}
+
+export interface TabInfo {
+  code: SafeHtml;
+  header: string;
+}

--- a/projects/www/src/app/components/docs/markdown-article.component.ts
+++ b/projects/www/src/app/components/docs/markdown-article.component.ts
@@ -192,7 +192,6 @@ export class MarkdownArticleComponent implements OnDestroy {
   }
 
   private watchHeadings() {
-    console.log('watchHeadings');
     if (this.intersectionObserver) {
       this.intersectionObserver.disconnect();
       this.intersectionObserver = undefined;

--- a/projects/www/src/app/pages/guide/component-store/usage.md
+++ b/projects/www/src/app/pages/guide/component-store/usage.md
@@ -82,16 +82,13 @@ You can see the full example at StackBlitz: <live-example name="component-store-
 
 </ngrx-docs-alert>
 
-<code-tabs linenums="true">
-  <code-pane
-    header="src/app/slide-toggle.component.ts"
-    path="component-store-slide-toggle/src/app/slide-toggle.component.ts">
-  </code-pane>
-  <code-pane
-    header="src/app/slide-toggle.html"
-    path="component-store-slide-toggle/src/app/slide-toggle.html">
-  </code-pane>
-</code-tabs>
+<ngrx-code-tabs>
+  <ngrx-code-example header="src/app/slide-toggle.component.ts">
+  </ngrx-code-example>
+
+  <ngrx-code-example header="src/app/slide-toggle.component.html">
+  </ngrx-code-example>
+</ngrx-code-tabs>
 
 Below are the steps of integrating `ComponentStore` into a component.
 
@@ -102,9 +99,6 @@ First, the state for the component needs to be identified. In `SlideToggleCompon
 <ngrx-code-example header="src/app/slide-toggle.component.ts"
   path="component-store-slide-toggle/src/app/slide-toggle.component.ts"
   region="state">
-
-`ts`
-
 </ngrx-code-example>
 
 Then we need to provide `ComponentStore` in the component's providers, so that each new instance of `SlideToggleComponent` has its own `ComponentStore`. It also has to be injected into the constructor.
@@ -119,9 +113,6 @@ In this example `ComponentStore` is provided directly in the component. This wor
   header="src/app/slide-toggle.component.ts"
   path="component-store-slide-toggle/src/app/slide-toggle.component.ts"
   region="providers">
-
-`ts`
-
 </ngrx-code-example>
 
 Next, the default state for the component needs to be set. It could be done lazily, however it needs to be done before any of `updater`s are executed, because they rely on the state to be present and would throw an error if the state is not initialized by the time they are invoked.
@@ -141,9 +132,6 @@ When it is called with a callback, the state is updated.
 <ngrx-code-example header="src/app/slide-toggle.component.ts"
   path="component-store-slide-toggle/src/app/slide-toggle.component.ts"
   region="init">
-
-`ts`
-
 </ngrx-code-example>
 
 #### Step 2. Updating state
@@ -158,9 +146,6 @@ When a user clicks the toggle (triggering a 'change' event), instead of calling 
   header="src/app/slide-toggle.component.ts"
   path="component-store-slide-toggle/src/app/slide-toggle.component.ts"
   region="updater">
-
-`ts`
-
 </ngrx-code-example>
 
 #### Step 3. Reading the state
@@ -173,12 +158,24 @@ Finally, the state is aggregated with selectors into two properties:
 <ngrx-code-example header="src/app/slide-toggle.component.ts"
   path="component-store-slide-toggle/src/app/slide-toggle.component.ts"
   region="selector">
-
-`ts`
-
 </ngrx-code-example>
 
 This example does not have a lot of business logic, however it is still fully reactive.
+
+<ngrx-code-tabs linenums="true">
+  <ngrx-code-example
+    header="PaginatorComponent with PaginatorStore Service"
+    path="component-store-paginator-service/src/app/paginator.component.ts">
+  </ngrx-code-example>
+  <ngrx-code-example
+    header="PaginatorComponent providing ComponentStore"
+    path="component-store-paginator/src/app/paginator.component.ts">
+  </ngrx-code-example>
+  <ngrx-code-example
+    header="src/app/paginator.store.ts"
+    path="component-store-paginator-service/src/app/paginator.store.ts">
+  </ngrx-code-example>
+</ngrx-code-tabs>
 
 ### Example 2: Service extending ComponentStore
 
@@ -209,21 +206,6 @@ You can see the examples at StackBlitz:
 
 </ngrx-docs-alert>
 
-<code-tabs linenums="true">
-  <code-pane
-    header="PaginatorComponent with PaginatorStore Service"
-    path="component-store-paginator-service/src/app/paginator.component.ts">
-  </code-pane>
-  <code-pane
-    header="PaginatorComponent providing ComponentStore"
-    path="component-store-paginator/src/app/paginator.component.ts">
-  </code-pane>
-  <code-pane
-    header="src/app/paginator.store.ts"
-    path="component-store-paginator-service/src/app/paginator.store.ts">
-  </code-pane>
-</code-tabs>
-
 #### Updating the state
 
 With `ComponentStore` extracted into `PaginatorStore`, the developer is now using updaters and effects to update the state. `@Input` values are passed directly into `updater`s as their arguments.
@@ -231,9 +213,6 @@ With `ComponentStore` extracted into `PaginatorStore`, the developer is now usin
 <ngrx-code-example header="src/app/paginator.store.ts"
   path="component-store-paginator-service/src/app/paginator.component.ts"
   region="inputs">
-
-`ts`
-
 </ngrx-code-example>
 
 Not all `updater`s have to be called in the `@Input`. For example, `changePageSize` is called from the template.
@@ -243,28 +222,25 @@ Effects are used to perform additional validation and get extra information from
 <ngrx-code-example header="src/app/paginator.store.ts"
   path="component-store-paginator-service/src/app/paginator.component.ts"
   region="updating-state">
-
-`ts`
-
 </ngrx-code-example>
 
 #### Reading the state
 
 `PaginatorStore` exposes the two properties: `vm$` for an aggregated _ViewModel_ to be used in the template and `page$` that would emit whenever data aggregated from a `PageEvent` changes.
 
-<code-tabs>
-  <code-pane
+<ngrx-code-tabs>
+  <ngrx-code-example
     header="src/app/paginator.component.ts"
     path="component-store-paginator-service/src/app/paginator.component.ts"
     region="selectors"
     >
-  </code-pane>
-  <code-pane
+  </ngrx-code-examp>
+  <ngrx-code-example
     header="src/app/paginator.store.ts"
     path="component-store-paginator-service/src/app/paginator.store.ts"
     region="selectors">
-  </code-pane>
-</code-tabs>
+  </ngrx-code-example>
+</ngrx-code-tabs>
 
 <ngrx-docs-alert type="help">
 

--- a/projects/www/src/app/pages/guide/signals/signal-state.md
+++ b/projects/www/src/app/pages/guide/signals/signal-state.md
@@ -159,8 +159,8 @@ export class CounterComponent {
 
 ### Example 2: SignalState in a Service
 
-<code-tabs linenums="true">
-<code-pane header="books.store.ts">
+<ngrx-code-tabs linenums="true">
+<ngrx-code-example header="books.store.ts">
 
 ```ts
 import { inject, Injectable } from '@angular/core';
@@ -204,9 +204,9 @@ export class BooksStore {
 }
 ```
 
-</code-pane>
+</ngrx-code-example>
 
-<code-pane header="books.component.ts">
+<ngrx-code-example header="books.component.ts">
 
 ```ts
 import {
@@ -244,5 +244,5 @@ export class BooksComponent implements OnInit {
 }
 ```
 
-</code-pane>
-</code-tabs>
+</ngrx-code-example>
+</ngrx-code-tabs>

--- a/projects/www/src/app/pages/guide/signals/signal-store/private-store-members.md
+++ b/projects/www/src/app/pages/guide/signals/signal-store/private-store-members.md
@@ -3,8 +3,8 @@
 SignalStore allows defining private members that cannot be accessed from outside the store by using the `_` prefix.
 This includes root-level state slices, properties, and methods.
 
-<!-- <code-tabs linenums="false">
-<code-pane header="counter.store.ts"> -->
+<ngrx-code-tabs linenums="false">
+<ngrx-code-example header="counter.store.ts">
 
 ```ts
 import { computed } from '@angular/core';
@@ -46,9 +46,9 @@ patchState(store, { \_count2: store.\_count2() + 1 });
 );
 ```
 
-<!-- </code-pane>
+</ngrx-code-example>
 
-<code-pane header="counter.component.ts"> -->
+<ngrx-code-example header="counter.component.ts">
 
 ````ts
 import { Component, inject, OnInit } from '@angular/core';
@@ -76,7 +76,8 @@ console.log(this.store.\_count2()); // ❌
 
 }
 }
-<!-- ```
-</code-pane>
-</code-tabs> -->
+```
+
+</ngrx-code-example>
+</ngrx-code-tabs>
 ````


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #4877

There's currently no implementation for code tabs.

## What is the new behavior?

This PR implements a code tabs component, and updates the content to use the new component.



## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Some notes:

- Styling is not my strongest point, Copilot helped me a hand here
- I added a copy functionality because I find it easier to copy paste code from the docs
- Because the current state of the docs don't have a tabs component with content, here are some screenshots to show it in action.
<img width="1252" height="452" alt="image" src="https://github.com/user-attachments/assets/f4e4a859-0914-42da-85d3-e212941162c4" />

<img width="1293" height="444" alt="image" src="https://github.com/user-attachments/assets/5a8606c3-2eb2-4e39-baf8-ef6f0b085186" />

