### PR TITLE
fix(data): remove QueryParams deprecation warning

### DIFF
--- a/modules/data/src/dataservices/interfaces.ts
+++ b/modules/data/src/dataservices/interfaces.ts
@@ -33,10 +33,6 @@ export interface RequestData {
  * Same as HttpClient's HttpParamsOptions which at the time of writing was
  * NOT exported at package level
  * https://github.com/angular/angular/issues/22013
- *
- * @deprecated Use HttpOptions instead. getWithQuery still accepts QueryParams as its
- * first argument, but HttpOptions.httpParams uses Angular's own HttpParamsOptions which
- * HttpClient accepts as an argument.
  */
 export interface QueryParams {
   [name: string]:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?
The `QueryParams` interface in `@ngrx/data` has a `@deprecated` JSDoc tag suggesting users migrate to `HttpOptions`.

## What is the new behavior?
The `@deprecated` tag is removed from the `QueryParams` interface. The rest of the JSDoc comment is preserved.

## Does this PR introduce a breaking change?
- [x] No

## Other information
Since `@ngrx/data` is in maintenance mode, no breaking changes will be introduced, making the deprecation warning unnecessary.

Closes #5150