### PR TITLE
fix(eslint-plugin): Support factory by with-state-no-arrays-at-root-level

### DIFF
--- a/modules/eslint-plugin/spec/rules/signals/with-state-no-arrays-at-root-level.spec.ts
+++ b/modules/eslint-plugin/spec/rules/signals/with-state-no-arrays-at-root-level.spec.ts
@@ -22,6 +22,20 @@ const valid: () => (string | ValidTestCase<Options>)[] = () => [
     const initialState = {};
     const Store = signalStore(withState(initialState));
   `,
+  `const store = withState(() => ({ foo: 'bar' }))`,
+  `const store = withState(function() { return { foo: 'bar' }; })`,
+  `
+    const initialState = { books: [] };
+    const store = withState(() => initialState);
+  `,
+  `
+    const initialState = { books: [] };
+    const store = withState(function() { return initialState; });
+  `,
+  `
+    function getState() { return { count: 0 }; }
+    const store = withState(getState);
+  `,
 ];
 
 const invalid: () => InvalidTestCase<MessageIds, Options>[] = () => [
@@ -95,6 +109,25 @@ const store = withState(function() {});
   fromFixture(`
 const store = withState(() => {});
                         ~~~~~~~~ [${messageId} { "property": "Function" }]`),
+  fromFixture(`
+const store = withState(() => () => ({ foo: 'bar' }));
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [${messageId} { "property": "Function" }]`),
+  fromFixture(`
+const store = withState(() => [1, 2, 3]);
+                        ~~~~~~~~~~~~~~~ [${messageId} { "property": "Array" }]`),
+  fromFixture(`
+const initialState: string[] = [];
+const store = withState(() => initialState);
+                        ~~~~~~~~~~~~~~~~~~ [${messageId} { "property": "Array" }]`),
+  fromFixture(`
+const store = withState(() => new Set());
+                        ~~~~~~~~~~~~~~~ [${messageId} { "property": "Set" }]`),
+  fromFixture(`
+const store = withState(() => new Map());
+                        ~~~~~~~~~~~~~~~ [${messageId} { "property": "Map" }]`),
+  fromFixture(`
+const store = withState(function() { return function() { return { foo: 'bar' }; }; });
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [${messageId} { "property": "Function" }]`),
 ];
 
 ruleTester(rule.meta.docs?.requiresTypeChecking).run(

--- a/modules/eslint-plugin/src/rules/signals/with-state-no-arrays-at-root-level.ts
+++ b/modules/eslint-plugin/src/rules/signals/with-state-no-arrays-at-root-level.ts
@@ -52,7 +52,12 @@ export default createRule<Options, MessageIds>({
         } else if (argument) {
           const services = ESLintUtils.getParserServices(context);
           const typeChecker = services.program.getTypeChecker();
-          const type = services.getTypeAtLocation(argument);
+
+          let type = services.getTypeAtLocation(argument);
+          const callSignatures = type.getCallSignatures();
+          if (callSignatures.length > 0) {
+            type = typeChecker.getReturnTypeOfSignature(callSignatures[0]);
+          }
 
           if (typeChecker.isArrayType(type) || typeChecker.isTupleType(type)) {
             context.report({
@@ -73,8 +78,7 @@ export default createRule<Options, MessageIds>({
             return;
           }
 
-          const callSignatures = type.getCallSignatures();
-          if (callSignatures.length > 0) {
+          if (type.getCallSignatures().length > 0) {
             context.report({
               node: argument,
               messageId,
@@ -84,6 +88,16 @@ export default createRule<Options, MessageIds>({
           }
 
           const typeString = typeChecker.typeToString(type);
+
+          if (typeString === 'void') {
+            context.report({
+              node: argument,
+              messageId,
+              data: { property: 'Function' },
+            });
+            return;
+          }
+
           const matchedType = NON_RECORD_TYPES.find((t) =>
             typeString.startsWith(`${t}<`)
           );

--- a/projects/www/src/app/pages/guide/eslint-plugin/rules/with-state-no-arrays-at-root-level.md
+++ b/projects/www/src/app/pages/guide/eslint-plugin/rules/with-state-no-arrays-at-root-level.md
@@ -10,3 +10,51 @@ withState should accept a record or dictionary as an input argument.
 
 <!-- Everything above this generated, do not edit -->
 <!-- MANUAL-DOC:START -->
+
+## Rule Details
+
+This rule ensures that `withState` does not accept a non-record type at the root level. Arrays, sets, maps, and other non-plain-object types are forbidden as the initial state argument. A factory function is also accepted, in which case its return type is checked instead.
+
+Examples of **correct** code for this rule:
+
+<ngrx-code-example>
+
+```ts
+const store = signalStore(withState({ count: 0 }));
+
+const store = signalStore(withState({ items: [] }));
+
+const initialState = { count: 0 };
+const store = signalStore(withState(initialState));
+
+// Factory function - return type is checked
+const store = signalStore(withState(() => ({ count: 0 })));
+
+// Factory function with dependency injection
+const INITIAL_STATE = new InjectionToken('InitialState', {
+  factory: () => ({ count: 0 }),
+});
+const store = signalStore(withState(() => inject(INITIAL_STATE)));
+```
+
+</ngrx-code-example>
+
+Examples of **incorrect** code for this rule:
+
+<ngrx-code-example>
+
+```ts
+const store = signalStore(withState([1, 2, 3]));
+
+const store = signalStore(withState(new Set()));
+
+const store = signalStore(withState(new Map()));
+
+const initialState: number[] = [];
+const store = signalStore(withState(initialState));
+
+// Factory function returning a forbidden type
+const store = signalStore(withState(() => [1, 2, 3]));
+```
+
+</ngrx-code-example>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The with-state-no-arrays-at-root-level rule incorrectly flagged any
factory function passed to `withState()`, even though `withState()` supports
factory functions for dependency injection (e.g. `withState(() => inject(TOKEN))`)

Closes #5104 

## What is the new behavior?

The rule no longer flags factory methods if the return type matches the underlying rule.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

N/A