### PR TITLE
fix(schematics): restore CommonJS module output for Node.js compatibi…

### DIFF
--- a/modules/component-store/tsconfig.schematics.json
+++ b/modules/component-store/tsconfig.schematics.json
@@ -4,8 +4,8 @@
     "rootDir": ".",
     "stripInternal": true,
     "experimentalDecorators": true,
-    "module": "preserve",
-    "moduleResolution": "bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "downlevelIteration": true,
     "outDir": "../../dist/modules/component-store",
     "paths": {

--- a/modules/component/tsconfig.schematics.json
+++ b/modules/component/tsconfig.schematics.json
@@ -4,8 +4,8 @@
     "rootDir": ".",
     "stripInternal": true,
     "experimentalDecorators": true,
-    "module": "preserve",
-    "moduleResolution": "bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "downlevelIteration": true,
     "outDir": "../../dist/modules/component",
     "paths": {

--- a/modules/data/tsconfig.schematics.json
+++ b/modules/data/tsconfig.schematics.json
@@ -4,8 +4,8 @@
     "rootDir": ".",
     "stripInternal": true,
     "experimentalDecorators": true,
-    "module": "preserve",
-    "moduleResolution": "bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "downlevelIteration": true,
     "outDir": "../../dist/modules/data",
     "paths": {

--- a/modules/entity/tsconfig.schematics.json
+++ b/modules/entity/tsconfig.schematics.json
@@ -4,8 +4,8 @@
     "rootDir": ".",
     "stripInternal": true,
     "experimentalDecorators": true,
-    "module": "preserve",
-    "moduleResolution": "bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "downlevelIteration": true,
     "outDir": "../../dist/modules/entity",
     "paths": {

--- a/modules/schematics/tsconfig.schematics.json
+++ b/modules/schematics/tsconfig.schematics.json
@@ -4,7 +4,8 @@
     "rootDir": ".",
     "stripInternal": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "downlevelIteration": true,
     "outDir": "../../dist/modules/schematics",
     "paths": {

--- a/modules/store/tsconfig.schematics.json
+++ b/modules/store/tsconfig.schematics.json
@@ -4,8 +4,8 @@
     "rootDir": ".",
     "stripInternal": true,
     "experimentalDecorators": true,
-    "module": "preserve",
-    "moduleResolution": "bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "downlevelIteration": true,
     "outDir": "../../dist/modules/store",
     "paths": {


### PR DESCRIPTION
Angular Schematics still run under CommonJS. That's why the `tsconfig.schematics.json`, has to revert its output via `moduleResolution: "node"`.

This fix has been successfully tested locally, via publishing to verdaccio and doing a fresh installation via `npx ng add @ngrx/schematics`.

As a follow-up/separate issue,I would suggest introducing a integration test, which creates a new Angular workspace and executes the schematics on it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

Closes #5050

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```