### PR TITLE
refactor: use vite-tsconfig-paths instead of deprecated nx/vite/plugins/nx-tsconfig-paths.plugin

### DIFF
--- a/projects/www/vitest.config.mts
+++ b/projects/www/vitest.config.mts
@@ -2,7 +2,7 @@
 import { defaultClientConditions, defaultServerConditions } from 'vite';
 import { defineConfig } from 'vitest/config';
 import analog from '@analogjs/platform';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import ngrxStackblitzPlugin from './src/tools/vite-ngrx-stackblitz.plugin';
 import { ngrxTheme, ngrxThemeLight } from './src/shared/ngrx-shiki-theme';
 import { configDefaults } from 'vitest/config';
@@ -65,7 +65,9 @@ export default defineConfig(({ mode }) => ({
         inlineStylesExtension: 'scss',
       },
     }),
-    nxViteTsPaths(),
+    // The workspace root tsconfig holds the path aliases for all projects,
+    // so resolve it explicitly instead of crawling the project root.
+    tsconfigPaths({ projects: [join(wwwRoot, '../../tsconfig.json')] }),
     ngrxStackblitzPlugin(),
   ],
 

--- a/tsdoc-metadata.json
+++ b/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.55.1"
+      "packageVersion": "7.59.0"
     }
   ]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,13 +1,22 @@
 import angular from '@analogjs/vite-plugin-angular';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const workspaceRoot = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Shared project configuration object.
  * Projects should merge this into their local 'defineProject' call.
  */
 export const baseConfig = {
-  plugins: [angular(), nxViteTsPaths()],
+  plugins: [
+    angular(),
+    // The workspace root tsconfig holds the path aliases for all projects,
+    // so resolve it explicitly instead of crawling each project root.
+    tsconfigPaths({ projects: [join(workspaceRoot, 'tsconfig.json')] }),
+  ],
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:
```

## What is the current behavior?

https://nx.dev/docs/kb/configure-vite#typescript-paths

```
`nxViteTsPaths` is deprecated

The nxViteTsPaths() plugin from @nx/vite/plugins/nx-tsconfig-paths.plugin is deprecated and will be removed in Nx v24. It still works in v23, but using it logs a deprecation warning. Swap it for tsconfigPaths() from vite-tsconfig-paths as shown above.
```

## What is the new behavior?

We use `vite-tsconfig-paths`, as recommended.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
