### PR TITLE
fix(signals): preserve entity when id changes number to equivalent string

### DIFF
--- a/modules/signals/entities/spec/updaters/update-entity.spec.ts
+++ b/modules/signals/entities/spec/updaters/update-entity.spec.ts
@@ -227,6 +227,26 @@ describe('updateEntity', () => {
     expect(store.ids()).toEqual([101, 2, 303]);
   });
 
+  it('updates a numeric entity id to the equivalent string id', () => {
+    type Entity = { id: string | number; name: string };
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities<Entity>()
+    );
+    const store = new Store();
+
+    patchState(
+      store,
+      addEntities<Entity>([{ id: 1, name: 'Ada' }]),
+      updateEntity<Entity>({ id: 1, changes: { id: '1' } })
+    );
+
+    const updatedEntity = { id: '1', name: 'Ada' };
+    expect(store.entityMap()).toEqual({ 1: updatedEntity });
+    expect(store.ids()).toEqual(['1']);
+    expect(store.entities()).toEqual([updatedEntity]);
+  });
+
   it('updates a custom entity id', () => {
     const Store = signalStore({ protectedState: false }, withEntities<Todo>());
     const store = new Store();

--- a/modules/signals/entities/src/helpers.ts
+++ b/modules/signals/entities/src/helpers.ts
@@ -193,16 +193,18 @@ export function updateEntitiesMutably(
     if (entity) {
       const changesRecord =
         typeof changes === 'function' ? changes(entity) : changes;
-      state.entityMap[id] = { ...entity, ...changesRecord };
+      const updatedEntity = { ...entity, ...changesRecord };
       didMutate = DidMutate.Entities;
 
-      const newId = selectId(state.entityMap[id]);
+      const newId = selectId(updatedEntity);
       if (newId !== id) {
-        state.entityMap[newId] = state.entityMap[id];
         delete state.entityMap[id];
+        state.entityMap[newId] = updatedEntity;
 
         newIds = newIds || {};
         newIds[id] = newId;
+      } else {
+        state.entityMap[id] = updatedEntity;
       }
     }
   }


### PR DESCRIPTION
## PR Checklist

#5218 

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: [https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit](https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit)
* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other... Please describe:


## What is the current behavior?

In `updateEntitiesMutably` (used by `updateEntity`, `updateEntities`, and `updateAllEntities`), when an entity's ID is changed to a value that is a different type but the same object key (e.g. numeric `1` to string `'1'`), the entity is deleted instead of updated. This happens because the new key is written before the old key is deleted, and JavaScript treats `1` and `'1'` as the same object property, so the delete step removes the just-written entity.

Reproduction:

```ts
const Store = signalStore({ protectedState: false }, withEntities<Entity>());
const store = new Store();

patchState(store, addEntity({ id: 1, name: 'Ada' }));
patchState(store, updateEntity({ id: 1, changes: { id: '1' } }));

store.entityMap(); // {} entity is lost
store.entities();  // [undefined]
```

## What is the new behavior?

The old entity key is deleted before the updated entity is assigned to the new key, so entities are preserved when the ID's string/number representation changes. `entityMap`, `ids`, and `entities` all stay consistent.

A regression test was added in `update-entity.spec.ts` covering the numeric-to-string ID update case.

## Does this PR introduce a breaking change?

No


