### PR TITLE
docs(www): add links to community footer

### DIFF
--- a/projects/www/src/app/components/footer.component.ts
+++ b/projects/www/src/app/components/footer.component.ts
@@ -31,10 +31,10 @@ import { RouterLink } from '@angular/router';
 
     <nav class="community">
       <h4>Community</h4>
-      <a href="">Blog</a>
-      <a href="">GitHub</a>
-      <a href="">X/Twitter</a>
-      <a href="">Discord</a>
+      <a href="https://dev.to/ngrx" target="_blank">Blog</a>
+      <a href="https://github.com/ngrx/platform" target="_blank">GitHub</a>
+      <a href="https://x.com/ngrx_io" target="_blank">X/Twitter</a>
+      <a href="https://discord.com/invite/ngrx" target="_blank">Discord</a>
     </nav>
   `,
   styles: [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The Community footer buttons on the New Docs homepage are currently missing `href` bindings.

Closes #4924

## What is the new behavior?

Add links to the following community footer:

Blog: https://dev.to/ngrx
Github: https://github.com/ngrx/platform
X/Twitter: https://x.com/ngrx_io
Discord: https://discord.com/invite/ngrx

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
