### PR TITLE
fix(effects): update ng-add schematic to use inject function

### DIFF
--- a/modules/effects/schematics/ng-add/files/__name@dasherize@if-flat__/__name@dasherize__.effects.spec.ts.template
+++ b/modules/effects/schematics/ng-add/files/__name@dasherize@if-flat__/__name@dasherize__.effects.spec.ts.template
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable } from 'rxjs';
 

--- a/modules/effects/schematics/ng-add/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
+++ b/modules/effects/schematics/ng-add/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
@@ -1,7 +1,7 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect } from '@ngrx/effects';
 
 @Injectable()
 export class <%= classify(name) %>Effects {
-  constructor(private actions$: Actions) {}
+  private actions$ = inject(Actions);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `ng-add` schematic for `@ngrx/effects` generates an effects class using constructor-based dependency injection and generates a spec file that imports `inject` from `@angular/core/testing` without using it.

Closes #5137

## What is the new behavior?

The generated effects class uses the `inject()` function for dependency injection instead of constructor-based DI:

```ts
// Before
import { Injectable } from '@angular/core';
import { Actions, createEffect } from '@ngrx/effects';

@Injectable()
export class AppEffects {
  constructor(private actions$: Actions) {}
}

// After
import { inject, Injectable } from '@angular/core';
import { Actions, createEffect } from '@ngrx/effects';

@Injectable()
export class AppEffects {
  private actions$ = inject(Actions);
}
```

The generated spec file also no longer imports the unused `inject` from `@angular/core/testing` (the spec already uses `TestBed.inject()` directly).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

N/A