### PR TITLE
docs(signals): add missing withMethods import in withLinkedState example

### DIFF
--- a/projects/ngrx.io/content/guide/signals/signal-store/linked-state.md
+++ b/projects/ngrx.io/content/guide/signals/signal-store/linked-state.md
@@ -13,7 +13,7 @@ As a result, the linked state slice is updated automatically whenever any of its
 <code-tabs linenums="true">
 <code-pane header="options-store.ts">
 
-import { patchState, signalStore, withLinkedState, withState } from '@ngrx/signals';
+import { patchState, signalStore, withLinkedState, withState, withMethods } from '@ngrx/signals';
 
 export const OptionsStore = signalStore(
   withState({ options: [1, 2, 3] }),
@@ -29,7 +29,7 @@ export const OptionsStore = signalStore(
       // 👇 Updating a linked state slice.
       patchState(store, { selectedOption });
     },
-  }),
+  })),
 );
 
 </code-pane>

--- a/projects/www/src/app/pages/guide/signals/signal-store/linked-state.md
+++ b/projects/www/src/app/pages/guide/signals/signal-store/linked-state.md
@@ -14,7 +14,7 @@ As a result, the linked state slice is updated automatically whenever any of its
 <ngrx-code-example header="options-store.ts">
 
 ```ts
-import { patchState, signalStore, withLinkedState, withState } from '@ngrx/signals';
+import { patchState, signalStore, withLinkedState, withState, withMethods } from '@ngrx/signals';
 
 export const OptionsStore = signalStore(
     withState({ options: [1, 2, 3] }),
@@ -30,7 +30,7 @@ export const OptionsStore = signalStore(
             // 👇 Updating a linked state slice.
             patchState(store, { selectedOption });
         },
-    }),
+    })),
 );
 ```
 


### PR DESCRIPTION
The withLinkedState example in the docs was missing the withMethods import, causing compilation errors when copied directly. This change adds the missing import and ensures the example compiles correctly.

Closes #4940

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Docs example for withLinkedState is missing the withMethods import,
causing compilation errors when copied and used directly.

Closes #4940 

## What is the new behavior?

Added missing withMethods import in the example.
Ensured parentheses are properly closed.
Example now compiles and runs correctly when copied.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

NA
