### PR TITLE
docs(www): fix call to action buttons

### DIFF
--- a/projects/www/src/app/pages/(home).page.ts
+++ b/projects/www/src/app/pages/(home).page.ts
@@ -20,8 +20,8 @@ import { MatIconModule } from '@angular/material/icon';
       <ngrx-banner-animation></ngrx-banner-animation>
       <img src="/ngrx-logo.svg" alt="ngrx logo" width="260" />
       <h1 class="mat-display-large">Reactive State for Angular</h1>
-      <a routerLink="/guide/store/walkthrough"
-        ><button mat-flat-button class="cta">Learn NgRx</button></a
+      <a routerLink="/guide/store/walkthrough" mat-flat-button class="cta"
+        >Learn NgRx</a
       >
     </div>
     <div class="content">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The CTA buttons on the New Docs homepage (`Learn NgRx`, `Attend a Workshop`, and `Get Support`) are currently missing `routerLink` bindings.

Closes #4925

## What is the new behavior?

Add the links to the following buttons:

Learn NgRx: `/guide/store/walkthrough`
Attend a Workshop: `/workshops`
Get Support: `/support`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
