### PR TITLE
fix(signals): avoid reading unrelated state slices in patchState

### DIFF
--- a/modules/signals/spec/state-source.spec.ts
+++ b/modules/signals/spec/state-source.spec.ts
@@ -3,6 +3,7 @@ import {
   effect,
   EnvironmentInjector,
   Injectable,
+  linkedSignal,
   signal,
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
@@ -61,6 +62,19 @@ describe('StateSource', () => {
   });
 
   describe('patchState', () => {
+    it('does not read unrelated state slices for partial state objects', () => {
+      const name = signal('');
+      const inaccessible = linkedSignal(() => {
+        throw new Error('Failed to read state slice');
+      });
+      const stateSource = {
+        [STATE_SOURCE]: { name, inaccessible },
+      };
+
+      expect(() => patchState(stateSource, { name: 'John' })).not.toThrow();
+      expect(name()).toBe('John');
+    });
+
     [
       {
         name: 'with signalState',

--- a/modules/signals/src/state-source.ts
+++ b/modules/signals/src/state-source.ts
@@ -82,13 +82,18 @@ export function patchState<State extends object>(
     Partial<NoInfer<State>> | PartialStateUpdater<NoInfer<State>>
   >
 ): void {
-  const currentState = untracked(() => getState(stateSource));
+  const requiresCurrentState = updaters.some(
+    (updater) => typeof updater === 'function'
+  );
+  const currentState = requiresCurrentState
+    ? untracked(() => getState(stateSource))
+    : undefined;
   const newState = updaters.reduce(
     (nextState: State, updater) => ({
       ...nextState,
       ...(typeof updater === 'function' ? updater(nextState) : updater),
     }),
-    currentState
+    currentState ?? ({} as State)
   );
 
   const signals = stateSource[STATE_SOURCE];
@@ -97,7 +102,10 @@ export function patchState<State extends object>(
   for (const key of Reflect.ownKeys(newState)) {
     if (stateKeys.includes(key)) {
       const signalKey = key as keyof State;
-      if (currentState[signalKey] !== newState[signalKey]) {
+      const currentValue = currentState
+        ? currentState[signalKey]
+        : untracked(() => signals[signalKey]());
+      if (currentValue !== newState[signalKey]) {
         signals[signalKey].set(newState[signalKey]);
       }
     } else if (typeof ngDevMode !== 'undefined' && ngDevMode) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows the [[NgRx commit guidelines](https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit)](https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit)
* [x] Tests for the changes have been added
* [ ] Documentation has been added / updated

## PR Type

What kind of change does this PR introduce?

```text
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other
```

## What is the current behavior?

`patchState` currently reads the complete state through `getState` before applying an update.

Because `getState` evaluates every state slice, patching an unrelated property can fail when another state slice throws while being read, for example a slice backed by a `resource` or `linkedSignal`.

This means a call such as:

```ts
patchState(store, { name: 'John' });
```

can be blocked by an unrelated state slice even though that slice is not part of the update.

Closes #5183

## What is the new behavior?

For partial state object updates, `patchState` no longer eagerly reads the complete state.

Instead, it only reads the state slices that are actually being updated when it needs to compare their current values.

Functional updaters still receive the complete current state as before:

```ts
patchState(store, (state) => ({
  count: state.count + 1,
}));
```

This preserves the existing behavior of functional updaters while allowing independent state slices to be patched even when another unrelated slice cannot currently be read.

## Implementation

The change distinguishes between two cases:

* Partial state object updates do not require the complete current state.
* Functional state updaters still require the complete state and therefore continue to use `getState`.

For partial object updates, the current value is read directly from the corresponding signal before deciding whether the signal needs to be updated.

This also preserves the existing equality check so unchanged state slices are not written unnecessarily.

## Tests

A regression test was added that creates:

* a writable `name` state slice
* an unrelated linked state slice that throws when accessed

The test verifies that:

```ts
patchState(stateSource, { name: 'John' });
```

does not read the throwing slice, does not throw, and successfully updates `name`.

The Signals test suite passes with the change:

```bash
pnpm exec nx test signals --watchAll=false
```

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

The behavior of functional updaters remains unchanged. The change only prevents unnecessary reads of unrelated state slices when using partial state object updates.