### PR TITLE
fix(entity): infer selectId return type from adapter configuration

### DIFF
--- a/modules/data/src/entity-metadata/entity-definition.ts
+++ b/modules/data/src/entity-metadata/entity-definition.ts
@@ -28,7 +28,10 @@ export function createEntityDefinition<T, S extends object>(
   const selectId = metadata.selectId || defaultSelectId;
   const sortComparer = (metadata.sortComparer = metadata.sortComparer || false);
 
-  const entityAdapter = createEntityAdapter<T>({ selectId, sortComparer });
+  const entityAdapter = createEntityAdapter<T>({
+    selectId: selectId as any,
+    sortComparer,
+  });
 
   const entityDispatcherOptions: Partial<EntityDispatcherDefaultOptions> =
     metadata.entityDispatcherOptions || {};

--- a/modules/data/src/entity-metadata/entity-definition.ts
+++ b/modules/data/src/entity-metadata/entity-definition.ts
@@ -25,11 +25,11 @@ export function createEntityDefinition<T, S extends object>(
     throw new Error('Missing required entityName');
   }
   metadata.entityName = entityName = entityName.trim();
-  const selectId = metadata.selectId || defaultSelectId;
+  const selectId = metadata.selectId || (defaultSelectId as IdSelector<T>);
   const sortComparer = (metadata.sortComparer = metadata.sortComparer || false);
 
   const entityAdapter = createEntityAdapter<T>({
-    selectId: selectId as any,
+    selectId,
     sortComparer,
   });
 

--- a/modules/entity/spec/types/entity_adapter.spec.ts
+++ b/modules/entity/spec/types/entity_adapter.spec.ts
@@ -1,0 +1,68 @@
+import { expecter } from 'ts-snippet';
+import { compilerOptions } from './utils';
+
+describe('EntityAdapter Types', () => {
+  const expectSnippet = expecter(
+    (code) => `
+        import { EntityState, createEntityAdapter, EntityAdapter } from '@ngrx/entity';
+
+        interface EntityWithStringId {
+          id: string;
+        }
+
+        interface EntityWithNumberId {
+          id: number;
+        }
+
+        interface EntityWithoutId {
+          key: number;
+        }
+
+
+        ${code}
+      `,
+    compilerOptions()
+  );
+
+  it('sets the id type to string when the entity has a string id', () => {
+    expectSnippet(`
+        export const adapter: EntityAdapter<EntityWithStringId, string> = createEntityAdapter<EntityWithStringId>();
+      `).toSucceed();
+  });
+
+  it('sets the id type to number when the entity has a number id', () => {
+    expectSnippet(`
+        export const adapter: EntityAdapter<EntityWithNumberId, number> = createEntityAdapter<EntityWithNumberId>();
+      `).toSucceed();
+  });
+
+  it('sets the id type to string when selectId returns a string', () => {
+    expectSnippet(`
+        export const adapter: EntityAdapter<EntityWithNumberId, string> = createEntityAdapter<EntityWithNumberId>({
+          selectId: (entity) => entity.id.toString(),
+        });
+      `).toSucceed();
+  });
+
+  it('sets the id type to string | number when the entity has no id and no selectId is provided', () => {
+    expectSnippet(`
+        export const adapter: EntityAdapter<EntityWithoutId, string | number> = createEntityAdapter<EntityWithoutId>();
+      `).toSucceed();
+  });
+
+  it('sets the id type to correct type if selectId is provided', () => {
+    expectSnippet(`
+        export const adapter: EntityAdapter<EntityWithoutId, string> = createEntityAdapter<EntityWithoutId>({
+          selectId: (entity) => entity.key.toString(),
+        });
+      `).toSucceed();
+  });
+
+  it('sets the id type to string when selectId returns a string', () => {
+    expectSnippet(`
+        export const adapter: EntityAdapter<EntityWithNumberId, string> = createEntityAdapter<EntityWithNumberId>({
+          selectId: (entity) => entity.id.toString(),
+        });
+      `).toSucceed();
+  });
+}, 8_000);

--- a/modules/entity/src/create_adapter.ts
+++ b/modules/entity/src/create_adapter.ts
@@ -3,12 +3,71 @@ import {
   Comparer,
   IdSelector,
   EntityAdapter,
+  IdSelectorStr,
+  IdSelectorNum,
 } from './models';
 import { createInitialStateFactory } from './entity_state';
 import { createSelectorsFactory } from './state_selectors';
 import { createSortedStateAdapter } from './sorted_state_adapter';
 import { createUnsortedStateAdapter } from './unsorted_state_adapter';
 
+/**
+ * Creates an entity adapter with methods for managing collections of entities in state.
+ *
+ * @description
+ * The entity adapter provides a set of predefined reducers and selectors for managing
+ * normalized entity collections. It includes methods for adding, updating, removing,
+ * and selecting entities from state.
+ *
+ * @template T - The entity type to be managed by the adapter
+ *
+ * @param options - Configuration options for the adapter
+ * @param options.selectId - A function that selects the unique identifier from an entity.
+ * Defaults to `(entity) => entity.id` if not provided.
+ * @param options.sortComparer - A comparer function for sorting entities in state.
+ * Set to `false` (default) to maintain insertion order, or provide a comparer function
+ * to keep entities sorted.
+ *
+ * @returns An entity adapter containing methods for managing and selecting entity collections in state.
+ *
+ * @example
+ * ```typescript
+ * // Entity with default 'id' property
+ * interface User {
+ *   id: number;
+ *   name: string;
+ * }
+ * const userAdapter = createEntityAdapter<User>();
+ *
+ * // Entity with custom id field
+ * interface Book {
+ *   isbn: string;
+ *   title: string;
+ * }
+ * const bookAdapter = createEntityAdapter<Book>({
+ *   selectId: (book) => book.isbn,
+ * });
+ *
+ * // Entity with sorting
+ * const sortedBookAdapter = createEntityAdapter<Book>({
+ *   sortComparer: (a, b) => a.title.localeCompare(b.title),
+ * });
+ * ```
+ */
+export function createEntityAdapter<
+  T extends { id: string | number },
+>(options?: {
+  sortComparer?: false | Comparer<T>;
+}): EntityAdapter<T, T extends { id: infer U } ? U : never>;
+export function createEntityAdapter<T>(options: {
+  selectId: IdSelectorStr<T>;
+  sortComparer?: false | Comparer<T>;
+}): EntityAdapter<T, string>;
+export function createEntityAdapter<T>(options: {
+  selectId: IdSelectorNum<T>;
+  sortComparer?: false | Comparer<T>;
+}): EntityAdapter<T, number>;
+export function createEntityAdapter<T>(): EntityAdapter<T>;
 export function createEntityAdapter<T>(
   options: {
     selectId?: IdSelector<T>;

--- a/modules/entity/src/create_adapter.ts
+++ b/modules/entity/src/create_adapter.ts
@@ -67,6 +67,10 @@ export function createEntityAdapter<T>(options: {
   selectId: IdSelectorNum<T>;
   sortComparer?: false | Comparer<T>;
 }): EntityAdapter<T, number>;
+export function createEntityAdapter<T>(options: {
+  selectId: IdSelector<T>;
+  sortComparer?: false | Comparer<T>;
+}): EntityAdapter<T>;
 export function createEntityAdapter<T>(): EntityAdapter<T>;
 export function createEntityAdapter<T>(
   options: {

--- a/modules/entity/src/models.ts
+++ b/modules/entity/src/models.ts
@@ -106,8 +106,15 @@ export type MemoizedEntitySelectors<T, V> = {
   >;
 };
 
-export interface EntityAdapter<T> extends EntityStateAdapter<T> {
-  selectId: IdSelector<T>;
+export interface EntityAdapter<
+  T,
+  IdType = string | number,
+> extends EntityStateAdapter<T> {
+  selectId: IdType extends string
+    ? IdSelectorStr<T>
+    : IdType extends number
+      ? IdSelectorNum<T>
+      : unknown;
   sortComparer: false | Comparer<T>;
   getInitialState(): EntityState<T>;
   getInitialState<S extends EntityState<T>>(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #5073 

The `IdSelector` always returned `string | number`. 

## What is the new behavior?

The return type if inferred by the adapter:

- uses the id property of the state
- uses the return type of the `selectId` method, if provided in the config options

## Does this PR introduce a breaking change?

I'm also ok with flagging this as a breaking change.

```
[x] Yes
[ ] No
```

BREAKING CHANGE:

BEFORE:

The `selectId` function in the entity adapter configuration has a `string | number` return type.

AFTER:

The `selectId` function in the entity adapter configuration is inferred from the adapter configuration.
The return type is `string` or `number`, depending on the implementation of the `selectId` function.
If no `selectId` function is provided, the default implementation infers the return type from the `id` property of the entity.

## Other information
