### PR TITLE
fix(signals): drop `assertInInjectionContext` in production

### DIFF
--- a/modules/signals/events/src/inject-dispatch.ts
+++ b/modules/signals/events/src/inject-dispatch.ts
@@ -58,7 +58,7 @@ export function injectDispatch<
   events: EventGroup,
   config?: { injector?: Injector }
 ): Prettify<InjectDispatchResult<EventGroup>> {
-  if (!config?.injector) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && !config?.injector) {
     assertInInjectionContext(injectDispatch);
   }
 

--- a/modules/signals/rxjs-interop/src/rx-method.ts
+++ b/modules/signals/rxjs-interop/src/rx-method.ts
@@ -26,7 +26,7 @@ export function rxMethod<Input>(
   generator: (source$: Observable<Input>) => Observable<unknown>,
   config?: { injector?: Injector }
 ): RxMethod<Input> {
-  if (!config?.injector) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && !config?.injector) {
     assertInInjectionContext(rxMethod);
   }
 

--- a/modules/signals/src/signal-method.ts
+++ b/modules/signals/src/signal-method.ts
@@ -22,7 +22,7 @@ export function signalMethod<Input>(
   processingFn: (value: Input) => void,
   config?: { injector?: Injector }
 ): SignalMethod<Input> {
-  if (!config?.injector) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && !config?.injector) {
     assertInInjectionContext(signalMethod);
   }
 

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -110,7 +110,7 @@ export function watchState<State extends object>(
   watcher: StateWatcher<State>,
   config?: { injector?: Injector }
 ): { destroy(): void } {
-  if (!config?.injector) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && !config?.injector) {
     assertInInjectionContext(watchState);
   }
 


### PR DESCRIPTION
Angular itself wraps `assertInInjectionContext()` (and similar helpers) in `ngDevMode` so that:

- In dev builds → the assertion runs, catches mistakes early, and gives clear errors.
- In prod builds → the code gets tree-shaken away, leaving no overhead.