### PR TITLE
build: remove deprecated baseUrl from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "target": "ES2022",
     "module": "preserve",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "rootDir": ".",
     "strict": true,
     "paths": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The root `tsconfig.json` sets `baseUrl: "."`, which TypeScript has
deprecated starting in 6.0 as part of the same cleanup tracked in
[#5163](https://github.com/ngrx/platform/issues/5163). `baseUrl` will
stop functioning entirely in TypeScript 7.0.

## What is the new behavior?

Removed `baseUrl` from `tsconfig.json`, using the official
`@andrewbranch/ts5to6` migration tool (built by a TypeScript team
member specifically for this and the related `rootDir` migration):

```
npx @andrewbranch/ts5to6 --fixBaseUrl .
```

The tool analyzed all 45 tsconfig files in the workspace and confirmed
`baseUrl` was only ever used as an implicit prefix for the `paths`
entries in the root config — not as a fallback module resolution root
— so removing it is a no-op change in behavior (`✓ No projects rely on
baseUrl for module resolution`). Only the root `tsconfig.json` set
`baseUrl` directly; the other 37 potentially-affected projects
inherited it via `extends` without redefining it themselves, so no
other files needed changes.

Also ran the tool's `rootDir` check as part of the same cleanup
category:

```
npx @andrewbranch/ts5to6 --fixRootDir .
```

This reported no changes needed — the `rootDir` values already
present match what TypeScript 5.9 would infer automatically, so
nothing to migrate there.

Verified with:
- `pnpm nx run store:build` — clean build
- `pnpm nx run eslint-plugin:test` — 78 test files, 554 tests, 0 type
  errors

This closes out the last remaining category from
[#5163](https://github.com/ngrx/platform/issues/5163) that this
contributor is addressing (`downlevelIteration` and `moduleResolution`
were covered in separate PRs). The one open item from that issue,
`modules/store/spec/ngc/tsconfig.ngc.json` (an apparently-unused
`target: "ES5"` config), is left for maintainers to decide on.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Related to [#5163](https://github.com/ngrx/platform/issues/5163).
