### PR TITLE
refactor(signals): use dot-notation to access properties in withFeature

### DIFF
--- a/modules/signals/src/with-feature.ts
+++ b/modules/signals/src/with-feature.ts
@@ -44,9 +44,9 @@ export function withFeature<
   return (store) => {
     const storeForFactory = {
       [STATE_SOURCE]: store[STATE_SOURCE],
-      ...store['stateSignals'],
-      ...store['props'],
-      ...store['methods'],
+      ...store.stateSignals,
+      ...store.props,
+      ...store.methods,
     };
 
     return featureFactory(storeForFactory)(store);


### PR DESCRIPTION
Minor refactor to use dot-notation instead of brackets for accessing the properties of the `store` object