### PR TITLE
feat(effects): add FEATURE_EFFECTS_INIT lifecycle action

### DIFF
--- a/modules/effects/spec/effects_feature_module.spec.ts
+++ b/modules/effects/spec/effects_feature_module.spec.ts
@@ -12,6 +12,7 @@ import {
 import { firstValueFrom } from 'rxjs';
 import { map, take, withLatestFrom } from 'rxjs/operators';
 import { Actions, EffectsModule, ofType, createEffect } from '../';
+import { FEATURE_EFFECTS_INIT } from '../src/effects_actions';
 import { EffectsFeatureModule } from '../src/effects_feature_module';
 import { EffectsRootModule } from '../src/effects_root_module';
 import { _FEATURE_EFFECTS_INSTANCE_GROUPS } from '../src/tokens';
@@ -24,6 +25,7 @@ describe('Effects Feature Module', () => {
     const effectSourceGroups = [[sourceA], [sourceB], [sourceC]];
 
     let mockEffectSources: { addEffects: MockInstance };
+    let mockStore: { dispatch: MockInstance };
 
     beforeEach(() => {
       TestBed.configureTestingModule({
@@ -32,6 +34,12 @@ describe('Effects Feature Module', () => {
             provide: EffectsRootModule,
             useValue: {
               addEffects: vi.fn(),
+            },
+          },
+          {
+            provide: Store,
+            useValue: {
+              dispatch: vi.fn(),
             },
           },
           {
@@ -45,6 +53,9 @@ describe('Effects Feature Module', () => {
       mockEffectSources = TestBed.inject<unknown>(EffectsRootModule) as {
         addEffects: MockInstance;
       };
+      mockStore = TestBed.inject<unknown>(Store) as {
+        dispatch: MockInstance;
+      };
     });
 
     it('should add all effects when instantiated', () => {
@@ -53,6 +64,14 @@ describe('Effects Feature Module', () => {
       expect(mockEffectSources.addEffects).toHaveBeenCalledWith(sourceA);
       expect(mockEffectSources.addEffects).toHaveBeenCalledWith(sourceB);
       expect(mockEffectSources.addEffects).toHaveBeenCalledWith(sourceC);
+    });
+
+    it('should dispatch the feature effects init action', () => {
+      TestBed.inject(EffectsFeatureModule);
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith({
+        type: FEATURE_EFFECTS_INIT,
+      });
     });
   });
 

--- a/modules/effects/spec/effects_root_module.spec.ts
+++ b/modules/effects/spec/effects_root_module.spec.ts
@@ -3,7 +3,10 @@ import { TestBed } from '@angular/core/testing';
 import { INIT, Store, StoreModule } from '@ngrx/store';
 
 import { EffectsModule } from '../src/effects_module';
-import { ROOT_EFFECTS_INIT } from '../src/effects_actions';
+import {
+  ROOT_EFFECTS_INIT,
+  FEATURE_EFFECTS_INIT,
+} from '../src/effects_actions';
 
 describe('Effects Root Module', () => {
   const foo = 'foo';
@@ -45,6 +48,37 @@ describe('Effects Root Module', () => {
     });
     expect(reducer).not.toHaveBeenCalledWith(foo, {
       type: ROOT_EFFECTS_INIT,
+    });
+  });
+
+  it('dispatches the feature effects init action when EffectsModule.forFeature() is used', () => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({ reducer }, { initialState: { reducer: foo } }),
+        EffectsModule.forRoot([]),
+        EffectsModule.forFeature([]),
+      ],
+    });
+
+    const store = TestBed.inject(Store);
+
+    expect(reducer).toHaveBeenCalledWith(foo, {
+      type: FEATURE_EFFECTS_INIT,
+    });
+  });
+
+  it(`doesn't dispatch the feature effects init action when EffectsModule.forFeature() isn't used`, () => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({ reducer }, { initialState: { reducer: foo } }),
+        EffectsModule.forRoot([]),
+      ],
+    });
+
+    const store = TestBed.inject(Store);
+
+    expect(reducer).not.toHaveBeenCalledWith(foo, {
+      type: FEATURE_EFFECTS_INIT,
     });
   });
 });

--- a/modules/effects/spec/integration.spec.ts
+++ b/modules/effects/spec/integration.spec.ts
@@ -9,6 +9,7 @@ import {
   EffectsModule,
   OnInitEffects,
   ROOT_EFFECTS_INIT,
+  FEATURE_EFFECTS_INIT,
   OnIdentifyEffects,
   EffectSources,
   Actions,
@@ -193,6 +194,8 @@ describe('NgRx Effects Integration spec', () => {
           '[RootEffectWithInitAction2]: INIT',
 
           ROOT_EFFECTS_INIT,
+
+          FEATURE_EFFECTS_INIT,
         ]);
       });
 
