### PR TITLE
docs(www): replace support link with sponsor link

### DIFF
--- a/projects/www/src/app/components/footer.component.ts
+++ b/projects/www/src/app/components/footer.component.ts
@@ -18,7 +18,7 @@ import { RouterLink } from '@angular/router';
       <h4>Learn NgRx</h4>
       <a routerLink="/workshops">Workshops</a>
       <a routerLink="/api">API Reference</a>
-      <a routerLink="/support">Support</a>
+      <a href="https://github.com/sponsors/ngrx" target="_blank">Sponsor</a>
     </nav>
 
     <nav class="packages">

--- a/projects/www/src/app/components/menu.component.ts
+++ b/projects/www/src/app/components/menu.component.ts
@@ -51,9 +51,13 @@ import { DOCUMENT } from '@angular/common';
         <mat-icon>description</mat-icon>
         API Reference
       </a>
-      <a routerLink="/support" routerLinkActive="active" class="menu-link">
-        <mat-icon>help</mat-icon>
-        Support
+      <a
+        href="https://github.com/sponsors/ngrx"
+        target="_blank"
+        class="menu-link"
+      >
+        <mat-icon>volunteer_activism</mat-icon>
+        Sponsor
       </a>
       <a
         href="https://github.com/ngrx/platform"

--- a/projects/www/src/app/pages/(home).page.ts
+++ b/projects/www/src/app/pages/(home).page.ts
@@ -45,13 +45,15 @@ import { MatIconModule } from '@angular/material/icon';
         <a routerLink="/workshops" mat-flat-button>Attend a Workshop</a>
       </ngrx-styled-box>
       <ngrx-styled-box>
-        <mat-icon inline>help</mat-icon>
-        <h3>Support</h3>
-        <p>
-          Join our free community Discord server to get help with NgRx, or
-          schedule a 1:1 session with an NgRx expert.
-        </p>
-        <a routerLink="/support" mat-flat-button>Get Support</a>
+        <mat-icon inline>volunteer_activism</mat-icon>
+        <h3>Support the team</h3>
+        <p>Support the development of NgRx by sponsoring us.</p>
+        <a
+          href="https://github.com/sponsors/ngrx"
+          target="_blank"
+          mat-flat-button
+          >Sponsor</a
+        >
       </ngrx-styled-box>
     </div>
   `,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

I noticed we don't have a sponsor link on the new website.
This replaces the (not implemented) support link to a sponsor link.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
