### PR TITLE
feat(store-devtools): add actionCreators config option

### DIFF
--- a/modules/store-devtools/spec/config.spec.ts
+++ b/modules/store-devtools/spec/config.spec.ts
@@ -1,4 +1,4 @@
-import { Action } from '@ngrx/store';
+import { Action, createAction } from '@ngrx/store';
 
 import { createConfig, DEFAULT_NAME, noMonitor } from '../src/config';
 
@@ -41,6 +41,7 @@ describe('StoreDevtoolsOptions', () => {
     function actionSanitizer(action: Action, id: number): Action {
       return action;
     }
+    const actionCreators = [createAction('[Counter] Increment')];
     const config = createConfig({
       maxAge: 20,
       actionSanitizer,
@@ -53,6 +54,7 @@ describe('StoreDevtoolsOptions', () => {
       features: {
         test: true,
       },
+      actionCreators,
     });
     expect(config).toEqual({
       maxAge: 20,
@@ -69,6 +71,7 @@ describe('StoreDevtoolsOptions', () => {
         test: true,
       },
       connectInZone: false,
+      actionCreators,
     });
   });
 

--- a/modules/store-devtools/spec/extension.spec.ts
+++ b/modules/store-devtools/spec/extension.spec.ts
@@ -181,7 +181,40 @@ describe('DevtoolsExtension', () => {
     // Subscription needed or else extension connection will not be established.
     devtoolsExtension.actions$.subscribe(() => null);
     expect(reduxDevtoolsExtension.connect).toHaveBeenCalledWith(
-      expect.objectContaining({ actionCreators: [bookRented, bookReturned] })
+      expect.objectContaining({
+        actionCreators: [
+          { name: '[Books] Rent', func: bookRented, args: ['props'] },
+          { name: '[Books] Return', func: bookReturned, args: ['props'] },
+        ],
+      })
+    );
+  });
+
+  it('should connect with action creators named by record keys', () => {
+    const bookRented = createAction(
+      '[Books] Rent',
+      props<{ id: number; customerId: number }>()
+    );
+    const allBooksReturned = createAction('[Books] Return All');
+
+    const { devtoolsExtension, reduxDevtoolsExtension } = testSetup({
+      config: createConfig({
+        actionCreators: {
+          rentBook: bookRented,
+          returnAllBooks: allBooksReturned,
+        },
+      }),
+    });
+
+    // Subscription needed or else extension connection will not be established.
+    devtoolsExtension.actions$.subscribe(() => null);
+    expect(reduxDevtoolsExtension.connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionCreators: [
+          { name: 'rentBook', func: bookRented, args: ['props'] },
+          { name: 'returnAllBooks', func: allBooksReturned, args: [] },
+        ],
+      })
     );
   });
 
@@ -244,6 +277,85 @@ describe('DevtoolsExtension', () => {
       });
     });
   }