@@ -292,12 +295,16 @@ describe('NgRx Effects Integration spec', () => {
         // next feat effects
         '[FeatEffectWithInitAction]: INIT',
 
+        FEATURE_EFFECTS_INIT,
+
         // lastly added features (3 effects but 2 unique keys)
         '[FeatEffectWithIdentifierAndInitAction]: INIT',
         '[FeatEffectWithIdentifierAndInitAction]: INIT',
 
         // from lazy loaded module
         '[FeatEffectFromLazyLoadedModuleWithInitAction]: INIT',
+
+        FEATURE_EFFECTS_INIT,
       ];
 
       // reducers should receive all actions
@@ -358,6 +365,8 @@ describe('NgRx Effects Integration spec', () => {
 
         // User provided effects loaded by feature module
         '[UserProvidedEffect2]: INIT',
+
+        FEATURE_EFFECTS_INIT,
       ];
       expect(dispatchedActionsLog).toEqual(expectedLog);
     });

--- a/modules/effects/src/effects_actions.ts
+++ b/modules/effects/src/effects_actions.ts
@@ -2,3 +2,6 @@ import { createAction } from '@ngrx/store';
 
 export const ROOT_EFFECTS_INIT = '@ngrx/effects/init';
 export const rootEffectsInit = createAction(ROOT_EFFECTS_INIT);
+
+export const FEATURE_EFFECTS_INIT = '@ngrx/effects/feature/init';
+export const featureEffectsInit = createAction(FEATURE_EFFECTS_INIT);

--- a/modules/effects/src/effects_feature_module.ts
+++ b/modules/effects/src/effects_feature_module.ts
@@ -1,5 +1,6 @@
 import { NgModule, Inject, Optional } from '@angular/core';
-import { StoreRootModule, StoreFeatureModule } from '@ngrx/store';
+import { Store, StoreRootModule, StoreFeatureModule } from '@ngrx/store';
+import { FEATURE_EFFECTS_INIT } from './effects_actions';
 import { EffectsRootModule } from './effects_root_module';
 import { _FEATURE_EFFECTS_INSTANCE_GROUPS } from './tokens';
 
@@ -7,6 +8,7 @@ import { _FEATURE_EFFECTS_INSTANCE_GROUPS } from './tokens';
 export class EffectsFeatureModule {
   constructor(
     effectsRootModule: EffectsRootModule,
+    store: Store,
     @Inject(_FEATURE_EFFECTS_INSTANCE_GROUPS)
     effectsInstanceGroups: unknown[][],
     @Optional() storeRootModule: StoreRootModule,
@@ -16,5 +18,7 @@ export class EffectsFeatureModule {
     for (const effectsInstance of effectsInstances) {
       effectsRootModule.addEffects(effectsInstance);
     }
+
+    store.dispatch({ type: FEATURE_EFFECTS_INIT });
   }
 }

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -14,7 +14,12 @@ export {
 export { Actions, ofType } from './actions';
 export { EffectsModule } from './effects_module';
 export { EffectSources } from './effect_sources';
-export { ROOT_EFFECTS_INIT, rootEffectsInit } from './effects_actions';
+export {
+  ROOT_EFFECTS_INIT,
+  rootEffectsInit,
+  FEATURE_EFFECTS_INIT,
+  featureEffectsInit,
+} from './effects_actions';
 export { EffectsRunner } from './effects_runner';
 export { EffectNotification } from './effect_notification';
 export { EffectsFeatureModule } from './effects_feature_module';

--- a/projects/www/src/app/pages/guide/effects/lifecycle.md
+++ b/projects/www/src/app/pages/guide/effects/lifecycle.md
@@ -18,6 +18,24 @@ init$ = createEffect(() => {
 
 </ngrx-code-example>
 
+### FEATURE_EFFECTS_INIT
+
+After all the root effects have been added, the feature effects are added, and after all of them are added too, the feature effect dispatches a `FEATURE_EFFECTS_INIT` action.
+Like with `ROOT_EFFECTS_INIT`, you can see this action as a lifecycle hook, which you can use in order to execute some code after all your root and feature effects have been added.
+
+<ngrx-code-example header="late-init.effects.ts">
+
+```ts
+lateInit$ = createEffect(() => {
+  return this.actions$.pipe(
+    ofType(FEATURE_EFFECTS_INIT),
+    map(action => ...)
+  );
+});
+```
+
+</ngrx-code-example>
+
 ## Effect Metadata
 
 ### Non-dispatching Effects
@@ -180,6 +198,8 @@ class UserEffects implements OnInitEffects {
   }
 }
 ```
+
+If there are too many effects in your app, you may instead consider relying on existing built-in actions `ROOT_EFFECTS_INIT` or `FEATURE_EFFECTS_INIT`.
 
 </ngrx-code-example>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, when app needs to wait for feature effects readiness, it can only use `OnInitEffects`.
If the app has a lot of feature effects and needs to wait for a group of them to be ready, it would require to add `OnInitEffects` on each effect in the group. And then to listen to all of the actions dispatched by each `OnInitEffects`.
This would be a lot of boilerplate and this kind of init logic would be pretty fragile.

## What is the new behavior?

FEATURE_EFFECTS_INIT action is dispatched after all feature effects are added.
In similar fashion to existing ROOT_EFFECTS_INIT.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
