### PR TITLE
docs(signals): correct entityMap signal formatting in documentation

### DIFF
--- a/projects/www/src/app/pages/guide/signals/signal-store/entity-management.md
+++ b/projects/www/src/app/pages/guide/signals/signal-store/entity-management.md
@@ -28,9 +28,9 @@ export const TodosStore = signalStore(withEntities<Todo>());
 
 The `withEntities` feature adds the following signals to the `TodosStore`:
 
-- `ids: Signal<EntityId[]>`: An array of all entity IDs.
-- `entityMap: Signal<EntityMap<Todo>`: A map of entities where each key is an ID.
-- `entities: Signal<Todo[]>`: An array of all entities.
+- `ids: Signal&lt;EntityId[]&gt;`: An array of all entity IDs.
+- `entityMap: Signal&lt;EntityMap&lt;Todo&gt;&gt;`: A map of entities where each key is an ID.
+- `entities: Signal&lt;Todo[]&gt;`: An array of all entities.
 
 The `ids` and `entityMap` are state slices, while `entities` is a computed signal.
 


### PR DESCRIPTION
…entation

Fix formatting issue in entity-management.md for entityMap signal.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I was reading the docs and noticed that the `>` is duplicated. When I checked the GitHub repo, I found that it’s just a typo. However, I also observed that the generic type isn’t shown in the docs—only the base type is, for example `Signal<Todo[]>` is shown as just `Signal`.