+
+  describe('actions dispatched with configured action creators', () => {
+    const bookRented = createAction(
+      '[Books] Rent',
+      props<{ id: number; customerId: number }>()
+    );
+    const allBooksReturned = createAction('[Books] Return All');
+    const booksSearched = createAction(
+      '[Books] Search',
+      (query: string, page: number) => ({ query, page })
+    );
+
+    function dispatchFromExtension(
+      config: StoreDevtoolsConfig,
+      payload: unknown
+    ) {
+      const { devtoolsExtension, extensionConnection } = testSetup({ config });
+      let unwrappedAction: Action | undefined = undefined;
+      devtoolsExtension.actions$.subscribe((action) => {
+        return (unwrappedAction = action);
+      });
+
+      const [callback] = extensionConnection.subscribe.mock.lastCall;
+      callback({ type: ExtensionActionTypes.START });
+      callback({ type: ExtensionActionTypes.ACTION, payload });
+      return unwrappedAction;
+    }
+
+    it('should create the action with the entered props', () => {
+      const unwrappedAction = dispatchFromExtension(
+        createConfig({ actionCreators: [bookRented, allBooksReturned] }),
+        {
+          name: '[Books] Rent(props)',
+          selected: 0,
+          args: ['{ id: 5, customerId: 12 }'],
+          rest: '',
+        }
+      );
+      expect(unwrappedAction).toEqual({
+        type: '[Books] Rent',
+        id: 5,
+        customerId: 12,
+      });
+    });
+
+    it('should create an action without props', () => {
+      const unwrappedAction = dispatchFromExtension(
+        createConfig({ actionCreators: [bookRented, allBooksReturned] }),
+        { name: '[Books] Return All()', selected: 1, args: [], rest: '' }
+      );
+      expect(unwrappedAction).toEqual({ type: '[Books] Return All' });
+    });
+
+    it('should create an action from a function-style creator with rest args', () => {
+      const unwrappedAction = dispatchFromExtension(
+        createConfig({ actionCreators: { searchBooks: booksSearched } }),
+        {
+          name: 'searchBooks(args)',
+          selected: 0,
+          args: [],
+          rest: '["tolkien", 3]',
+        }
+      );
+      expect(unwrappedAction).toEqual({
+        type: '[Books] Search',
+        query: 'tolkien',
+        page: 3,
+      });
+    });
+
+    it('should pass the payload through when the selected index is unknown', () => {
+      const payload = { name: 'unknown()', selected: 99, args: [], rest: '' };
+      const unwrappedAction = dispatchFromExtension(
+        createConfig({ actionCreators: [bookRented] }),
+        payload
+      );
+      expect(unwrappedAction).toEqual(payload);
+    });
+  });
 
   describe('notify', () => {
     it('should send notification with default options', () => {

--- a/modules/store-devtools/spec/extension.spec.ts
+++ b/modules/store-devtools/spec/extension.spec.ts
@@ -225,7 +225,7 @@ describe('DevtoolsExtension', () => {
 
     // Subscription needed or else extension connection will not be established.
     devtoolsExtension.actions$.subscribe(() => null);
-    const [connectOptions] = reduxDevtoolsExtension.connect.mock.lastCall;
+    const [connectOptions] = reduxDevtoolsExtension.connect.mock.calls[0];
     expect(connectOptions).not.toHaveProperty('actionCreators');
   });
 
@@ -304,7 +304,7 @@ describe('DevtoolsExtension', () => {
         return (unwrappedAction = action);
       });
 
-      const [callback] = extensionConnection.subscribe.mock.lastCall;
+      const [callback] = extensionConnection.subscribe.mock.calls[0];
       callback({ type: ExtensionActionTypes.START });
       callback({ type: ExtensionActionTypes.ACTION, payload });
       return unwrappedAction;

--- a/modules/store-devtools/spec/extension.spec.ts
+++ b/modules/store-devtools/spec/extension.spec.ts
@@ -6,7 +6,7 @@ import {
   ReduxDevtoolsExtensionConfig,
   ReduxDevtoolsExtensionConnection,
 } from './../src/extension';
-import { Action } from '@ngrx/store';
+import { Action, createAction, props } from '@ngrx/store';
 
 import { DevtoolsExtension, ReduxDevtoolsExtension } from '../src/extension';
 import {
@@ -160,6 +160,40 @@ describe('DevtoolsExtension', () => {
       20
     );
     expect(reduxDevtoolsExtension.connect).toHaveBeenCalledWith(options);
+  });
+
+  it('should connect with given action creators', () => {
+    const bookRented = createAction(
+      '[Books] Rent',
+      props<{ id: number; customerId: number }>()
+    );
+    const bookReturned = createAction(
+      '[Books] Return',
+      props<{ id: number }>()
+    );
+
+    const { devtoolsExtension, reduxDevtoolsExtension } = testSetup({
+      config: createConfig({
+        actionCreators: [bookRented, bookReturned],
+      }),
+    });
+
+    // Subscription needed or else extension connection will not be established.
+    devtoolsExtension.actions$.subscribe(() => null);
+    expect(reduxDevtoolsExtension.connect).toHaveBeenCalledWith(
+      expect.objectContaining({ actionCreators: [bookRented, bookReturned] })
+    );
+  });
+
+  it('should not add action creators to the connect options when not provided', () => {
+    const { devtoolsExtension, reduxDevtoolsExtension } = testSetup({
+      config: createConfig({}),
+    });
+
+    // Subscription needed or else extension connection will not be established.
+    devtoolsExtension.actions$.subscribe(() => null);
+    const [connectOptions] = reduxDevtoolsExtension.connect.mock.lastCall;
+    expect(connectOptions).not.toHaveProperty('actionCreators');
   });
 
   it('should connect with custom serializer', () => {

--- a/modules/store-devtools/src/config.ts
+++ b/modules/store-devtools/src/config.ts
@@ -1,4 +1,4 @@
-import { ActionReducer, Action } from '@ngrx/store';
+import { ActionCreator, ActionReducer, Action } from '@ngrx/store';
 import { InjectionToken } from '@angular/core';
 
 export type ActionSanitizer = (action: Action, id: number) => Action;
@@ -120,6 +120,12 @@ export class StoreDevtoolsConfig {
    * Angular zone or not. It is set to `false` by default.
    */
   connectInZone?: boolean;
+
+  /**
+   * Action creators to make available in the extension's dispatcher,
+   * so actions can be dispatched manually from the extension.
+   */
+  actionCreators?: ActionCreator[] | Record<string, ActionCreator>;
 }
 
 export const STORE_DEVTOOLS_CONFIG = new InjectionToken<StoreDevtoolsConfig>(
@@ -151,6 +157,7 @@ export function createConfig(
     monitor: noMonitor,
     actionSanitizer: undefined,
     stateSanitizer: undefined,
+    actionCreators: undefined,
     name: DEFAULT_NAME,
     serialize: false,
     logOnly: false,

--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, InjectionToken } from '@angular/core';
-import { Action, UPDATE } from '@ngrx/store';
+import { Action, ActionCreator, UPDATE } from '@ngrx/store';
 import { EMPTY, Observable, of } from 'rxjs';
 import {
   catchError,
@@ -60,6 +60,7 @@ export interface ReduxDevtoolsExtensionConfig {
   serialize?: boolean | SerializationOptions;
   trace?: boolean | (() => string);
   traceLimit?: number;
+  actionCreators?: ActionCreator[] | Record<string, ActionCreator>;
 }
 
 export interface ReduxDevtoolsExtension {
@@ -269,6 +270,9 @@ export class DevtoolsExtension {
     };
     if (config.maxAge !== false /* support === 0 */) {
       extensionOptions.maxAge = config.maxAge;
+    }
+    if (config.actionCreators) {
+      extensionOptions.actionCreators = config.actionCreators;
     }
     return extensionOptions;
   }

--- a/modules/store-devtools/src/extension.ts
+++ b/modules/store-devtools/src/extension.ts
@@ -60,8 +60,89 @@ export interface ReduxDevtoolsExtensionConfig {
   serialize?: boolean | SerializationOptions;
   trace?: boolean | (() => string);
   traceLimit?: number;
-  actionCreators?: ActionCreator[] | Record<string, ActionCreator>;
+  actionCreators?: ActionCreatorDescriptor[];
 }
+
+/**
+ * The shape the Redux DevTools extension expects action creators to be in.
+ * The extension serializes the entries with `JSON.stringify` (keeping `name`
+ * and `args` to render its dispatcher) and refers back to an entry by its
+ * index (`selected`) when an action is dispatched from the extension.
+ */
+export interface ActionCreatorDescriptor {
+  name: string;
+  func: ActionCreator;
+  args: string[];
+}
+
+/**
+ * The payload the extension sends when an action is dispatched from its
+ * dispatcher using one of the configured action creators. `selected` is the
+ * index of the action creator and `args` contains the entered arguments as
+ * strings of JavaScript.
+ */
+interface ActionCreatorPayload {
+  name: string;
+  selected: number;
+  args: string[];
+  rest: string;
+}
+
+function isActionCreatorPayload(
+  action: unknown
+): action is ActionCreatorPayload {
+  return (
+    typeof action === 'object' &&
+    action !== null &&
+    !('type' in action) &&
+    typeof (action as ActionCreatorPayload).selected === 'number' &&
+    Array.isArray((action as ActionCreatorPayload).args)
+  );
+}
+
+/**
+ * Parse the parameter names out of an action creator so the extension can
+ * render input fields for them in its dispatcher.
+ */
+function getActionCreatorArgs(actionCreator: ActionCreator): string[] {
+  const source = String(actionCreator);
+  const parenthesizedArgs = source.match(/^[^(]*\(([^)]*)\)/);
+  if (!parenthesizedArgs) {
+    // arrow function with a single parameter without parentheses
+    const singleArg = source.match(/^\s*([^=\s(]+)\s*=>/);
+    return singleArg ? [singleArg[1]] : [];
+  }
+  return parenthesizedArgs[1]
+    .split(',')
+    .map((arg) =>
+      arg
+        .replace(/^\s*\.{3}/, '')
+        .split('=')[0]
+        .trim()
+    )
+    .filter((arg) => arg !== '');
+}
+
+function getActionCreatorDescriptors(
+  actionCreators: ActionCreator[] | Record<string, ActionCreator>
+): ActionCreatorDescriptor[] {
+  if (Array.isArray(actionCreators)) {
+    return actionCreators.map((actionCreator) => ({
+      name: actionCreator.type || actionCreator.name || 'anonymous',
+      func: actionCreator,
+      args: getActionCreatorArgs(actionCreator),
+    }));
+  }
+  return Object.keys(actionCreators).map((name) => ({
+    name,
+    func: actionCreators[name],
+    args: getActionCreatorArgs(actionCreators[name]),
+  }));
+}
+
+// indirect eval according to https://esbuild.github.io/content-types/#direct-eval
+const evalArg = (arg: string): unknown =>
+  arg === '' ? undefined : (0, eval)(`(${arg})`);
 
 export interface ReduxDevtoolsExtension {
   connect(
@@ -74,6 +155,7 @@ export interface ReduxDevtoolsExtension {
 export class DevtoolsExtension {
   private devtoolsExtension: ReduxDevtoolsExtension;
   private extensionConnection!: ReduxDevtoolsExtensionConnection;
+  private readonly actionCreatorDescriptors?: ActionCreatorDescriptor[];
 
   liftedActions$!: Observable<any>;
   actions$!: Observable<any>;
@@ -87,6 +169,9 @@ export class DevtoolsExtension {
     private dispatcher: DevtoolsDispatcher
   ) {
     this.devtoolsExtension = devtoolsExtension;
+    this.actionCreatorDescriptors = config.actionCreators
+      ? getActionCreatorDescriptors(config.actionCreators)
+      : undefined;
     this.createActionStreams();
   }
 
@@ -248,8 +333,27 @@ export class DevtoolsExtension {
   }
 
   private unwrapAction(action: Action) {
-    // indirect eval according to https://esbuild.github.io/content-types/#direct-eval
-    return typeof action === 'string' ? (0, eval)(`(${action})`) : action;
+    if (typeof action === 'string') {
+      // indirect eval according to https://esbuild.github.io/content-types/#direct-eval
+      return (0, eval)(`(${action})`);
+    }
+    // When action creators are configured, the extension dispatches them as a
+    // `{ selected, args }` payload that refers back to the configured action
+    // creators instead of a ready-made action.
+    if (this.actionCreatorDescriptors && isActionCreatorPayload(action)) {
+      const descriptor = this.actionCreatorDescriptors[action.selected];
+      if (descriptor) {
+        const args = action.args.map(evalArg);
+        if (action.rest) {
+          const rest = evalArg(action.rest);
+          if (Array.isArray(rest)) {
+            args.push(...rest);
+          }
+        }
+        return descriptor.func(...args);
+      }
+    }
+    return action;
   }
 
   private getExtensionConfig(config: StoreDevtoolsConfig) {
@@ -271,8 +375,8 @@ export class DevtoolsExtension {
     if (config.maxAge !== false /* support === 0 */) {
       extensionOptions.maxAge = config.maxAge;
     }
-    if (config.actionCreators) {
-      extensionOptions.actionCreators = config.actionCreators;
+    if (this.actionCreatorDescriptors) {
+      extensionOptions.actionCreators = this.actionCreatorDescriptors;
     }
     return extensionOptions;
   }

--- a/projects/www/src/app/pages/guide/store-devtools/config.md
+++ b/projects/www/src/app/pages/guide/store-devtools/config.md
@@ -54,6 +54,8 @@ function - called for every action before sending, takes state and action object
 
 array or object of action creators to make available in the extension's dispatcher, so actions can be dispatched manually from the extension, [more information here](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#actioncreators).
 
+When an array is given, the creators are listed in the dispatcher under their action type. When an object is given (for example an action group created with `createActionGroup`), the creators are listed under their keys.
+
 ```typescript
 const bookRented = createAction(
   '[Books] Rent',
@@ -65,7 +67,13 @@ const bookReturned = createAction(
 );
 
 provideStoreDevtools({
+  // listed as '[Books] Rent' and '[Books] Return'
   actionCreators: [bookRented, bookReturned],
+});
+
+provideStoreDevtools({
+  // listed as 'rentBook' and 'returnBook'
+  actionCreators: { rentBook: bookRented, returnBook: bookReturned },
 });
 ```
 

--- a/projects/www/src/app/pages/guide/store-devtools/config.md
+++ b/projects/www/src/app/pages/guide/store-devtools/config.md
@@ -52,7 +52,7 @@ function - called for every action before sending, takes state and action object
 
 ### `actionCreators`
 
-array or object of action creators to make available in the extension's dispatcher, so actions can be dispatched manually from the extension, [more information here](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#actioncreators).
+An array or object of action creators to make available in the extension's dispatcher, so actions can be dispatched manually from the extension, [more information here](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#actioncreators).
 
 When an array is given, the creators are listed in the dispatcher under their action type. When an object is given (for example an action group created with `createActionGroup`), the creators are listed under their keys.
 

--- a/projects/www/src/app/pages/guide/store-devtools/config.md
+++ b/projects/www/src/app/pages/guide/store-devtools/config.md
@@ -50,6 +50,25 @@ array of strings as regex - actions types to be hidden / shown in the monitors, 
 
 function - called for every action before sending, takes state and action object, and returns `true` in case it allows sending the current data to the monitor, [more information here](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#predicate).
 
+### `actionCreators`
+
+array or object of action creators to make available in the extension's dispatcher, so actions can be dispatched manually from the extension, [more information here](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#actioncreators).
+
+```typescript
+const bookRented = createAction(
+  '[Books] Rent',
+  props<{ id: number }>()
+);
+const bookReturned = createAction(
+  '[Books] Return',
+  props<{ id: number }>()
+);
+
+provideStoreDevtools({
+  actionCreators: [bookRented, bookReturned],
+});
+```
+
 ### `connectInZone`
 
 boolean - property determines whether the extension connection is established within the Angular zone or not. When `false`, the connection is established outside the Angular zone to prevent unnecessary change detection cycles. Default is `false`.


### PR DESCRIPTION
Allow action creators to be passed to the Redux DevTools extension so actions can be dispatched manually from the extension's dispatcher.

Closes #4038

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There is no way to make action creators available in the Redux DevTools extension's dispatcher. Dispatching an action manually from the extension requires writing the action as a JSON string by hand each time, which is tedious and error-prone.

Closes #4038

## What is the new behavior?

`StoreDevtoolsConfig` accepts a new optional `actionCreators` option (an array or object of action creators, e.g. created with `createAction`). It is passed through to the Redux DevTools extension's `connect`/`send` options, so the extension's dispatcher lists the app's actions and they can be dispatched manually from the DevTools UI.

```ts
const bookRented = createAction('[Books] Rent', props<{ id: number }>());
const bookReturned = createAction('[Books] Return', props<{ id: number }>());

provideStoreDevtools({
  actionCreators: [bookRented, bookReturned],
});
```

The option was requested in #4038 and corresponds to the extension's [`actionCreators` argument](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#actioncreators).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

The option is optional and is omitted from the extension config when not provided, so existing setups are unaffected.

## Other information

The feature was greenlit by @timdeschryver in the issue thread. Docs added to the store-devtools instrumentation options guide.