### PR TITLE
fix: add unique member check to `withLinkedState`

### DIFF
--- a/modules/signals/spec/with-linked-state.spec.ts
+++ b/modules/signals/spec/with-linked-state.spec.ts
@@ -6,8 +6,9 @@ import {
   withLinkedState,
   withState,
 } from '../src';
-import { getInitialInnerStore } from '../src/signal-store';
+import { getInitialInnerStore, signalStore } from '../src/signal-store';
 import { isWritableSignal, STATE_SOURCE } from '../src/state-source';
+import { vi } from 'vitest';
 
 describe('withLinkedState', () => {
   describe('adds linked state slices to the STATE_SOURCE', () => {
@@ -234,5 +235,24 @@ describe('withLinkedState', () => {
       user.set({ name: 'Mark' });
       expect(name()).toBe('Mark');
     });
+  });
+
+  it('logs a warning if previously defined signal store members have the same name', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const linkedStateFeature = signalStoreFeature(
+      withState({ value: 1 }),
+      withLinkedState(() => ({
+        value: () => 1,
+      }))
+    );
+
+    linkedStateFeature(getInitialInnerStore());
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '@ngrx/signals: SignalStore members cannot be overridden.',
+      'Trying to override:',
+      'value'
+    );
   });
 });

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -1,5 +1,6 @@
 import { linkedSignal, WritableSignal } from '@angular/core';
 import { toDeepSignal } from './deep-signal';
+import { assertUniqueStoreMembers } from './signal-store-assertions';
 import {
   InnerSignalStore,
   SignalsDictionary,
@@ -85,6 +86,7 @@ export function withLinkedState<
       ...store.props,
     });
     const stateKeys = Reflect.ownKeys(linkedState);
+    assertUniqueStoreMembers(store, stateKeys);
     const stateSource = store[STATE_SOURCE] as SignalsDictionary;
     const stateSignals = {} as SignalsDictionary;
 


### PR DESCRIPTION
This fixes a bug with `withLinkedState` that fails to check for unique members.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Duplicated members go unnoticed.

Closes #4931

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
