### PR TITLE
fix(www): navigate in-article fragment links via the router

### DIFF
--- a/projects/www/src/app/components/docs/markdown-article.component.spec.ts
+++ b/projects/www/src/app/components/docs/markdown-article.component.spec.ts
@@ -1,0 +1,92 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { MarkdownArticleComponent } from './markdown-article.component';
+
+@Component({
+  standalone: true,
+  imports: [MarkdownArticleComponent],
+  template: `
+    <ngrx-markdown-article>
+      <h2 id="rules">Rules</h2>
+      <p>
+        <a id="fragment-link" href="#rules">rules</a>
+        <a id="page-link" href="/guide/store">store guide</a>
+      </p>
+    </ngrx-markdown-article>
+  `,
+})
+class TestHostComponent {}
+
+describe('MarkdownArticleComponent', () => {
+  let router: Router;
+
+  beforeEach(() => {
+    // jsdom implements neither scrollIntoView nor link navigation
+    Element.prototype.scrollIntoView = vi.fn();
+
+    TestBed.configureTestingModule({
+      providers: [provideRouter([])],
+      imports: [TestHostComponent],
+    });
+
+    router = TestBed.inject(Router);
+  });
+
+  function clickLink(id: string, eventInit: MouseEventInit = {}) {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const link = fixture.nativeElement.querySelector(
+      `#${id}`
+    ) as HTMLAnchorElement;
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      ...eventInit,
+    });
+
+    // capture whether the component prevented the default action and then
+    // always prevent it, so jsdom does not attempt to navigate
+    let defaultPrevented = false;
+    document.addEventListener(
+      'click',
+      (bubbledEvent) => {
+        defaultPrevented = bubbledEvent.defaultPrevented;
+        bubbledEvent.preventDefault();
+      },
+      { once: true }
+    );
+    link.dispatchEvent(event);
+
+    return { defaultPrevented };
+  }
+
+  it('navigates to the fragment when a fragment-only link is clicked', () => {
+    const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    const { defaultPrevented } = clickLink('fragment-link');
+
+    expect(defaultPrevented).toBe(true);
+    expect(navigate).toHaveBeenCalledWith([], { fragment: 'rules' });
+  });
+
+  it('does not intercept links to other pages', () => {
+    const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    const { defaultPrevented } = clickLink('page-link');
+
+    expect(defaultPrevented).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept fragment link clicks with modifier keys', () => {
+    const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    const { defaultPrevented } = clickLink('fragment-link', { ctrlKey: true });
+
+    expect(defaultPrevented).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/projects/www/src/app/components/docs/markdown-article.component.ts
+++ b/projects/www/src/app/components/docs/markdown-article.component.ts
@@ -19,7 +19,7 @@ type Heading = { level: number; text: string; id: string; url: string };
   standalone: true,
   imports: [MatIcon],
   template: `
-    <article #article>
+    <article #article (click)="onArticleClick($event)">
       <ng-content></ng-content>
     </article>
     <menu>
@@ -222,8 +222,33 @@ export class MarkdownArticleComponent implements OnDestroy {
   navigateToHeading($event: MouseEvent, heading: Heading) {
     $event.preventDefault();
 
-    this.router.navigate([], { fragment: heading.id }).then(() => {
-      const element = document.getElementById(heading.id);
+    this.navigateToFragment(heading.id);
+  }
+
+  onArticleClick($event: MouseEvent) {
+    if (
+      $event.button !== 0 ||
+      $event.ctrlKey ||
+      $event.metaKey ||
+      $event.shiftKey ||
+      $event.altKey
+    ) {
+      return;
+    }
+
+    const anchor = ($event.target as HTMLElement).closest('a');
+    const href = anchor?.getAttribute('href');
+    if (!href?.startsWith('#')) {
+      return;
+    }
+
+    $event.preventDefault();
+    this.navigateToFragment(decodeURIComponent(href.slice(1)));
+  }
+
+  private navigateToFragment(fragment: string) {
+    this.router.navigate([], { fragment }).then(() => {
+      const element = document.getElementById(fragment);
       if (element) {
         element.scrollIntoView({ behavior: 'smooth' });
       }


### PR DESCRIPTION
Fragment-only links in markdown articles resolve against the base href and navigate to the homepage instead of scrolling to the target heading. Intercept them and use router fragment navigation, matching the content menu behavior.

Closes #5191

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

In-article fragment links on the docs site (e.g. "configuration" and "rules" on https://ngrx.io/guide/eslint-plugin, or the runtime check links on https://ngrx.io/guide/store/configuration/runtime-checks) are broken. They are rendered as `<a href="#rules">`, and because of the site's `<base href="/">` the browser resolves them against the site root — clicking one navigates to `https://ngrx.io/#rules` (the homepage) instead of scrolling to the heading. The links in the content menu work because they are already handled with router fragment navigation.

Closes #5191

## What is the new behavior?

Clicks on fragment-only links inside a markdown article are intercepted by `MarkdownArticleComponent` and handled the same way as the content menu links: router navigation with the fragment, followed by scrolling the target heading into view. The current page and scroll position are preserved and the URL hash updates correctly.

Not intercepted (unchanged behavior):
- links to other pages or external sites
- clicks with modifier keys (ctrl/cmd/shift/alt) or non-primary buttons

Verified locally on both pages referenced in the issue, plus a regression check that the content menu links still work. Unit tests added for the new behavior.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

_None_