### PR TITLE
test(eslint-plugin): introduce typecheck for rule specs

### DIFF
--- a/modules/eslint-plugin/spec/rules/operators/prefer-concat-latest-from.spec.ts
+++ b/modules/eslint-plugin/spec/rules/operators/prefer-concat-latest-from.spec.ts
@@ -10,7 +10,7 @@ import rule, {
 import { ruleTester, fromFixture } from '../../utils';
 
 type MessageIds = ESLintUtils.InferMessageIdsTypeFromRule<typeof rule>;
-type Options = readonly ESLintUtils.InferOptionsTypeFromRule<typeof rule>[0][];
+type Options = ESLintUtils.InferOptionsTypeFromRule<typeof rule>;
 
 const valid: () => (string | ValidTestCase<Options>)[] = () => [
   {

--- a/modules/eslint-plugin/spec/rules/signals/enforce-type-call.spec.ts
+++ b/modules/eslint-plugin/spec/rules/signals/enforce-type-call.spec.ts
@@ -10,7 +10,7 @@ import rule, {
 } from '../../../src/rules/signals/enforce-type-call';
 
 type MessageIds = ESLintUtils.InferMessageIdsTypeFromRule<typeof rule>;
-type Options = readonly ESLintUtils.InferOptionsTypeFromRule<typeof rule>[];
+type Options = ESLintUtils.InferOptionsTypeFromRule<typeof rule>;
 
 const valid: () => (string | ValidTestCase<Options>)[] = () => [
   {

--- a/modules/eslint-plugin/spec/rules/signals/prefer-protected-state.spec.ts
+++ b/modules/eslint-plugin/spec/rules/signals/prefer-protected-state.spec.ts
@@ -11,7 +11,7 @@ import rule, {
 import { ruleTester, fromFixture } from '../../utils';
 
 type MessageIds = ESLintUtils.InferMessageIdsTypeFromRule<typeof rule>;
-type Options = readonly ESLintUtils.InferOptionsTypeFromRule<typeof rule>[];
+type Options = ESLintUtils.InferOptionsTypeFromRule<typeof rule>;
 
 const valid: () => (string | ValidTestCase<Options>)[] = () => [
   `const mySignalStore = signalStore();`,

--- a/modules/eslint-plugin/spec/rules/signals/signal-store-feature-should-use-generic-type.spec.ts
+++ b/modules/eslint-plugin/spec/rules/signals/signal-store-feature-should-use-generic-type.spec.ts
@@ -10,7 +10,7 @@ import rule, {
 import { ruleTester, fromFixture } from '../../utils';
 
 type MessageIds = ESLintUtils.InferMessageIdsTypeFromRule<typeof rule>;
-type Options = readonly ESLintUtils.InferOptionsTypeFromRule<typeof rule>[];
+type Options = ESLintUtils.InferOptionsTypeFromRule<typeof rule>;
 
 const valid: () => (string | ValidTestCase<Options>)[] = () => [
   `const withY = <Y>() => signalStoreFeature({ state: type<{ y: Y }>() }, withState({}));`,

--- a/modules/eslint-plugin/spec/rules/store/select-style.spec.ts
+++ b/modules/eslint-plugin/spec/rules/store/select-style.spec.ts
@@ -8,7 +8,7 @@ import rule, { SelectStyle } from '../../../src/rules/store/select-style';
 import { ruleTester, fromFixture } from '../../utils';
 
 type MessageIds = ESLintUtils.InferMessageIdsTypeFromRule<typeof rule>;
-type Options = readonly ESLintUtils.InferOptionsTypeFromRule<typeof rule>[0][];
+type Options = ESLintUtils.InferOptionsTypeFromRule<typeof rule>;
 
 const validConstructor: () => (string | ValidTestCase<Options>)[] = () => [
   `

--- a/modules/eslint-plugin/spec/rules/store/use-consistent-global-store-name.spec.ts
+++ b/modules/eslint-plugin/spec/rules/store/use-consistent-global-store-name.spec.ts
@@ -11,7 +11,7 @@ import rule, {
 import { ruleTester, fromFixture } from '../../utils';
 
 type MessageIds = ESLintUtils.InferMessageIdsTypeFromRule<typeof rule>;
-type Options = readonly ESLintUtils.InferOptionsTypeFromRule<typeof rule>[0][];
+type Options = ESLintUtils.InferOptionsTypeFromRule<typeof rule>;
 
 const validConstructor: () => (string | ValidTestCase<Options>)[] = () => [
   `

--- a/modules/eslint-plugin/vitest.config.mts
+++ b/modules/eslint-plugin/vitest.config.mts
@@ -7,9 +7,6 @@ export default defineProject((config) =>
     test: {
       name: 'eslint-plugin',
       testTimeout: 8000,
-      typecheck: {
-        exclude: ['spec/rules/**/*.{spec,test}.ts'],
-      },
     },
     define: {
       'import.meta.vitest': config.mode !== 'production',


### PR DESCRIPTION
## What is the current behavior?

Type Tests do not run on the ESLint rules tests.

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Closes #5179

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```