### PR TITLE
feat(eslint-plugin): enhance prefix-selectors-with-select to handle destructuring  

### DIFF
--- a/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
+++ b/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
@@ -62,6 +62,165 @@ export const selectCount: MemoizedSelector<any, any> = (state: AppState) => stat
   ),
   fromFixture(
     `
+export const getF01 = createSelector((state: AppState) => state.feature)
+             ~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          output: `
+export const selectF01 = createSelector((state: AppState) => state.feature)`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+export const get_f01 = createSelector((state: AppState) => state.feature)
+             ~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          output: `
+export const select_f01 = createSelector((state: AppState) => state.feature)`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+export const select = (id: string) => createSelector(selectThings, things => things[id])
+             ~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          data: {
+            name: 'selectSelect',
+          },
+          messageId: prefixSelectorsWithSelectSuggest,
+          output: `
+export const selectSelect = (id: string) => createSelector(selectThings, things => things[id])`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+export const SELECT_TEST = (id: string) => {
+             ~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]
+  return createSelector(selectThings, things => things[id])
+}`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: {
+            name: 'selectSELECT_TEST',
+          },
+          output: `
+export const selectSELECT_TEST = (id: string) => {
+  return createSelector(selectThings, things => things[id])
+}`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+export const feature = createFeatureSelector<AppState, FeatureState>(featureKey)
+             ~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: {
+            name: 'selectFeature',
+          },
+          output: `
+export const selectFeature = createFeatureSelector<AppState, FeatureState>(featureKey)`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+export const selectfeature = createSelector((state: AppState) => state.feature)
+             ~~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: {
+            name: 'selectFeature',
+          },
+          output: `
+export const selectFeature = createSelector((state: AppState) => state.feature)`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+export const createSelect = createSelectorFactory((projectionFun) =>
+             ~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]
+  defaultMemoize(
+    projectionFun,
+    orderDoesNotMatterComparer,
+    orderDoesNotMatterComparer,
+  ),
+)`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: {
+            name: 'selectCreateSelect',
+          },
+          output: `
+export const selectCreateSelect = createSelectorFactory((projectionFun) =>
+  defaultMemoize(
+    projectionFun,
+    orderDoesNotMatterComparer,
+    orderDoesNotMatterComparer,
+  ),
+)`,
+        },
+      ],
+    }
+  ),
+  // https://github.com/ngrx/platform/issues/3956
+  fromFixture(
+    `
+import {createFeatureSelector} from '@ngrx/store';
+
+export interface FileListResponseState {
+  loading: boolean;
+}
+
+const featureSelector = createFeatureSelector<FileListResponseState>("name");
+      ~~~~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: {
+            name: 'selectFeatureSelector',
+          },
+          output: `
+import {createFeatureSelector} from '@ngrx/store';
+
+export interface FileListResponseState {
+  loading: boolean;
+}
+
+const selectFeatureSelector = createFeatureSelector<FileListResponseState>("name");`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
 export const { selectAll: allBooks } = booksAdapter.getSelectors(createSelector(selectBookInfo, (state) => state.books));
                           ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {

--- a/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
+++ b/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
@@ -33,6 +33,9 @@ const valid: () => (string | ValidTestCase<Options>)[] = () => [
       }),
     })
   `,
+  `
+    export const { selectAll: selectAllBooks } = booksAdapter.getSelectors(createSelector(selectBookInfo, (state) => state.books));
+  `,
 ];
 
 const invalid: () => InvalidTestCase<MessageIds, Options>[] = () => [
@@ -44,9 +47,7 @@ export const getCount: MemoizedSelector<any, any> = (state: AppState) => state.f
       suggestions: [
         {
           messageId: prefixSelectorsWithSelectSuggest,
-          data: {
-            name: 'selectCount',
-          },
+          data: { name: 'selectCount' },
           output: `
 export const selectCount: MemoizedSelector<any, any> = (state: AppState) => state.feature`,
         },
@@ -88,10 +89,8 @@ export const select = (id: string) => createSelector(selectThings, things => thi
     {
       suggestions: [
         {
-          data: {
-            name: 'selectSelect',
-          },
           messageId: prefixSelectorsWithSelectSuggest,
+          data: { name: 'selectSelect' },
           output: `
 export const selectSelect = (id: string) => createSelector(selectThings, things => things[id])`,
         },
@@ -108,9 +107,7 @@ export const SELECT_TEST = (id: string) => {
       suggestions: [
         {
           messageId: prefixSelectorsWithSelectSuggest,
-          data: {
-            name: 'selectSELECT_TEST',
-          },
+          data: { name: 'selectSELECT_TEST' },
           output: `
 export const selectSELECT_TEST = (id: string) => {
   return createSelector(selectThings, things => things[id])
@@ -127,9 +124,7 @@ export const feature = createFeatureSelector<AppState, FeatureState>(featureKey)
       suggestions: [
         {
           messageId: prefixSelectorsWithSelectSuggest,
-          data: {
-            name: 'selectFeature',
-          },
+          data: { name: 'selectFeature' },
           output: `
 export const selectFeature = createFeatureSelector<AppState, FeatureState>(featureKey)`,
         },
@@ -144,9 +139,7 @@ export const selectfeature = createSelector((state: AppState) => state.feature)
       suggestions: [
         {
           messageId: prefixSelectorsWithSelectSuggest,
-          data: {
-            name: 'selectFeature',
-          },
+          data: { name: 'selectFeature' },
           output: `
 export const selectFeature = createSelector((state: AppState) => state.feature)`,
         },
@@ -167,9 +160,7 @@ export const createSelect = createSelectorFactory((projectionFun) =>
       suggestions: [
         {
           messageId: prefixSelectorsWithSelectSuggest,
-          data: {
-            name: 'selectCreateSelect',
-          },
+          data: { name: 'selectCreateSelect' },
           output: `
 export const selectCreateSelect = createSelectorFactory((projectionFun) =>
   defaultMemoize(
@@ -182,7 +173,6 @@ export const selectCreateSelect = createSelectorFactory((projectionFun) =>
       ],
     }
   ),
-  // https://github.com/ngrx/platform/issues/3956
   fromFixture(
     `
 import {createFeatureSelector} from '@ngrx/store';
@@ -197,9 +187,7 @@ const featureSelector = createFeatureSelector<FileListResponseState>("name");
       suggestions: [
         {
           messageId: prefixSelectorsWithSelectSuggest,
-          data: {
-            name: 'selectFeatureSelector',
-          },
+          data: { name: 'selectFeatureSelector' },
           output: `
 import {createFeatureSelector} from '@ngrx/store';
 
@@ -208,6 +196,21 @@ export interface FileListResponseState {
 }
 
 const selectFeatureSelector = createFeatureSelector<FileListResponseState>("name");`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+export const { selectAll: allBooks } = booksAdapter.getSelectors(createSelector(selectBookInfo, (state) => state.books));
+                          ~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: { name: 'selectAllBooks' },
+          output: `
+export const { selectAll: selectAllBooks } = booksAdapter.getSelectors(createSelector(selectBookInfo, (state) => state.books));`,
         },
       ],
     }

--- a/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
+++ b/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
@@ -77,44 +77,60 @@ export const { selectAll: selectAllBooks } = booksAdapter.getSelectors(createSel
   ),
   fromFixture(
     `
-const { selectAll: allItems, selectEntities: entitiesMap } = getSelectors(adapter);
-              ~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]
-                                 ~~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+const { selectAll: allItems } = getSelectors(adapter);
+              ~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {
       suggestions: [
         {
           messageId: prefixSelectorsWithSelectSuggest,
           data: { name: 'selectAllItems' },
           output: `
-const { selectAll: selectAllItems, selectEntities: entitiesMap } = getSelectors(adapter);`,
-        },
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          data: { name: 'selectEntitiesMap' },
-          output: `
-const { selectAll: allItems, selectEntities: selectEntitiesMap } = getSelectors(adapter);`,
+const { selectAll: selectAllItems } = getSelectors(adapter);`,
         },
       ],
     }
   ),
   fromFixture(
     `
-const { allItems, entitiesMap } = getSelectors(adapter);
-        ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]
-                     ~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+const { selectEntities: entitiesMap } = getSelectors(adapter);
+                    ~~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: { name: 'selectEntitiesMap' },
+          output: `
+const { selectEntities: selectEntitiesMap } = getSelectors(adapter);`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+const { allItems } = getSelectors(adapter);
+        ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {
       suggestions: [
         {
           messageId: prefixSelectorsWithSelectSuggest,
           data: { name: 'selectAllItems' },
           output: `
-const { selectAllItems, entitiesMap } = getSelectors(adapter);`,
+const { selectAllItems } = getSelectors(adapter);`,
         },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+const { entitiesMap } = getSelectors(adapter);
+        ~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
         {
           messageId: prefixSelectorsWithSelectSuggest,
           data: { name: 'selectEntitiesMap' },
           output: `
-const { allItems, selectEntitiesMap } = getSelectors(adapter);`,
+const { selectEntitiesMap } = getSelectors(adapter);`,
         },
       ],
     }

--- a/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
+++ b/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
@@ -63,7 +63,7 @@ export const selectCount: MemoizedSelector<any, any> = (state: AppState) => stat
   fromFixture(
     `
 export const { selectAll: allBooks } = booksAdapter.getSelectors(createSelector(selectBookInfo, (state) => state.books));
-                                  ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+                          ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {
       suggestions: [
         {
@@ -78,7 +78,7 @@ export const { selectAll: selectAllBooks } = booksAdapter.getSelectors(createSel
   fromFixture(
     `
 const { selectAll: allItems } = getSelectors(adapter);
-                        ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+                   ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {
       suggestions: [
         {
@@ -93,7 +93,7 @@ const { selectAll: selectAllItems } = getSelectors(adapter);`,
   fromFixture(
     `
 const { selectEntities: entitiesMap } = getSelectors(adapter);
-                              ~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+                        ~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {
       suggestions: [
         {

--- a/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
+++ b/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
@@ -36,6 +36,12 @@ const valid: () => (string | ValidTestCase<Options>)[] = () => [
   `
     export const { selectAll: selectAllBooks } = booksAdapter.getSelectors(createSelector(selectBookInfo, (state) => state.books));
   `,
+  `
+    const { selectAll, selectEntities } = getSelectors(adapter);
+  `,
+  `
+    const { selectAll: selectAllItems, selectEntities: selectEntitiesMap } = getSelectors(adapter);
+  `,
 ];
 
 const invalid: () => InvalidTestCase<MessageIds, Options>[] = () => [
@@ -56,152 +62,6 @@ export const selectCount: MemoizedSelector<any, any> = (state: AppState) => stat
   ),
   fromFixture(
     `
-export const getF01 = createSelector((state: AppState) => state.feature)
-             ~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
-    {
-      suggestions: [
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          output: `
-export const selectF01 = createSelector((state: AppState) => state.feature)`,
-        },
-      ],
-    }
-  ),
-  fromFixture(
-    `
-export const get_f01 = createSelector((state: AppState) => state.feature)
-             ~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
-    {
-      suggestions: [
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          output: `
-export const select_f01 = createSelector((state: AppState) => state.feature)`,
-        },
-      ],
-    }
-  ),
-  fromFixture(
-    `
-export const select = (id: string) => createSelector(selectThings, things => things[id])
-             ~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
-    {
-      suggestions: [
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          data: { name: 'selectSelect' },
-          output: `
-export const selectSelect = (id: string) => createSelector(selectThings, things => things[id])`,
-        },
-      ],
-    }
-  ),
-  fromFixture(
-    `
-export const SELECT_TEST = (id: string) => {
-             ~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]
-  return createSelector(selectThings, things => things[id])
-}`,
-    {
-      suggestions: [
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          data: { name: 'selectSELECT_TEST' },
-          output: `
-export const selectSELECT_TEST = (id: string) => {
-  return createSelector(selectThings, things => things[id])
-}`,
-        },
-      ],
-    }
-  ),
-  fromFixture(
-    `
-export const feature = createFeatureSelector<AppState, FeatureState>(featureKey)
-             ~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
-    {
-      suggestions: [
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          data: { name: 'selectFeature' },
-          output: `
-export const selectFeature = createFeatureSelector<AppState, FeatureState>(featureKey)`,
-        },
-      ],
-    }
-  ),
-  fromFixture(
-    `
-export const selectfeature = createSelector((state: AppState) => state.feature)
-             ~~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
-    {
-      suggestions: [
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          data: { name: 'selectFeature' },
-          output: `
-export const selectFeature = createSelector((state: AppState) => state.feature)`,
-        },
-      ],
-    }
-  ),
-  fromFixture(
-    `
-export const createSelect = createSelectorFactory((projectionFun) =>
-             ~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]
-  defaultMemoize(
-    projectionFun,
-    orderDoesNotMatterComparer,
-    orderDoesNotMatterComparer,
-  ),
-)`,
-    {
-      suggestions: [
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          data: { name: 'selectCreateSelect' },
-          output: `
-export const selectCreateSelect = createSelectorFactory((projectionFun) =>
-  defaultMemoize(
-    projectionFun,
-    orderDoesNotMatterComparer,
-    orderDoesNotMatterComparer,
-  ),
-)`,
-        },
-      ],
-    }
-  ),
-  fromFixture(
-    `
-import {createFeatureSelector} from '@ngrx/store';
-
-export interface FileListResponseState {
-  loading: boolean;
-}
-
-const featureSelector = createFeatureSelector<FileListResponseState>("name");
-      ~~~~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
-    {
-      suggestions: [
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          data: { name: 'selectFeatureSelector' },
-          output: `
-import {createFeatureSelector} from '@ngrx/store';
-
-export interface FileListResponseState {
-  loading: boolean;
-}
-
-const selectFeatureSelector = createFeatureSelector<FileListResponseState>("name");`,
-        },
-      ],
-    }
-  ),
-  fromFixture(
-    `
 export const { selectAll: allBooks } = booksAdapter.getSelectors(createSelector(selectBookInfo, (state) => state.books));
                           ~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {
@@ -211,6 +71,50 @@ export const { selectAll: allBooks } = booksAdapter.getSelectors(createSelector(
           data: { name: 'selectAllBooks' },
           output: `
 export const { selectAll: selectAllBooks } = booksAdapter.getSelectors(createSelector(selectBookInfo, (state) => state.books));`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+const { selectAll: allItems, selectEntities: entitiesMap } = getSelectors(adapter);
+              ~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]
+                                 ~~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: { name: 'selectAllItems' },
+          output: `
+const { selectAll: selectAllItems, selectEntities: entitiesMap } = getSelectors(adapter);`,
+        },
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: { name: 'selectEntitiesMap' },
+          output: `
+const { selectAll: allItems, selectEntities: selectEntitiesMap } = getSelectors(adapter);`,
+        },
+      ],
+    }
+  ),
+  fromFixture(
+    `
+const { allItems, entitiesMap } = getSelectors(adapter);
+        ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]
+                     ~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+    {
+      suggestions: [
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: { name: 'selectAllItems' },
+          output: `
+const { selectAllItems, entitiesMap } = getSelectors(adapter);`,
+        },
+        {
+          messageId: prefixSelectorsWithSelectSuggest,
+          data: { name: 'selectEntitiesMap' },
+          output: `
+const { allItems, selectEntitiesMap } = getSelectors(adapter);`,
         },
       ],
     }

--- a/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
+++ b/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
@@ -42,6 +42,9 @@ const valid: () => (string | ValidTestCase<Options>)[] = () => [
   `
     const { selectAll: selectAllItems, selectEntities: selectEntitiesMap } = getSelectors(adapter);
   `,
+  `
+    const { selectItems, ...rest } = getSelectors(adapter);
+  `,
 ];
 
 const invalid: () => InvalidTestCase<MessageIds, Options>[] = () => [

--- a/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
+++ b/modules/eslint-plugin/spec/rules/store/prefix-selectors-with-select.spec.ts
@@ -63,7 +63,7 @@ export const selectCount: MemoizedSelector<any, any> = (state: AppState) => stat
   fromFixture(
     `
 export const { selectAll: allBooks } = booksAdapter.getSelectors(createSelector(selectBookInfo, (state) => state.books));
-                          ~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+                                  ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {
       suggestions: [
         {
@@ -78,7 +78,7 @@ export const { selectAll: selectAllBooks } = booksAdapter.getSelectors(createSel
   fromFixture(
     `
 const { selectAll: allItems } = getSelectors(adapter);
-              ~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+                        ~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {
       suggestions: [
         {
@@ -93,7 +93,7 @@ const { selectAll: selectAllItems } = getSelectors(adapter);`,
   fromFixture(
     `
 const { selectEntities: entitiesMap } = getSelectors(adapter);
-                    ~~~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
+                              ~~~~~~~~~~~ [${prefixSelectorsWithSelect} suggest]`,
     {
       suggestions: [
         {

--- a/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
+++ b/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
@@ -32,7 +32,12 @@ export default createRule<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     function reportIfInvalid(name: string, node: TSESTree.Identifier) {
-      if (!name.startsWith('select')) {
+      const isValid =
+        name.startsWith('select') &&
+        name.length > 'select'.length &&
+        /^[A-Z_$]/.test(name.slice('select'.length));
+
+      if (!isValid) {
         const suggestedName = getSuggestedName(name);
         context.report({
           node,
@@ -58,10 +63,7 @@ export default createRule<Options, MessageIds>({
                   parent.id.type === 'Identifier'
                 ) {
                   const fullText = sourceCode.getText(parent.id);
-                  const updatedText = fullText.replace(
-                    node.name,
-                    suggestedName
-                  );
+                  const updatedText = fullText.replace(name, suggestedName);
                   return fixer.replaceText(parent.id, updatedText);
                 }
 
@@ -70,6 +72,41 @@ export default createRule<Options, MessageIds>({
             },
           ],
         });
+      }
+    }
+
+    function isSelectorFactoryCall(node: TSESTree.CallExpression): boolean {
+      const callee = node.callee;
+      return (
+        callee.type === 'Identifier' &&
+        [
+          'createSelector',
+          'createFeatureSelector',
+          'createSelectorFactory',
+        ].includes(callee.name)
+      );
+    }
+
+    function checkFunctionBody(
+      name: string,
+      node: TSESTree.Identifier,
+      body: TSESTree.BlockStatement | TSESTree.Expression
+    ) {
+      if (body.type === 'CallExpression' && isSelectorFactoryCall(body)) {
+        reportIfInvalid(name, node);
+      }
+
+      if (body.type === 'BlockStatement') {
+        for (const stmt of body.body) {
+          if (
+            stmt.type === 'ReturnStatement' &&
+            stmt.argument &&
+            stmt.argument.type === 'CallExpression' &&
+            isSelectorFactoryCall(stmt.argument)
+          ) {
+            reportIfInvalid(name, node);
+          }
+        }
       }
     }
 
@@ -91,18 +128,37 @@ export default createRule<Options, MessageIds>({
               reportIfInvalid(prop.value.name, prop.value);
             }
           }
-          return; // Early exit to prevent duplicate lint errors when handling ObjectPattern selectors
+          return;
         }
 
-        if (
-          id.type === 'Identifier' &&
-          id.typeAnnotation?.typeAnnotation.type === 'TSTypeReference' &&
-          id.typeAnnotation.typeAnnotation.typeName.type === 'Identifier' &&
-          /^MemoizedSelector(WithProps)?$/.test(
-            id.typeAnnotation.typeAnnotation.typeName.name
-          )
-        ) {
-          reportIfInvalid(id.name, id);
+        if (id.type === 'Identifier') {
+          const hasSelectorType =
+            node.id.typeAnnotation?.typeAnnotation.type === 'TSTypeReference' &&
+            node.id.typeAnnotation.typeAnnotation.typeName.type ===
+              'Identifier' &&
+            /^MemoizedSelector(WithProps)?$/.test(
+              node.id.typeAnnotation.typeAnnotation.typeName.name
+            );
+
+          const isSelectorCall =
+            init?.type === 'CallExpression' && isSelectorFactoryCall(init);
+
+          const isArrowFunction =
+            init?.type === 'ArrowFunctionExpression' &&
+            init.body &&
+            (init.body.type === 'CallExpression' ||
+              init.body.type === 'BlockStatement');
+
+          const isFunctionExpression =
+            init?.type === 'FunctionExpression' &&
+            init.body &&
+            init.body.type === 'BlockStatement';
+
+          if (hasSelectorType || isSelectorCall) {
+            reportIfInvalid(id.name, id);
+          } else if (isArrowFunction || isFunctionExpression) {
+            checkFunctionBody(id.name, id, init.body);
+          }
         }
       },
     };
@@ -116,25 +172,32 @@ function getSuggestedName(name: string): string {
 
   const selectWord = 'select';
 
-  // Case 1: Already starts with "select" isn't pascal-case
-  let possibleReplacedName = name.replace(
-    new RegExp(`^${selectWord}(.+)`),
-    (_, word: string) => `${selectWord}${capitalize(word)}`
-  );
+  // Case 1: Already starts with "select" but not properly capitalized
+  if (name.startsWith(selectWord)) {
+    const rest = name.slice(selectWord.length);
+    if (rest.length === 0) {
+      return 'selectSelect';
+    }
 
-  if (name !== possibleReplacedName) {
-    return possibleReplacedName;
+    // Preserve casing for snake_case or ALL_CAPS
+    if (/^[A-Z_]+$/.test(rest)) {
+      return `${selectWord}${rest}`;
+    }
+
+    return `${selectWord}${capitalize(rest)}`;
   }
 
   // Case 2: Starts with "get"
-  possibleReplacedName = name.replace(/^get([^a-z].+)/, (_, word: string) => {
-    return `${selectWord}${capitalize(word)}`;
-  });
-
-  if (name !== possibleReplacedName) {
-    return possibleReplacedName;
+  if (/^get([^a-z].+)/.test(name)) {
+    const rest = name.slice(3);
+    return `${selectWord}${capitalize(rest)}`;
   }
 
-  // Case 3: No prefix
+  // Case 3: ALL_CAPS or snake_case
+  if (/^[A-Z_]+$/.test(name)) {
+    return `${selectWord}${name}`;
+  }
+
+  // Case 4: generic or camelCase
   return `${selectWord}${capitalize(name)}`;
 }

--- a/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
+++ b/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
@@ -91,7 +91,7 @@ export default createRule<Options, MessageIds>({
               reportIfInvalid(prop.value.name, prop.value);
             }
           }
-          return;
+          return; // Early exit to prevent duplicate lint errors when handling ObjectPattern selectors
         }
 
         if (
@@ -110,10 +110,13 @@ export default createRule<Options, MessageIds>({
 });
 
 function getSuggestedName(name: string): string {
-  if (typeof name !== 'string') return 'selectUnknown';
+  if (typeof name !== 'string') {
+    return 'selectUnknown';
+  }
 
   const selectWord = 'select';
 
+  // Case 1: Already starts with "select" isn't pascal-case
   let possibleReplacedName = name.replace(
     new RegExp(`^${selectWord}(.+)`),
     (_, word: string) => `${selectWord}${capitalize(word)}`
@@ -123,6 +126,7 @@ function getSuggestedName(name: string): string {
     return possibleReplacedName;
   }
 
+  // Case 2: Starts with "get"
   possibleReplacedName = name.replace(/^get([^a-z].+)/, (_, word: string) => {
     return `${selectWord}${capitalize(word)}`;
   });
@@ -131,5 +135,6 @@ function getSuggestedName(name: string): string {
     return possibleReplacedName;
   }
 
+  // Case 3: No prefix
   return `${selectWord}${capitalize(name)}`;
 }

--- a/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
+++ b/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
@@ -67,7 +67,7 @@ export default createRule<Options, MessageIds>({
               init.callee.property.type === 'Identifier' &&
               init.callee.property.name === 'getSelectors'));
 
-        if (id.type === 'ObjectPattern') {
+        if (id.type === 'ObjectPattern' && isSelectorSource) {
           for (const prop of id.properties) {
             if (prop.type === 'Property' && prop.value.type === 'Identifier') {
               reportIfInvalid(prop.value.name, prop.value);

--- a/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
+++ b/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
@@ -48,7 +48,26 @@ export default createRule<Options, MessageIds>({
             {
               messageId: prefixSelectorsWithSelectSuggest,
               data: { name: suggestedName },
-              fix: (fixer) => fixer.replaceText(node, suggestedName),
+              fix: (fixer) => {
+                const sourceCode =
+                  context.sourceCode ?? context.getSourceCode();
+                const parent = node.parent;
+
+                if (
+                  parent &&
+                  parent.type === 'VariableDeclarator' &&
+                  parent.id.type === 'Identifier'
+                ) {
+                  const fullText = sourceCode.getText(parent.id);
+                  const updatedText = fullText.replace(
+                    node.name,
+                    suggestedName
+                  );
+                  return fixer.replaceText(parent.id, updatedText);
+                }
+
+                return fixer.replaceText(node, suggestedName);
+              },
             },
           ],
         });

--- a/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
+++ b/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
@@ -166,10 +166,6 @@ export default createRule<Options, MessageIds>({
 });
 
 function getSuggestedName(name: string): string {
-  if (typeof name !== 'string') {
-    return 'selectUnknown';
-  }
-
   const selectWord = 'select';
 
   // Case 1: Already starts with "select" but not properly capitalized

--- a/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
+++ b/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
@@ -32,6 +32,8 @@ export default createRule<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     function reportIfInvalid(name: string, node: TSESTree.Identifier) {
+      // Name starts with select and
+      // the first character after select is an uppercase ASCII letter, _, or $
       const isValid =
         name.startsWith('select') &&
         name.length > 'select'.length &&

--- a/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
+++ b/modules/eslint-plugin/src/rules/store/prefix-selectors-with-select.ts
@@ -49,8 +49,7 @@ export default createRule<Options, MessageIds>({
               messageId: prefixSelectorsWithSelectSuggest,
               data: { name: suggestedName },
               fix: (fixer) => {
-                const sourceCode =
-                  context.sourceCode ?? context.getSourceCode();
+                const sourceCode = context.sourceCode;
                 const parent = node.parent;
 
                 if (
@@ -119,12 +118,18 @@ function getSuggestedName(name: string): string {
     new RegExp(`^${selectWord}(.+)`),
     (_, word: string) => `${selectWord}${capitalize(word)}`
   );
-  if (name !== possibleReplacedName) return possibleReplacedName;
+
+  if (name !== possibleReplacedName) {
+    return possibleReplacedName;
+  }
 
   possibleReplacedName = name.replace(/^get([^a-z].+)/, (_, word: string) => {
     return `${selectWord}${capitalize(word)}`;
   });
-  if (name !== possibleReplacedName) return possibleReplacedName;
+
+  if (name !== possibleReplacedName) {
+    return possibleReplacedName;
+  }
 
   return `${selectWord}${capitalize(name)}`;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Closes #4845 

## What is the new behavior?

ESLint will now complain when destructuring is used with incorrect names.  The rule will likely not work with nested destructuring or other advanced / edge cases.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

## Other information
