### PR TITLE
feat(signals): add withFeature

### DIFF
--- a/modules/signals/spec/with-feature-factrory.spec.ts
+++ b/modules/signals/spec/with-feature-factrory.spec.ts
@@ -1,0 +1,111 @@
+import { computed, Signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import { setAllEntities, withEntities } from '../entities';
+import {
+  patchState,
+  signalStore,
+  signalStoreFeature,
+  withComputed,
+  withHooks,
+  withMethods,
+  withState,
+} from '../src';
+import { withFeatureFactory } from '../src/with-feature-factory';
+
+type Book = {
+  id: string;
+  name: string;
+  author: string;
+};
+
+describe('withFeatureFactory', () => {
+  it('should enable to create a feature that needs input data', () => {
+    const withBooksFilter = withFeatureFactory((books: Signal<Book[]>) =>
+      signalStoreFeature(
+        withState({ query: '' }),
+        withComputed((store) => ({
+          filteredBooks: computed(() =>
+            books().filter((b) => b.name.includes(store.query()))
+          ),
+        })),
+        withMethods((store) => ({
+          setQuery(query: string): void {
+            patchState(store, { query });
+          },
+        }))
+      )
+    );
+
+    expect(withBooksFilter).toBeDefined();
+  });
+  it('should not allow to pass several parameters to the custom feature', () => {
+    let error = undefined;
+    try {
+      const withBooksFilter = withFeatureFactory(
+        //@ts-expect-error withFeatureFactory accepts a function with only one parameter
+        (books: Signal<Book[]>, arg2: boolean) =>
+          signalStoreFeature(
+            withState({ query: '' }),
+            withComputed((store) => ({
+              filteredBooks: computed(() =>
+                books().filter((b) => b.name.includes(store.query()))
+              ),
+            })),
+            withMethods((store) => ({
+              setQuery(query: string): void {
+                patchState(store, { query });
+              },
+            }))
+          )
+      );
+    } catch (featureError) {
+      error = featureError;
+    }
+    expect(error).toBeDefined();
+  });
+  it('wires the store (state, properties, methods) to the feature input correctly', () => {
+    const withBooksFilter = withFeatureFactory((books: Signal<Book[]>) =>
+      signalStoreFeature(
+        withState({ query: '' }),
+        withComputed((store) => ({
+          filteredBooks: computed(() =>
+            books().filter((b) => b.name.includes(store.query()))
+          ),
+        })),
+        withMethods((store) => ({
+          setQuery(query: string): void {
+            patchState(store, { query });
+          },
+        }))
+      )
+    );
+
+    const BooksStore = signalStore(
+      withEntities<Book>(),
+      withBooksFilter(({ entities }) => entities),
+      withHooks((store) => ({
+        onInit: () => {
+          patchState(
+            store,
+            setAllEntities([
+              { id: '1', name: 'Angular Basics', author: 'John Doe' },
+              { id: '2', name: 'React Basics', author: 'Jane Doe' },
+            ])
+          );
+        },
+      }))
+    );
+    TestBed.configureTestingModule({
+      providers: [BooksStore],
+    });
+    const store = TestBed.inject(BooksStore);
+
+    expect(store.filteredBooks()).toEqual(store.entities());
+    store.setQuery('Angular');
+    const filteredBooks = store.filteredBooks();
+    expect(filteredBooks).toEqual([
+      { id: '1', name: 'Angular Basics', author: 'John Doe' },
+    ]);
+  });
+});

--- a/modules/signals/src/index.ts
+++ b/modules/signals/src/index.ts
@@ -24,6 +24,7 @@ export { Prettify } from './ts-helpers';
 
 export { withComputed } from './with-computed';
 export { withFeature } from './with-feature';
+export { withFeatureFactory } from './with-feature-factory';
 export { withHooks } from './with-hooks';
 export { withLinkedState } from './with-linked-state';
 export { withMethods } from './with-methods';

--- a/modules/signals/src/with-feature-factory.ts
+++ b/modules/signals/src/with-feature-factory.ts
@@ -1,0 +1,83 @@
+import {
+  SignalStoreFeature,
+  SignalStoreFeatureResult,
+  StateSignals,
+} from './signal-store-models';
+import { STATE_SOURCE, WritableStateSource } from './state-source';
+import { Prettify } from './ts-helpers';
+import { withFeature } from './with-feature';
+
+type FeatureOutput<
+  Input extends SignalStoreFeatureResult,
+  Feature extends (data: any) => SignalStoreFeature
+> = ReturnType<Feature> extends SignalStoreFeature<
+  infer ResultInput,
+  infer ResultOutput
+>
+  ? SignalStoreFeature<Input, ResultOutput>
+  : never;
+
+type FeatureFacotyWithOnelyOneParams<
+  Feature extends (data: any) => SignalStoreFeature
+> = Feature extends (data: infer Params) => SignalStoreFeature ? Params : never;
+
+/**
+ * @description
+ *
+ * Define a feature that depends on a specific part of the parent store.
+ *
+ * @usageNotes
+ * ```ts
+ * const withBooksFilter = withFeatureFactory((books: Signal<Book[]>) =>
+ *   signalStoreFeature(
+ *     withState({ query: '' }),
+ *     withComputed((store) => ({
+ *       filteredBooks: computed(() =>
+ *         books().filter((b) => b.name.includes(store.query()))
+ *       ),
+ *     })),
+ *     withMethods((store) => ({
+ *       setQuery(query: string): void {
+ *         patchState(store, { query });
+ *       },
+ *     }))
+ *   )
+ * );
+ *
+ * signalStore(
+ *   withEntities<Book>(),
+ *   withBooksFilter(({ entities }) => entities)
+ * );
+ * ```
+ *
+ * @param feature A feature factory function that accepts exactly one parameter.
+ */
+export function withFeatureFactory<
+  Feature extends (data: any) => SignalStoreFeature
+>(feature: Feature) {
+  if (feature.length > 1) {
+    throw new Error(
+      `withFeatureFactory only supports functions with exactly one parameter. Got ${feature.length}.\n` +
+        `If you need to pass multiple values, wrap them in a single object:\n\n` +
+        `// ✅ Good:\n` +
+        `withFeatureFactory(({ signalA, signalB }) => ...)\n\n` +
+        `// ❌ Not allowed:\n` +
+        `withFeatureFactory((signalA, signalB) => ...)`
+    );
+  }
+  return <
+    Input extends SignalStoreFeatureResult,
+    Store extends Prettify<
+      StateSignals<Input['state']> &
+        Input['props'] &
+        Input['methods'] &
+        WritableStateSource<Input['state']>
+    >
+  >(
+    entries: (store: Store) => FeatureFacotyWithOnelyOneParams<Feature>
+  ) =>
+    withFeature((store) => feature(entries(store as Store))) as FeatureOutput<
+      Input,
+      Feature
+    >;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, to add a custom feature that depends on an input value from the store, developers must use the withFeature utility manually.
While this works, it introduces boilerplate and breaks the composability of features, since the custom feature cannot be directly passed into the signalStore factory.

Closes #

## What is the new behavior?
This PR introduces the withFeatureFactory utility, which simplifies the creation of custom SignalStore features that depend on one external input.

withFeatureFactory wraps withFeature under the hood, but allows developers to define reusable features that can be directly integrated into the signalStore() call, just like built-in features (withState, withMethods, etc.).

It enforces that the feature factory accepts exactly one parameter, and provides a better developer experience by preserving type safety and composability.

Stackblitz: https://stackblitz.com/edit/stackblitz-starters-31qrd2nq?file=withFeature%2F1-simple-only-one-helper-to-use.spec.ts

The link comes from an article that I wrote:: https://dev.to/romain_geffrault_10d88369/ngrx-signalstore-hacks-beautiful-dx-with-custom-features-1n4k

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
