### PR TITLE
fix(component): use setTimeout instead of requestAnimationFrame in SSR mode

### DIFF
--- a/modules/component/spec/core/tick-scheduler.spec.ts
+++ b/modules/component/spec/core/tick-scheduler.spec.ts
@@ -6,20 +6,20 @@ import {
 } from '@angular/core/testing';
 import { ApplicationRef, NgZone, PLATFORM_ID } from '@angular/core';
 import {
-  ZonelessTickScheduler,
   NoopTickScheduler,
   TickScheduler,
+  ZonelessTickScheduler,
 } from '../../src/core/tick-scheduler';
 import { ngZoneMock, noopNgZoneMock } from '../fixtures/fixtures';
 
 describe('TickScheduler', () => {
-  function setup(ngZone: unknown, server = false) {
+  function setup(ngZone: unknown, isSsrMode = false) {
     TestBed.configureTestingModule({
       providers: [
         { provide: NgZone, useValue: ngZone },
         {
           provide: PLATFORM_ID,
-          useValue: server ? 'server' : 'browser',
+          useValue: isSsrMode ? 'server' : 'browser',
         },
       ],
     });
@@ -37,7 +37,7 @@ describe('TickScheduler', () => {
     });
   });
 
-  describe('when NgZone is not provided and running in server context', () => {
+  describe('when NgZone is not provided and running in browser mode', () => {
     // `fakeAsync` uses 16ms as `requestAnimationFrame` delay
     const animationFrameDelay = 16;
 
@@ -46,7 +46,7 @@ describe('TickScheduler', () => {
       expect(tickScheduler instanceof ZonelessTickScheduler).toBe(true);
     });
 
-    it('should schedule tick using the ZonelessTickScheduler', fakeAsync(() => {
+    it('should schedule tick using requestAnimationFrame', fakeAsync(() => {
       const { tickScheduler, appRef } = setup(noopNgZoneMock);
 
       tickScheduler.schedule();
@@ -94,13 +94,13 @@ describe('TickScheduler', () => {
     }));
   });
 
-  describe('when NgZone is not provided and running in ssr', () => {
+  describe('when NgZone is not provided and running in SSR mode', () => {
     it('should initialize ZonelessTickScheduler', () => {
       const { tickScheduler } = setup(noopNgZoneMock, true);
       expect(tickScheduler instanceof ZonelessTickScheduler).toBe(true);
     });
 
-    it('should schedule tick using the ZonelessTickScheduler', fakeAsync(() => {
+    it('should schedule tick using setTimeout', fakeAsync(() => {
       const { tickScheduler, appRef } = setup(noopNgZoneMock, true);
 
       tickScheduler.schedule();

--- a/modules/component/src/core/tick-scheduler.ts
+++ b/modules/component/src/core/tick-scheduler.ts
@@ -5,8 +5,8 @@ import {
   NgZone,
   PLATFORM_ID,
 } from '@angular/core';
-import { isNgZone } from './zone-helpers';
 import { isPlatformServer } from '@angular/common';
+import { isNgZone } from './zone-helpers';
 
 @Injectable({
   providedIn: 'root',
@@ -25,13 +25,13 @@ export abstract class TickScheduler {
   providedIn: 'root',
 })
 export class ZonelessTickScheduler extends TickScheduler {
-  private isScheduled = false;
+  private readonly appRef = inject(ApplicationRef);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly isServer = isPlatformServer(this.platformId);
-  private readonly appRef = inject(ApplicationRef);
   private readonly scheduleFn = this.isServer
     ? setTimeout
     : requestAnimationFrame;
+  private isScheduled = false;
 
   schedule(): void {
     if (!this.isScheduled) {


### PR DESCRIPTION
…stead of requestAnimationFrame

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When using either ngrxLet or ngrxPush in ssr and zoneless, the server calls `requestAnimationFrame` which does not exist in a node environment. 

Closes #4902

## What is the new behavior?

Within a node environment ( ssr ) and zoneless we use setTimeout instead of requestAnimationFrame.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I did some more testing on angular v20, when using ssr + zoneless and using a `NoopTickScheduler` it does trigger changes. I opted for not removing the `NoopTickScheduler` and making big changes since `@ngrx/component` is in maintenance mode.
