### PR TITLE
fix(signals): drop `assertUniqueStoreMembers` in production

### DIFF
--- a/modules/signals/src/signal-store-assertions.ts
+++ b/modules/signals/src/signal-store-assertions.ts
@@ -1,15 +1,9 @@
 import { InnerSignalStore } from './signal-store-models';
 
-declare const ngDevMode: unknown;
-
 export function assertUniqueStoreMembers(
   store: InnerSignalStore,
   newMemberKeys: Array<string | symbol>
 ): void {
-  if (typeof ngDevMode === 'undefined' || !ngDevMode) {
-    return;
-  }
-
   const storeMembers = {
     ...store.stateSignals,
     ...store.props,

--- a/modules/signals/src/with-linked-state.ts
+++ b/modules/signals/src/with-linked-state.ts
@@ -86,7 +86,9 @@ export function withLinkedState<
       ...store.props,
     });
     const stateKeys = Reflect.ownKeys(linkedState);
-    assertUniqueStoreMembers(store, stateKeys);
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      assertUniqueStoreMembers(store, stateKeys);
+    }
     const stateSource = store[STATE_SOURCE] as SignalsDictionary;
     const stateSignals = {} as SignalsDictionary;
 

--- a/modules/signals/src/with-methods.ts
+++ b/modules/signals/src/with-methods.ts
@@ -30,7 +30,9 @@ export function withMethods<
       ...store.props,
       ...store.methods,
     });
-    assertUniqueStoreMembers(store, Reflect.ownKeys(methods));
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      assertUniqueStoreMembers(store, Reflect.ownKeys(methods));
+    }
 
     return {
       ...store,

--- a/modules/signals/src/with-props.ts
+++ b/modules/signals/src/with-props.ts
@@ -28,7 +28,9 @@ export function withProps<
       ...store.props,
       ...store.methods,
     });
-    assertUniqueStoreMembers(store, Reflect.ownKeys(props));
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      assertUniqueStoreMembers(store, Reflect.ownKeys(props));
+    }
 
     return {
       ...store,

--- a/modules/signals/src/with-state.ts
+++ b/modules/signals/src/with-state.ts
@@ -34,7 +34,9 @@ export function withState<State extends object>(
     ) as Record<string | symbol, unknown>;
     const stateKeys = Reflect.ownKeys(state);
 
-    assertUniqueStoreMembers(store, stateKeys);
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      assertUniqueStoreMembers(store, stateKeys);
+    }
 
     const stateSource = store[STATE_SOURCE] as Record<
       string | symbol,


### PR DESCRIPTION
The `assertUniqueStoreMembers` method previously used an early-return guard:

```js
  if (!ngDevMode) return;
  // dev-only code ...
```

In production builds, `ngDevMode` is replaced with `false`, so the guard compiles to `return;`. However, bundlers like ESBuild still keep the remaining statements after the return as unreachable code instead of removing them. This leaves behind unnecessary dead code in the output.

Technically, the body is unreachable. But to prove that, the bundler must be 100% certain that:

- `return` cannot be removed by some transform
- there's no later transformation that changes control flow

As thus, it's always conservative.

This commit updates the method to instead wrap the full function:

```js
  if (ngDevMode) {
    // assertUniqueStoreMembers ...
  }
```

<img width="1060" height="517" alt="Снимок экрана 2025-09-06 в 13 46 09" src="https://github.com/user-attachments/assets/9dcefc4c-0f37-4dcd-b059-4ffebcc6c031" />

