### PR TITLE
fix(signals): `patchState` does not block on error

### DIFF
--- a/modules/signals/spec/state-source.spec.ts
+++ b/modules/signals/spec/state-source.spec.ts
@@ -15,6 +15,7 @@ import {
   StateSource,
   watchState,
   withHooks,
+  withLinkedState,
   withMethods,
   withState,
 } from '../src';
@@ -245,6 +246,45 @@ describe('StateSource', () => {
       }));
       TestBed.tick();
       expect(userChangedCount).toBe(2);
+    });
+
+    describe('error behavior', () => {
+      function setupStore() {
+        const Store = signalStore(
+          { providedIn: 'root', protectedState: false },
+          withState({ name: '' }),
+          withLinkedState(() => ({
+            value: () => {
+              throw new Error('Failed to read value.');
+            },
+          }))
+        );
+
+        return TestBed.inject(Store);
+      }
+
+      it('patches an unrelated state slice without throwing', () => {
+        const store = setupStore();
+
+        expect(() => patchState(store, { name: 'foo' })).not.toThrow();
+        expect(store.name()).toBe('foo');
+      });
+
+      it('throws when an updater reads the errored state slice', () => {
+        const store = setupStore();
+
+        expect(() =>
+          patchState(store, ({ value }) => ({ name: String(value) }))
+        ).toThrow('Failed to read value.');
+      });
+
+      it('throws when patching the errored state slice', () => {
+        const store = setupStore();
+
+        expect(() => patchState(store, { value: undefined })).toThrow(
+          'Failed to read value.'
+        );
+      });
     });
   });
 

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -82,24 +82,24 @@ export function patchState<State extends object>(
     Partial<NoInfer<State>> | PartialStateUpdater<NoInfer<State>>
   >
 ): void {
-  const currentState = untracked(() => getState(stateSource));
-  const newState = updaters.reduce(
-    (nextState: State, updater) => ({
-      ...nextState,
-      ...(typeof updater === 'function' ? updater(nextState) : updater),
-    }),
-    currentState
-  );
-
   const signals = stateSource[STATE_SOURCE];
   const stateKeys = Reflect.ownKeys(stateSource[STATE_SOURCE]);
+  const draftState = untracked(() => getSafeState(stateSource));
+  const touchedKeys = new Set<keyof State>();
 
-  for (const key of Reflect.ownKeys(newState)) {
-    if (stateKeys.includes(key)) {
-      const signalKey = key as keyof State;
-      if (currentState[signalKey] !== newState[signalKey]) {
-        signals[signalKey].set(newState[signalKey]);
-      }
+  for (const updater of updaters) {
+    const partial =
+      typeof updater === 'function' ? updater(draftState) : updater;
+
+    for (const key of Reflect.ownKeys(partial) as Array<keyof State>) {
+      touchedKeys.add(key);
+      draftState[key] = partial[key] as State[keyof State];
+    }
+  }
+
+  for (const key of touchedKeys) {
+    if (stateKeys.includes(key as string | symbol)) {
+      signals[key].set(draftState[key]);
     } else if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       console.warn(
         `@ngrx/signals: patchState was called with an unknown state slice '${String(
@@ -112,6 +112,34 @@ export function patchState<State extends object>(
   }
 
   notifyWatchers(stateSource);
+}
+
+function getSafeState<State extends object>(
+  stateSource: StateSource<State>
+): State {
+  const signals: Record<string | symbol, Signal<unknown>> = stateSource[
+    STATE_SOURCE
+  ];
+  const state = {} as State;
+
+  for (const key of Reflect.ownKeys(signals)) {
+    try {
+      (state as Record<string | symbol, unknown>)[key] = signals[key]();
+    } catch (error) {
+      Object.defineProperty(state, key, {
+        get() {
+          throw error;
+        },
+        set() {
+          throw error;
+        },
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  }
+
+  return state;
 }
 
 /**


### PR DESCRIPTION
Signals can throw an error if they are accessed. `patchState` needs to call `getState` in order to provide the current state to an updater function.

This fix catches errors in the internal `getState` call and keeps the errored signals in a proxy, where accessing them throws again.

That means `patchState` does not block unrelated updates, and the user can apply the normal error handling features like `try/catch`, `ErrorHandler`, or the upcoming error boundaries.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Closes #5183

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
