### PR TITLE
build: migrate deprecated moduleResolution node to modern equivalents

### DIFF
--- a/modules/eslint-plugin/spec/fixtures/tsconfig.json
+++ b/modules/eslint-plugin/spec/fixtures/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["esnext"],
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "skipLibCheck": true,
     "target": "esnext",
     "paths": {

--- a/modules/eslint-plugin/tsconfig.schematics.json
+++ b/modules/eslint-plugin/tsconfig.schematics.json
@@ -4,7 +4,7 @@
     "rootDir": ".",
     "stripInternal": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "downlevelIteration": true,
     "ignoreDeprecations": "6.0",
     "esModuleInterop": true,

--- a/modules/schematics/tsconfig.build.json
+++ b/modules/schematics/tsconfig.build.json
@@ -4,7 +4,7 @@
     "stripInternal": true,
     "experimentalDecorators": true,
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "downlevelIteration": true,
     "ignoreDeprecations": "6.0",
     "outDir": "../../dist/modules/schematics",

--- a/projects/www/src/app/examples/__base/tsconfig.json
+++ b/projects/www/src/app/examples/__base/tsconfig.json
@@ -4,7 +4,7 @@
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "compilerOptions": {
     "target": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -3,7 +3,7 @@
     "importHelpers": true,
     "sourceMap": true,
     "declaration": false,
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "experimentalDecorators": true,
     "downlevelIteration": true,
     "ignoreDeprecations": "6.0",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Several `tsconfig.json` files across the workspace set `moduleResolution:
"node"`, which TypeScript has marked for removal as part of the
`target`/`moduleResolution` deprecation cleanup tracked in [#5163](https://github.com/ngrx/platform/issues/5163). Left as-is, these configs
will start failing once the workspace upgrades to a TypeScript version
where the value is removed.

## What is the new behavior?

Migrates `moduleResolution: "node"` away from the 5 affected tsconfig
files:

- `projects/www/src/app/examples/__base/tsconfig.json`: already used
  `module: "ES2022"`, so `moduleResolution` moved directly to `"bundler"`.
- `tsconfig.docs.json`, `modules/schematics/tsconfig.build.json`,
  `modules/eslint-plugin/tsconfig.schematics.json`,
  `modules/eslint-plugin/spec/fixtures/tsconfig.json`: these use (or
  default to) `module: "commonjs"` for code executed directly via Node
  (schematics, docs generation, test fixtures). Migrating these to
  `"bundler"` or `"nodenext"` surfaced unrelated pre-existing type
  errors or ECMAScript import-extension requirements incompatible with
  the current dependency graph. Moved `moduleResolution` to `"node10"`
  instead — TypeScript's renamed, non-deprecated equivalent of the old
  `"node"` behavior, with no change in resolution semantics.

One file from the original scope,
`modules/store/spec/ngc/tsconfig.ngc.json`, is intentionally left
untouched: it isn't referenced by any Nx target and appears to be dead
code left over from an old ngc/Ivy AOT compiler test setup. Left for
maintainers to decide whether to fix or remove.

Verified with:
- `tsc --noEmit` on `tsconfig.docs.json`,
  `modules/schematics/tsconfig.build.json`, and
  `modules/eslint-plugin/tsconfig.schematics.json` (no new errors
  introduced versus the pre-existing baseline)
- `pnpm nx run eslint-plugin:test` (78 test files, 554 tests, 0 type
  errors)

This PR addresses the `moduleResolution` portion of the broader scope
outlined in [#5163](https://github.com/ngrx/platform/issues/5163). Remaining categories from that issue
(the one remaining `target: "ES5"` config, and `baseUrl`/`rootDir`) are
being tracked separately and are not part of this PR.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Related to [#5163](https://github.com/ngrx/platform/issues/5163) (partial — see scope note above; not marked as closing
since further work from that issue is still in progress).
