### PR TITLE
docs(www): unregister legacy service worker

### DIFF
--- a/projects/www/src/main.ts
+++ b/projects/www/src/main.ts
@@ -4,7 +4,7 @@ import { config } from './app/app.config.browser';
 
 // Deactivate service worker from old ngrx.io app
 // TODO: Remove after 6 months
-if (typeof window !== 'undefined' && window.navigator.serviceWorker) {
+if (typeof window !== 'undefined') {
   window.navigator.serviceWorker.getRegistrations().then((registrations) => {
     for (const registration of registrations) {
       registration.unregister();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, the old ngrx docs website is always displayed on browser reinitialization for all users who opened the old ngrx docs website before, because the service worker from the old app is still registered.

## What is the new behavior?

Service worker from the old ngrx website is unregistered.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
